### PR TITLE
Add engines to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bugs": {
     "url": "https://github.com/dojo/cli/issues"
   },
+  "engines": {
+    "node": ">= 6.0.0"
+  },
   "license": "BSD-3-Clause",
   "keywords": [
     "dojo",


### PR DESCRIPTION
Supporting only v6+ for now. Fixes https://github.com/dojo/cli/issues/38

We will potentially transpile to es5 in the future when async/await is supported for that target.