### PR TITLE
added yargs version entry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ const pkg = <any> require(packageJsonFilePath);
  */
 async function init() {
 	updateNotifier(pkg, 0);
+	yargs.version(pkg.version);
 	const loader = initCommandLoader(config.searchPrefix);
 	const { commandsMap, yargsCommandNames } = await loadCommands(yargs, config, loader);
 	registerCommands(yargs, commandsMap, yargsCommandNames);

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -50,5 +50,6 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 		.epilog(helpEpilog)
 		.help('h')
 		.alias('h', 'help')
+		.alias('v', 'version')
 		.argv;
 }

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -45,8 +45,7 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 		});
 	});
 
-	yargs.demand(1, 'must provide a valid command')
-		.usage(helpUsage)
+	yargs.usage(helpUsage)
 		.epilog(helpEpilog)
 		.help('h')
 		.alias('h', 'help')

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -45,7 +45,8 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 		});
 	});
 
-	yargs.usage(helpUsage)
+	yargs.demand(1, '')
+		.usage(helpUsage)
 		.epilog(helpEpilog)
 		.help('h')
 		.alias('h', 'help')

--- a/tests/unit/loadCommands.ts
+++ b/tests/unit/loadCommands.ts
@@ -43,6 +43,7 @@ registerSuite({
 		}
 	},
 	async 'failed load'() {
+		const consoleStub = stub(console, 'error');
 		const failConfig = {
 			searchPaths: [ '_build/tests/support' ],
 			searchPrefix: 'esmodule-fail'
@@ -55,6 +56,7 @@ registerSuite({
 		catch (error) {
 			assert.isTrue(error instanceof Error);
 			assert.isTrue(error.message.indexOf('Failed to load module') > -1);
+			consoleStub.restore();
 		}
 	}
 });

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -22,11 +22,12 @@ registerSuite({
 		yargsStub = getYargsStub();
 	},
 	'Should setup correct yargs arguments'() {
-		const yargsArgs = ['demand', 'usage', 'epilog', 'help', 'alias'];
+		const yargsArgs = ['demand', 'usage', 'epilog', 'help'];
 		registerCommands(yargsStub, commandsMap, {});
 		yargsArgs.forEach((arg) => {
 			assert.isTrue(yargsStub[arg].calledOnce);
 		});
+		assert.isTrue(yargsStub.alias.calledTwice, 'Should be called for help and version aliases');
 	},
 	'Should not call yargs.command when no yargsCommandNames are passed'() {
 		registerCommands(yargsStub, commandsMap, {});

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -22,7 +22,7 @@ registerSuite({
 		yargsStub = getYargsStub();
 	},
 	'Should setup correct yargs arguments'() {
-		const yargsArgs = ['usage', 'epilog', 'help'];
+		const yargsArgs = ['demand', 'usage', 'epilog', 'help'];
 		registerCommands(yargsStub, commandsMap, {});
 		yargsArgs.forEach((arg) => {
 			assert.isTrue(yargsStub[arg].calledOnce);

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -22,7 +22,7 @@ registerSuite({
 		yargsStub = getYargsStub();
 	},
 	'Should setup correct yargs arguments'() {
-		const yargsArgs = ['demand', 'usage', 'epilog', 'help'];
+		const yargsArgs = ['usage', 'epilog', 'help'];
 		registerCommands(yargsStub, commandsMap, {});
 		yargsArgs.forEach((arg) => {
 			assert.isTrue(yargsStub[arg].calledOnce);


### PR DESCRIPTION
fixes: #34 

calling `dojo -v` will now output the version number of the cli. This is not the same as the upcoming `dojo version` command.