### PR TITLE
Pass args when calling command from helper

### DIFF
--- a/src/CommandHelper.ts
+++ b/src/CommandHelper.ts
@@ -22,7 +22,7 @@ export default class implements CommandHelper {
 	run(group: string, commandName?: string, args?: yargs.Argv): Promise<any> {
 		const command = getCommand(this.commandsMap, group, commandName);
 		if (command) {
-			return command.run(new Helper(this, yargs, this.context));
+			return command.run(new Helper(this, yargs, this.context), args);
 		}
 		else {
 			return Promise.reject(new Error('The command does not exist'));

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -13,12 +13,14 @@ export function getCommandsMap(groupDef: GroupDef) {
 	groupDef.forEach((group) => {
 		group.commands.forEach((command) => {
 			const compositeKey = `${group.groupName}-${command.commandName}`;
+			const runStub = stub();
 			const commandWrapper = {
 				name: command.commandName,
 				group: group.groupName,
 				description: compositeKey,
 				register: stub().returns(compositeKey),
-				run: stub().returns(command.fails ?
+				runStub,
+				run: runStub.returns(command.fails ?
 					Promise.reject(new Error(compositeKey)) :
 					Promise.resolve(compositeKey))
 			};

--- a/tests/unit/CommandHelper.ts
+++ b/tests/unit/CommandHelper.ts
@@ -47,6 +47,15 @@ registerSuite({
 			assert.equal(key, response);
 		});
 	},
+	'Should run a command that exists with args and return a promise that resolves'() {
+		const key = 'group1-command1';
+		return commandHelper.run(key, undefined, 'args').then((response: string) => {
+			const mockCommand = commandsMap.get(key);
+			assert.isTrue(mockCommand.runStub.called);
+			assert.equal(mockCommand.runStub.getCall(0).args[1], 'args');
+			assert.equal(key, response);
+		});
+	},
 	'Should run a command that exists and return a rejected promise when it fails'() {
 		const key = 'group2-failcommand';
 		return commandHelper.run(key).then(


### PR DESCRIPTION
Ensure that args are passed to the run function when called via the command helper.

resolves #56 