### PR TITLE
Coverage: Excluded bin dir

### DIFF
--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -43,4 +43,4 @@ export const loaderOptions = {
 export const suites = [ 'tests/unit/all' ];
 
 // A regular expression matching URLs to files that should not be included in code coverage analysis
-export const excludeInstrumentation = /(?:node_modules|bower_components|tests)[\/\\]/;
+export const excludeInstrumentation = /(?:node_modules|bower_components|tests|bin)[\/\\]|(src\/index)/;

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -43,4 +43,4 @@ export const loaderOptions = {
 export const suites = [ 'tests/unit/all' ];
 
 // A regular expression matching URLs to files that should not be included in code coverage analysis
-export const excludeInstrumentation = /(?:node_modules|bower_components|tests|bin)[\/\\]|(src\/index)/;
+export const excludeInstrumentation = /(?:node_modules|bower_components|tests|bin)[\/\\]/;


### PR DESCRIPTION
The `bin/dojo` directory cannot be covered by tests so we should exclude it.