### PR TITLE
Increase code coverage for CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dojo-cli",
-  "version": "2.0.0-alpha.3",
+  "version": "2.0.0-pre",
   "description": "Dojo 2 CLI utility",
   "homepage": "http://dojotoolkit.org",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dojo-cli",
-  "version": "2.0.0-pre",
+  "version": "2.0.0-alpha.3",
   "description": "Dojo 2 CLI utility",
   "homepage": "http://dojotoolkit.org",
   "bugs": {

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,6 +1,8 @@
 import './command';
 import './config';
+import './index';
 import './text';
 import './loadCommands';
 import './registerCommands';
+import './updateNotifier';
 import './CommandHelper';

--- a/tests/unit/index.ts
+++ b/tests/unit/index.ts
@@ -1,0 +1,49 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import * as mockery from 'mockery';
+import { SinonStub, stub } from 'sinon';
+
+const updateNotifierStub: SinonStub = stub();
+const yargsVersionStub: SinonStub = stub();
+const commandLoaderStub: SinonStub = stub();
+const loadCommandsStub: SinonStub = stub().returns(Promise.resolve());
+const registerCommandsStub: SinonStub = stub();
+let index: any;
+
+registerSuite({
+	name: 'index',
+	'setup'() {
+		mockery.enable({ 'warnOnUnregistered': false });
+
+		mockery.registerMock('./updateNotifier', { 'default': updateNotifierStub });
+		mockery.registerMock('./config', { 'default': {} });
+		mockery.registerMock('./command', { 'initCommandLoader': commandLoaderStub });
+		mockery.registerMock('./loadCommands', { 'default': loadCommandsStub });
+		mockery.registerMock('./registerCommands', { 'default': registerCommandsStub });
+		mockery.registerMock('testDir/package.json', { 'testKey': 'testValue' });
+
+		mockery.registerMock('yargs', { 'version': yargsVersionStub });
+		mockery.registerMock('pkg-dir', { 'sync': stub().returns('testDir') });
+
+		index = require('intern/dojo/node!./../../src/index');
+	},
+	'teardown'() {
+		mockery.deregisterAll();
+		mockery.disable();
+	},
+	async 'Should call updateNotifier'() {
+		assert.isTrue(updateNotifierStub.calledOnce);
+	},
+	async 'Should set yargs version'() {
+		assert.isTrue(yargsVersionStub.calledOnce);
+		assert.isTrue(yargsVersionStub.calledAfter(updateNotifierStub));
+	},
+	async 'Should init the command loader'() {
+		assert.isTrue(commandLoaderStub.calledOnce);
+		assert.isTrue(commandLoaderStub.calledAfter(yargsVersionStub));
+	},
+	async 'Should load the commands using the command loader'() {
+		assert.isTrue(loadCommandsStub.calledOnce);
+		assert.isTrue(loadCommandsStub.calledAfter(commandLoaderStub));
+	}
+});

--- a/tests/unit/index.ts
+++ b/tests/unit/index.ts
@@ -31,19 +31,16 @@ registerSuite({
 		mockery.deregisterAll();
 		mockery.disable();
 	},
-	'Should call updateNotifier'() {
-		assert.isTrue(updateNotifierStub.calledOnce);
-	},
-	'Should set yargs version'() {
-		assert.isTrue(yargsVersionStub.calledOnce);
-		assert.isTrue(yargsVersionStub.calledAfter(updateNotifierStub));
-	},
-	'Should init the command loader'() {
-		assert.isTrue(commandLoaderStub.calledOnce);
-		assert.isTrue(commandLoaderStub.calledAfter(yargsVersionStub));
-	},
-	'Should load the commands using the command loader'() {
-		assert.isTrue(loadCommandsStub.calledOnce);
-		assert.isTrue(loadCommandsStub.calledAfter(commandLoaderStub));
+	'Should call functions in order'() {
+		assert.isTrue(updateNotifierStub.calledOnce, 'should call update notifier');
+		assert.isTrue(yargsVersionStub.calledOnce, 'should set yargs version');
+		assert.isTrue(yargsVersionStub.calledAfter(updateNotifierStub),
+			'should set yargs version after update notifier');
+		assert.isTrue(commandLoaderStub.calledOnce, 'should call init command loader');
+		assert.isTrue(commandLoaderStub.calledAfter(yargsVersionStub),
+			'should call init command loader after set yargs version');
+		assert.isTrue(loadCommandsStub.calledOnce, 'should call load commands');
+		assert.isTrue(loadCommandsStub.calledAfter(commandLoaderStub),
+			'should call load commands after init command loader');
 	}
 });

--- a/tests/unit/index.ts
+++ b/tests/unit/index.ts
@@ -31,18 +31,18 @@ registerSuite({
 		mockery.deregisterAll();
 		mockery.disable();
 	},
-	async 'Should call updateNotifier'() {
+	'Should call updateNotifier'() {
 		assert.isTrue(updateNotifierStub.calledOnce);
 	},
-	async 'Should set yargs version'() {
+	'Should set yargs version'() {
 		assert.isTrue(yargsVersionStub.calledOnce);
 		assert.isTrue(yargsVersionStub.calledAfter(updateNotifierStub));
 	},
-	async 'Should init the command loader'() {
+	'Should init the command loader'() {
 		assert.isTrue(commandLoaderStub.calledOnce);
 		assert.isTrue(commandLoaderStub.calledAfter(yargsVersionStub));
 	},
-	async 'Should load the commands using the command loader'() {
+	'Should load the commands using the command loader'() {
 		assert.isTrue(loadCommandsStub.calledOnce);
 		assert.isTrue(loadCommandsStub.calledAfter(commandLoaderStub));
 	}

--- a/tests/unit/updateNotifier.ts
+++ b/tests/unit/updateNotifier.ts
@@ -1,0 +1,53 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import * as mockery from 'mockery';
+import { SinonStub, stub } from 'sinon';
+
+let updateNotifier: any;
+const notifyStub: SinonStub = stub();
+const updateNotifierStub: SinonStub = stub().returns({ 'notify': notifyStub });
+const testPkg = { 'testKey': 'testValue' };
+const testInterval = 100;
+
+registerSuite({
+	name: 'updateNotifier',
+	'setup'() {
+		mockery.enable({
+			warnOnUnregistered: false
+		});
+
+		mockery.registerMock('update-notifier', updateNotifierStub);
+
+		updateNotifier = require('intern/dojo/node!./../../src/updateNotifier').default;
+	},
+	'beforeEach'() {
+		notifyStub.reset();
+		updateNotifierStub.reset();
+	},
+	'teardown'() {
+		mockery.deregisterAll();
+		mockery.disable();
+	},
+	'Should call update-notifier with the passed arguments'() {
+		updateNotifier(testPkg, testInterval);
+		assert.isTrue(updateNotifierStub.calledOnce);
+		assert.isTrue(updateNotifierStub.firstCall.calledWith({
+			'pkg': testPkg,
+			'updateCheckInterval': testInterval
+		}));
+	},
+	'Should default interval to zero if none passed'() {
+		updateNotifier(testPkg);
+		assert.isTrue(updateNotifierStub.calledOnce);
+		assert.isTrue(updateNotifierStub.firstCall.calledWith({
+			'pkg': testPkg,
+			'updateCheckInterval': 0
+		}));
+	},
+	'Should call notify function once notifier is set up'() {
+		updateNotifier(testPkg, testInterval);
+		assert.isTrue(updateNotifierStub.calledOnce);
+		assert.isTrue(notifyStub.calledOnce);
+		assert.isTrue(notifyStub.calledAfter(updateNotifierStub));
+	}
+});


### PR DESCRIPTION
Using the `dirname` import has made it possible to add tests for `index.ts` and `updateNotifier.ts`