### PR TITLE
issue 48: Feature error on reject

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dojo-cli",
-  "version": "2.0.0-alpha.3",
+  "version": "2.0.0-pre",
   "description": "Dojo 2 CLI utility",
   "homepage": "http://dojotoolkit.org",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dojo-cli",
-  "version": "2.0.0-pre",
+  "version": "2.0.0-alpha.3",
   "description": "Dojo 2 CLI utility",
   "homepage": "http://dojotoolkit.org",
   "bugs": {

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -3,6 +3,7 @@ import { getGroupDescription, CommandsMap, CommandWrapper } from './command';
 import CommandHelper from './CommandHelper';
 import Helper from './Helper';
 import { helpUsage, helpEpilog } from './text';
+import * as chalk from 'chalk';
 
 export interface YargsCommandNames {
 	[property: string]: string[];
@@ -27,6 +28,7 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 		const groupDescription = getGroupDescription(commandNames, commandsMap);
 		const defaultCommand = <CommandWrapper> commandsMap.get(group);
 		const defaultCommandAvailable = !!(defaultCommand && defaultCommand.register && defaultCommand.run);
+		const reportError = (error: Error) => console.error(chalk.red.bold(error.message));
 		yargs.command(group, groupDescription, (yargs: Yargs) => {
 			// Register the default command so that options show
 			if (defaultCommandAvailable) {
@@ -43,7 +45,7 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 						return yargs;
 					},
 					(argv: Argv) => {
-						return run(helper, argv);
+						return run(helper, argv).catch(reportError);
 					}
 				);
 			});
@@ -55,7 +57,7 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 			// so we call default command, else, the subcommand will
 			// have been ran and we don't want to run the default.
 			if (defaultCommandAvailable && argv._.length === 1) {
-				return defaultCommand.run(helper, argv);
+				return defaultCommand.run(helper, argv).catch(reportError);
 			}
 		});
 	});

--- a/tests/unit/loadCommands.ts
+++ b/tests/unit/loadCommands.ts
@@ -13,14 +13,19 @@ let loadStub: SinonStub;
 let yargsStub: any;
 let commandWrapper1: any;
 let commandWrapper2: any;
+let consoleStub: SinonStub;
 
 registerSuite({
 	name: 'loadCommands',
 	'beforeEach'() {
+			consoleStub = stub(console, 'error');
 			commandWrapper1 = getCommandWrapper('command1');
 			commandWrapper2 = getCommandWrapper('command2');
 			yargsStub = getYargsStub();
 			loadStub = stub();
+	},
+	'afterEach'() {
+		consoleStub.restore();
 	},
 	'successful load': {
 		'beforeEach'() {
@@ -43,7 +48,6 @@ registerSuite({
 		}
 	},
 	async 'failed load'() {
-		const consoleStub = stub(console, 'error');
 		const failConfig = {
 			searchPaths: [ '_build/tests/support' ],
 			searchPrefix: 'esmodule-fail'
@@ -56,7 +60,6 @@ registerSuite({
 		catch (error) {
 			assert.isTrue(error instanceof Error);
 			assert.isTrue(error.message.indexOf('Failed to load module') > -1);
-			consoleStub.restore();
 		}
 	}
 });

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -19,6 +19,8 @@ let commandsMap: any;
 let yargsStub: any;
 let defaultRegisterStub: SinonStub;
 let defaultRunStub: SinonStub;
+let consoleErrorStub: SinonStub;
+const errorMessage = 'test error message';
 
 registerSuite({
 	name: 'registerCommands',
@@ -75,6 +77,20 @@ registerSuite({
 		'Should not run default command when yargs called with group name and command'() {
 			yargsStub.command.firstCall.args[3]({'_': ['group', 'command']});
 			assert.isFalse(defaultRunStub.called);
+		},
+		'error message': {
+			'beforeEach'() {
+				consoleErrorStub = stub(console, 'error');
+				defaultRunStub.returns(Promise.reject(new Error(errorMessage)));
+			},
+			'afterEach'() {
+				consoleErrorStub.restore();
+			},
+			async 'Should show error message if the run command rejects'() {
+				await yargsStub.command.firstCall.args[3]({'_': ['group']});
+				assert.isTrue(consoleErrorStub.calledOnce);
+				assert.isTrue(consoleErrorStub.firstCall.calledWithMatch(errorMessage));
+			}
 		}
 	}
 });

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -56,7 +56,7 @@ registerSuite({
 	'default command': {
 		'beforeEach'() {
 			defaultRegisterStub = stub(defaultCommandWrapper, 'register');
-			defaultRunStub = stub(defaultCommandWrapper, 'run');
+			defaultRunStub = stub(defaultCommandWrapper, 'run').returns(Promise.resolve());
 			commandsMap.set('group1', defaultCommandWrapper);
 			const key = 'group1-command1';
 			registerCommands(yargsStub, commandsMap, {'group1': [ key ]});


### PR DESCRIPTION
Cli will now show error messages from a command's `run` function.
fixes: https://github.com/dojo/cli/issues/48
example:
<img width="286" alt="screenshot 2016-09-29 17 01 29" src="https://cloud.githubusercontent.com/assets/814453/18961862/64af365e-8666-11e6-9984-613c5469db88.png">
