### PR TITLE
Adding built-in version command, fixes #11

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,12 @@
 module.exports = function (grunt) {
-	require('grunt-dojo2').initConfig(grunt, {});
+	require('grunt-dojo2').initConfig(grunt, {
+		copy: {
+			staticTestFiles: {
+				expand: true,
+				cwd: '.',
+				src: 'tests/**/*.json',
+				dest: '<%= tsconfig.compilerOptions.outDir %>'
+			}
+		}
+	});
 };

--- a/src/command.ts
+++ b/src/command.ts
@@ -4,6 +4,7 @@ const cliui = require('cliui');
 export interface CommandWrapper extends Command {
 	name: string;
 	group: string;
+	path: string;
 };
 
 export type CommandsMap = Map<string, CommandWrapper>;
@@ -35,7 +36,8 @@ export function initCommandLoader(searchPrefix: string): (path: string) => Comma
 				group,
 				description,
 				register,
-				run
+				run,
+				path
 			};
 		}
 		else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,6 @@ const pkg = <any> require(packageJsonFilePath);
  */
 async function init() {
 	updateNotifier(pkg, 0);
-	yargs.version(pkg.version);
 	const loader = initCommandLoader(config.searchPrefix);
 	const { commandsMap, yargsCommandNames } = await loadCommands(yargs, config, loader);
 	registerCommands(yargs, commandsMap, yargsCommandNames);

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -2,7 +2,8 @@ import { Yargs, Argv } from 'yargs';
 import { getGroupDescription, CommandsMap, CommandWrapper } from './command';
 import CommandHelper from './CommandHelper';
 import Helper from './Helper';
-import { helpUsage, helpEpilog } from './text';
+import { helpUsage, helpEpilog, versionDescription } from './text';
+import createVersionsString from './version';
 import * as chalk from 'chalk';
 
 export interface YargsCommandNames {
@@ -69,6 +70,8 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 		.help('h')
 		.alias('h', 'help')
 		.alias('v', 'version')
+		.version(() => createVersionsString(commandsMap))
+		.command('version', versionDescription, (yarts) => yargs, () => console.log(createVersionsString(commandsMap)))
 		.strict()
 		.argv;
 }

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,4 +1,4 @@
-import { bold } from 'chalk';
+import { bold, yellow } from 'chalk';
 
 export const helpUsage = `${bold('dojo help')}
 
@@ -9,3 +9,18 @@ Hey there, here are all the things you can do with dojo-cli:`;
 export const helpEpilog = `For more information on any of these commands just run them with '-h'.
 
 e.g. 'dojo run -h' will give you the help for the 'run' group of commands.`;
+
+export const versionCurrentVersion = `
+You are currently running dojo-cli {version}
+`;
+
+export const versionDescription = 'List versions of registered commands';
+
+export const versionNoRegisteredCommands = `
+There are no registered commands available.`;
+
+export const versionNoVersion = yellow('package.json missing');
+
+export const versionRegisteredCommands = `
+The currently installed groups are:
+`;

--- a/src/version.ts
+++ b/src/version.ts
@@ -11,17 +11,29 @@ import { join } from 'path';
 const pkgDir = require('pkg-dir');
 const packagePath = pkgDir.sync(dirname);
 
+/**
+ * The details of one command group's module.
+ */
 export interface ModuleVersion {
 	name: string;
 	version: string;
 	group: string;
 }
 
+/**
+ * Important information to be retrieved from a module's package.json
+ */
 export interface PackageDetails {
 	name: string;
 	version: string;
 }
 
+/**
+ * Read information about a package/module, if available, or return default values.
+ *
+ * @param {string} packageDir The directory containing the package.json file.
+ * @returns {{name: (any|string), version: any}}
+ */
 export function readPackageDetails(packageDir: string): PackageDetails {
 	let data: any = {};
 	try {
@@ -36,7 +48,14 @@ export function readPackageDetails(packageDir: string): PackageDetails {
 	};
 }
 
-export function buildVersions(commandsMap: CommandsMap) {
+/**
+ * Iterate through a CommandsMap and retrieve the module details of each module referenced in the
+ * CommandsMap. The returned list is sorted in alphabetical order, by group.
+ *
+ * @param {CommandsMap} commandsMap
+ * @returns {{name, version, group}[]}
+ */
+export function buildVersions(commandsMap: CommandsMap): ModuleVersion[] {
 	/*
 	 * commandsMap comes in as a map of [command-name, command]. The command has a default command,
 	 * the map will actually contain two entries for one command, on for the default command, one for the real,
@@ -59,6 +78,13 @@ export function buildVersions(commandsMap: CommandsMap) {
 		}).sort((a, b) => a.group > b.group ? 1 : -1);
 }
 
+/**
+ * Returns a string describing the command group, module name, and module version of each
+ * command referenced in a specified CommandsMap. This is used to print the the help string.
+ *
+ * @param {CommandsMap} commandsMap
+ * @returns {string}
+ */
 export default function createVersionsString(commandsMap: CommandsMap): string {
 	const myPackageDetails = readPackageDetails(packagePath),
 		commands = buildVersions(commandsMap);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,80 @@
+import { CommandsMap } from './command';
+import dirname from './dirname';
+import {
+	versionNoRegisteredCommands,
+	versionRegisteredCommands,
+	versionCurrentVersion,
+	versionNoVersion
+} from './text';
+import { join } from 'path';
+
+const pkgDir = require('pkg-dir');
+const packagePath = pkgDir.sync(dirname);
+
+export interface ModuleVersion {
+	name: string;
+	version: string;
+	group: string;
+}
+
+export interface PackageDetails {
+	name: string;
+	version: string;
+}
+
+export function readPackageDetails(packageDir: string): PackageDetails {
+	let data: any = {};
+	try {
+		data = require(join(packageDir, 'package.json'));
+	} catch (e) {
+		data = {};
+	}
+
+	return {
+		name: data.name || packageDir,
+		version: data.version || versionNoVersion
+	};
+}
+
+export function buildVersions(commandsMap: CommandsMap) {
+	/*
+	 * commandsMap comes in as a map of [command-name, command]. The command has a default command,
+	 * the map will actually contain two entries for one command, on for the default command, one for the real,
+	 * expanded, command.
+	 *
+	 * Loop over commandsMap and create a new map with one entry per command, then loop over each entry and extract
+	 * the package details.
+	 */
+	const consolidatedCommands = [ ...new Map<string, string>([ ...commandsMap ]
+		.map(([, command]) => <[string, string]> [ command.path, command.group ])) ];
+
+	return consolidatedCommands.map(([path, group]) => {
+			const { name, version } = readPackageDetails(path);
+
+			return {
+				name,
+				version,
+				group
+			};
+		}).sort((a, b) => a.group > b.group ? 1 : -1);
+}
+
+export default function createVersionsString(commandsMap: CommandsMap): string {
+	const myPackageDetails = readPackageDetails(packagePath),
+		commands = buildVersions(commandsMap);
+	let output = '';
+
+	if (commands.length) {
+		output += versionRegisteredCommands;
+		output += '\n'
+			+ commands.map((command) => `${command.group} (${command.name}) ${command.version}`).join('\n')
+			+ '\n';
+	}
+	else {
+		output += versionNoRegisteredCommands;
+	}
+
+	output += versionCurrentVersion.replace('\{version\}', myPackageDetails.version);
+
+	return output;
+}

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -1,4 +1,6 @@
+import {CommandWrapper} from '../../src/command';
 import { stub } from 'sinon';
+
 export type GroupDef = [{
 	groupName: string;
 	commands: [{
@@ -6,6 +8,14 @@ export type GroupDef = [{
 		fails?: boolean;
 	}]
 }];
+
+export interface CommandWrapperConfig {
+	group?: string;
+	name?: string;
+	description?: string;
+	path?: string;
+	runs?: boolean;
+}
 
 export function getCommandsMap(groupDef: GroupDef) {
 	const commands = new Map();
@@ -31,7 +41,7 @@ export function getCommandsMap(groupDef: GroupDef) {
 	return commands;
 };
 
-const yargsFunctions = [ 'demand', 'usage', 'epilog', 'help', 'alias', 'strict' ];
+const yargsFunctions = [ 'demand', 'usage', 'epilog', 'help', 'alias', 'strict', 'version' ];
 export function getYargsStub() {
 	const yargsStub: any = {};
 	yargsFunctions.forEach((fnc) => {
@@ -42,12 +52,25 @@ export function getYargsStub() {
 }
 
 export function getCommandWrapper(name: string, runs: boolean = true) {
-	const commandWrapper = {
-		group: 'foo',
+	return getCommandWrapperWithConfiguration({
 		name,
-		description: 'test-description',
+		runs,
+		group: 'foo',
+		description: 'test-description'
+	});
+}
+
+export function getCommandWrapperWithConfiguration(config: CommandWrapperConfig): CommandWrapper {
+	const {group = '', name = '', description = '', path = '', runs = false} = config;
+
+	const commandWrapper = {
+		group,
+		name,
+		description,
+		path,
 		register: stub().returns('registered'),
 		run: stub().returns(runs ? Promise.resolve('success') : Promise.reject(new Error()))
 	};
+
 	return commandWrapper;
 }

--- a/tests/support/valid-package/package.json
+++ b/tests/support/valid-package/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "Test Package 1",
+  "version": "1.0.0"
+}

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -5,4 +5,5 @@ import './text';
 import './loadCommands';
 import './registerCommands';
 import './updateNotifier';
+import './version';
 import './CommandHelper';

--- a/tests/unit/index.ts
+++ b/tests/unit/index.ts
@@ -33,11 +33,8 @@ registerSuite({
 	},
 	'Should call functions in order'() {
 		assert.isTrue(updateNotifierStub.calledOnce, 'should call update notifier');
-		assert.isTrue(yargsVersionStub.calledOnce, 'should set yargs version');
-		assert.isTrue(yargsVersionStub.calledAfter(updateNotifierStub),
-			'should set yargs version after update notifier');
 		assert.isTrue(commandLoaderStub.calledOnce, 'should call init command loader');
-		assert.isTrue(commandLoaderStub.calledAfter(yargsVersionStub),
+		assert.isTrue(commandLoaderStub.calledAfter(updateNotifierStub),
 			'should call init command loader after set yargs version');
 		assert.isTrue(loadCommandsStub.calledOnce, 'should call load commands');
 		assert.isTrue(loadCommandsStub.calledAfter(commandLoaderStub),

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -2,7 +2,9 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { stub, SinonStub } from 'sinon';
 import { getCommandsMap, getYargsStub, GroupDef } from '../support/testHelper';
-const registerCommands = require('intern/dojo/node!../../src/registerCommands').default;
+import { versionRegisteredCommands } from '../../src/text';
+
+const { 'default': registerCommands } = require('intern/dojo/node!../../src/registerCommands');
 const defaultCommandWrapper = require('intern/dojo/node!../support/test-prefix-foo-bar');
 
 const groupDef: GroupDef = [
@@ -36,9 +38,9 @@ registerSuite({
 		});
 		assert.isTrue(yargsStub.alias.calledTwice, 'Should be called for help and version aliases');
 	},
-	'Should not call yargs.command when no yargsCommandNames are passed'() {
+	'Should call yargs.command once when no yargsCommandNames are passed'() {
 		registerCommands(yargsStub, commandsMap, {});
-		assert.isFalse(yargsStub.command.called);
+		assert.isTrue(yargsStub.command.calledOnce);
 	},
 	'Should call strict for all commands'() {
 		registerCommands(yargsStub, commandsMap, {
@@ -51,7 +53,7 @@ registerSuite({
 		const key = 'group1-command1';
 		const { group, description } = commandsMap.get(key);
 		registerCommands(yargsStub, commandsMap, {'group1': [ key ]});
-		assert.isTrue(yargsStub.command.calledTwice);
+		assert.isTrue(yargsStub.command.calledThrice);
 		assert.isTrue(yargsStub.command.firstCall.calledWith(group, description), 'First call is for parent');
 		assert.isTrue(yargsStub.command.secondCall.calledWith('command1', key), 'Second call is sub-command');
 	},
@@ -98,6 +100,37 @@ registerSuite({
 				assert.isTrue(consoleErrorStub.calledOnce);
 				assert.isTrue(consoleErrorStub.firstCall.calledWithMatch(errorMessage));
 			}
+		}
+	},
+	'version': {
+		'version option'() {
+			commandsMap.set('group1', defaultCommandWrapper);
+			const key = 'group1-command1';
+			registerCommands(yargsStub, commandsMap, { 'group1': [ key ] });
+
+			let versionString = yargsStub.version.lastCall.args[ 0 ]();
+
+			assert.include(versionString, versionRegisteredCommands);
+		},
+
+		'version command'() {
+			defaultRegisterStub = stub(defaultCommandWrapper, 'register');
+			defaultRunStub = stub(defaultCommandWrapper, 'run').returns(Promise.resolve());
+			commandsMap.set('group1', defaultCommandWrapper);
+			const key = 'group1-command1';
+			registerCommands(yargsStub, commandsMap, { 'group1': [ key ] });
+
+			let output = '';
+			let consoleStub = stub(console, 'log', function (...lines: string[]) {
+				output += lines.join(' ');
+			});
+
+			yargsStub.command.lastCall.args[ 3 ]();
+
+			consoleStub.restore();
+
+			assert.isTrue(consoleStub.calledOnce);
+			assert.include(output, versionRegisteredCommands);
 		}
 	}
 });

--- a/tests/unit/text.ts
+++ b/tests/unit/text.ts
@@ -4,12 +4,23 @@ const text = require('intern/dojo/node!../../src/text');
 
 registerSuite({
 	name: 'text',
-	'Should export helpUsage'() {
-		assert.isNotNull(text.helpUsage);
-		assert.equal('string', typeof text.helpUsage);
-	},
-	'Should export helpEpilog'() {
-		assert.isNotNull(text.helpEpilog);
-		assert.equal('string', typeof text.helpEpilog);
-	}
+	exports: (function (exportedStrings) {
+		const tests: (() => void)[] = [];
+
+		exportedStrings.forEach(function (exportedString) {
+			tests.push(function () {
+				assert.isNotNull(text[exportedString]);
+				assert.isString(text[exportedString]);
+			});
+		});
+
+		return tests;
+	})([
+		'helpUsage',
+		'helpEpilog',
+		'versionDescription',
+		'versionNoRegisteredCommands',
+		'versionRegisteredCommands',
+		'versionCurrentVersion'
+	])
 });

--- a/tests/unit/version.ts
+++ b/tests/unit/version.ts
@@ -1,0 +1,88 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { CommandsMap, CommandWrapper } from '../../src/command';
+import { getCommandWrapperWithConfiguration } from '../support/testHelper';
+import { versionNoRegisteredCommands, versionNoVersion, versionRegisteredCommands } from '../../src/text';
+const { readPackageDetails, buildVersions, 'default': createVersionsString } = require('intern/dojo/node!../../src/version');
+
+registerSuite({
+	name: 'text',
+
+	readPackageDetails: {
+		validPackage() {
+			const details = readPackageDetails('../tests/support/valid-package');
+
+			assert.equal(details.name, 'Test Package 1');
+			assert.equal(details.version, '1.0.0');
+		},
+
+		missingPackage() {
+			const details = readPackageDetails('../tests/support');
+
+			assert.equal(details.name, '../tests/support');
+			assert.equal(details.version, versionNoVersion);
+		}
+	},
+
+	buildVersions() {
+
+		const commandWrapper1 = getCommandWrapperWithConfiguration({
+				group: 'apple',
+				name: 'test',
+				path: '../tests/support/valid-package'
+			}),
+			commandWrapper2 = getCommandWrapperWithConfiguration({
+				group: 'banana',
+				name: 'test 2',
+				path: '../tests/support'
+			});
+
+		const commandMap: CommandsMap = new Map<string, CommandWrapper>([
+			['banana', commandWrapper2],
+			['apple', commandWrapper1]
+		]);
+
+		const commands = buildVersions(commandMap);
+
+		assert.equal(commands.length, 2, 'There should be two commands');
+		assert.equal(commands[0].name, 'Test Package 1');
+		assert.equal(commands[0].version, '1.0.0');
+		assert.equal(commands[0].group, 'apple');
+
+		assert.equal(commands[1].name, '../tests/support');
+		assert.equal(commands[1].version, versionNoVersion);
+		assert.equal(commands[1].group, 'banana');
+	},
+
+	'createCommand': {
+		'no commands'() {
+			const commandMap: CommandsMap = new Map<string, CommandWrapper>();
+
+			assert.include(createVersionsString(commandMap), versionNoRegisteredCommands);
+		},
+
+		'commands'() {
+			const commandWrapper1 = getCommandWrapperWithConfiguration({
+					group: 'apple',
+					name: 'test',
+					path: '../tests/support/valid-package'
+				}),
+				commandWrapper2 = getCommandWrapperWithConfiguration({
+					group: 'banana',
+					name: 'test 2',
+					path: '../tests/support'
+				});
+
+			const commandMap: CommandsMap = new Map<string, CommandWrapper>([
+				['apple', commandWrapper1],
+				['banana', commandWrapper2]
+			]);
+
+			const output = createVersionsString(commandMap);
+
+			assert.include(output, versionRegisteredCommands);
+			assert.include(output, 'apple (Test Package 1) 1.0.0');
+			assert.include(output, 'banana (../tests/support) ' + versionNoVersion) ;
+		}
+	}
+});


### PR DESCRIPTION
Adding `version` command. This command is built into cli core and will show the version of all the registered commands.

Usage:

```
$ dojo version
```

Example output with no commands,

```
There are no registered commands available.

You are currently running dojo-cli 2.0.0-pre
```

Example output with commands,

```
The currently installed groups are:

create (dojo-cli-create-app) 2.0.0-alpha.2

You are currently running dojo-cli 2.0.0-pre
```

What the help looks like,

```
dojo help

Usage: dojo <group> <command> [options]

Hey there, here are all the things you can do with dojo-cli:

Commands:
  create   Scaffolds a new command
  version  List versions of registered commands

Options:
  -h, --help     Show help                                             [boolean]
  -v, --version  Show version number                                   [boolean]

For more information on any of these commands just run them with '-h'.

e.g. 'dojo run -h' will give you the help for the 'run' group of commands.
```