### PR TITLE
Fixed sub command issue

### DIFF
--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -53,8 +53,6 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 			// so we call default command, else, the subcommand will
 			// have been ran and we don't want to run the default.
 			if (argv._.length === 1) {
-				// Run the default command
-				console.log('running default command');
 				return defaultCommand.run(helper, argv);
 			}
 		});

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -26,10 +26,12 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 		const commandNames = yargsCommandNames[group];
 		const groupDescription = getGroupDescription(commandNames, commandsMap);
 		const defaultCommand = <CommandWrapper> commandsMap.get(group);
-
+		const defaultCommandAvailable = !!(defaultCommand && defaultCommand.register && defaultCommand.run);
 		yargs.command(group, groupDescription, (yargs: Yargs) => {
 			// Register the default command so that options show
-			defaultCommand.register(helper);
+			if (defaultCommandAvailable) {
+				defaultCommand.register(helper);
+			}
 
 			commandNames.forEach((command: string) => {
 				const { name, description, register, run } = <CommandWrapper> commandsMap.get(command);
@@ -52,7 +54,7 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 			// if `dojo example` was called, it will only be size one,
 			// so we call default command, else, the subcommand will
 			// have been ran and we don't want to run the default.
-			if (argv._.length === 1) {
+			if (defaultCommandAvailable && argv._.length === 1) {
 				return defaultCommand.run(helper, argv);
 			}
 		});

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -25,8 +25,12 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 	Object.keys(yargsCommandNames).forEach((group: string) => {
 		const commandNames = yargsCommandNames[group];
 		const groupDescription = getGroupDescription(commandNames, commandsMap);
+		const defaultCommand = <CommandWrapper> commandsMap.get(group);
 
 		yargs.command(group, groupDescription, (yargs: Yargs) => {
+			// Register the default command so that options show
+			defaultCommand.register(helper);
+
 			commandNames.forEach((command: string) => {
 				const { name, description, register, run } = <CommandWrapper> commandsMap.get(command);
 				yargs.command(
@@ -42,6 +46,17 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 				);
 			});
 			return yargs;
+		},
+		(argv: Argv) => {
+			// argv._ is an array of commands.
+			// if `dojo example` was called, it will only be size one,
+			// so we call default command, else, the subcommand will
+			// have been ran and we don't want to run the default.
+			if (argv._.length === 1) {
+				// Run the default command
+				console.log('running default command');
+				return defaultCommand.run(helper, argv);
+			}
 		});
 	});
 

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -1,7 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { stub, SinonStub } from 'sinon';
-import * as yargs from 'yargs';
 import { getCommandsMap, getYargsStub, GroupDef } from '../support/testHelper';
 const registerCommands = require('intern/dojo/node!../../src/registerCommands').default;
 const defaultCommandWrapper = require('intern/dojo/node!../support/test-prefix-foo-bar');
@@ -56,7 +55,6 @@ registerSuite({
 	},
 	'default command': {
 		'beforeEach'() {
-			yargs.reset();
 			defaultRegisterStub = stub(defaultCommandWrapper, 'register');
 			defaultRunStub = stub(defaultCommandWrapper, 'run');
 			commandsMap.set('group1', defaultCommandWrapper);

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -77,5 +77,4 @@ registerSuite({
 			assert.isFalse(defaultRunStub.called);
 		}
 	}
-
 });

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -1,7 +1,10 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import { stub, SinonStub } from 'sinon';
+import * as yargs from 'yargs';
 import { getCommandsMap, getYargsStub, GroupDef } from '../support/testHelper';
 const registerCommands = require('intern/dojo/node!../../src/registerCommands').default;
+const defaultCommandWrapper = require('intern/dojo/node!../support/test-prefix-foo-bar');
 
 const groupDef: GroupDef = [
 	{
@@ -13,13 +16,16 @@ const groupDef: GroupDef = [
 		commands: [ { commandName: 'command1' } ]
 	}
 ];
-const commandsMap = getCommandsMap(groupDef);
+let commandsMap: any;
 let yargsStub: any;
+let defaultRegisterStub: SinonStub;
+let defaultRunStub: SinonStub;
 
 registerSuite({
 	name: 'registerCommands',
 	'beforeEach'() {
 		yargsStub = getYargsStub();
+		commandsMap = getCommandsMap(groupDef);
 	},
 	'Should setup correct yargs arguments'() {
 		const yargsArgs = ['demand', 'usage', 'epilog', 'help'];
@@ -33,12 +39,45 @@ registerSuite({
 		registerCommands(yargsStub, commandsMap, {});
 		assert.isFalse(yargsStub.command.called);
 	},
-	'Should call yargs.command once for each yargsCommandName passed'() {
+	'Should call yargs.command once for each yargsCommandName passed and once for the default command'() {
 		const key = 'group1-command1';
 		const { group, description } = commandsMap.get(key);
 		registerCommands(yargsStub, commandsMap, {'group1': [ key ]});
 		assert.isTrue(yargsStub.command.calledTwice);
 		assert.isTrue(yargsStub.command.firstCall.calledWith(group, description), 'First call is for parent');
 		assert.isTrue(yargsStub.command.secondCall.calledWith('command1', key), 'Second call is sub-command');
+	},
+	'Should run the passed command when yargs called with group name and command'() {
+		const key = 'group1-command1';
+		const { run } = commandsMap.get(key);
+		registerCommands(yargsStub, commandsMap, {'group1': [ key ]});
+		yargsStub.command.secondCall.args[3]();
+		assert.isTrue(run.calledOnce);
+	},
+	'default command': {
+		'beforeEach'() {
+			yargs.reset();
+			defaultRegisterStub = stub(defaultCommandWrapper, 'register');
+			defaultRunStub = stub(defaultCommandWrapper, 'run');
+			commandsMap.set('group1', defaultCommandWrapper);
+			const key = 'group1-command1';
+			registerCommands(yargsStub, commandsMap, {'group1': [ key ]});
+		},
+		'afterEach'() {
+			defaultRegisterStub.restore();
+			defaultRunStub .restore();
+		},
+		'Should register the default command'() {
+			assert.isTrue(defaultRegisterStub.calledOnce);
+		},
+		'Should run default command when yargs called with only group name'() {
+			yargsStub.command.firstCall.args[3]({'_': ['group']});
+			assert.isTrue(defaultRunStub.calledOnce);
+		},
+		'Should not run default command when yargs called with group name and command'() {
+			yargsStub.command.firstCall.args[3]({'_': ['group', 'command']});
+			assert.isFalse(defaultRunStub.called);
+		}
 	}
+
 });


### PR DESCRIPTION
Fixes: #37 

*Not written tests yet*

- Registers the default command so it's options show
- Runs the default command if only one command arg is present in `argv._`.

