### PR TITLE
Bug: Duplicate command names and precedence order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dojo-cli",
-  "version": "2.0.0-alpha.3",
+  "version": "2.0.0-pre",
   "description": "Dojo 2 CLI utility",
   "homepage": "http://dojotoolkit.org",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dojo-cli",
-  "version": "2.0.0-pre",
+  "version": "2.0.0-alpha.3",
   "description": "Dojo 2 CLI utility",
   "homepage": "http://dojotoolkit.org",
   "bugs": {

--- a/src/command.ts
+++ b/src/command.ts
@@ -46,19 +46,19 @@ export function initCommandLoader(searchPrefix: string): (path: string) => Comma
 	};
 }
 
-export function getGroupDescription(commandNames: string[], commands: CommandsMap): string {
-	const numCommands = commandNames.length;
+export function getGroupDescription(commandNames: Set<string>, commands: CommandsMap): string {
+	const numCommands = commandNames.size;
 	if (numCommands > 1) {
 		return getMultiCommandDescription(commandNames, commands);
 	}
 	else {
-		const { description } = <CommandWrapper> commands.get(commandNames[0]);
+		const { description } = <CommandWrapper> commands.get(Array.from(commandNames.keys())[0]);
 		return description;
 	}
 }
 
-function getMultiCommandDescription(commandNames: string[], commands: CommandsMap): string {
-	const descriptions = commandNames.map((commandName) => {
+function getMultiCommandDescription(commandNames: Set<string>, commands: CommandsMap): string {
+	const descriptions = Array.from(commandNames.keys(), (commandName) => {
 		const { name, description } = (<CommandWrapper> commands.get(commandName));
 		return `${name}  \t${description}`;
 	});

--- a/src/loadCommands.ts
+++ b/src/loadCommands.ts
@@ -5,7 +5,7 @@ import * as globby from 'globby';
 import { resolve } from 'path';
 
 export interface YargsCommandNames {
-	[property: string]: string[];
+	[property: string]: Set<string>;
 };
 
 export type LoadedCommands = {
@@ -48,10 +48,12 @@ export default async function (yargs: Yargs, config: Config, load: (path: string
 						// First of each type will be 'default' for now
 						setDefaultGroup(commandsMap, group, commandWrapper);
 
-						yargsCommandNames[group] = [];
+						yargsCommandNames[group] = new Set();
 					}
 					commandsMap.set(compositeKey, commandWrapper);
-					yargsCommandNames[group].push(compositeKey);
+
+					const groupCommandNames = yargsCommandNames[group];
+					groupCommandNames.add(compositeKey);
 				}
 				catch (error) {
 					console.error(`Failed to load module: ${path}, error: ${error.message}`);

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -7,7 +7,7 @@ import createVersionsString from './version';
 import * as chalk from 'chalk';
 
 export interface YargsCommandNames {
-	[property: string]: string[];
+	[property: string]: Set<string>;
 };
 
 /**

--- a/tests/unit/command.ts
+++ b/tests/unit/command.ts
@@ -89,13 +89,13 @@ registerSuite({
 		},
 		'Should return simple command description when only one command name passed'() {
 			const key = 'group1-command1';
-			const description = command.getGroupDescription([key], commandsMap);
+			const description = command.getGroupDescription(new Set([key]), commandsMap);
 			assert.equal(commandsMap.get(key).description, description);
 		},
 		'Should return composite description of sub commands when multiple command names passed'() {
 			const key1 = 'group1-command1';
 			const key2 = 'group2-command1';
-			const description = command.getGroupDescription([key1, key2], commandsMap);
+			const description = command.getGroupDescription(new Set([key1, key2]), commandsMap);
 			const expected = `${commandsMap.get(key1).name}  ${commandsMap.get(key1).description}\n${commandsMap.get(key1).name}  ${commandsMap.get(key2).description}`;
 
 			assert.equal(expected, description);

--- a/tests/unit/loadCommands.ts
+++ b/tests/unit/loadCommands.ts
@@ -61,5 +61,20 @@ registerSuite({
 			assert.isTrue(error instanceof Error);
 			assert.isTrue(error.message.indexOf('Failed to load module') > -1);
 		}
+	},
+	async 'should apply loading precedence to duplicate commands'() {
+		const duplicateCommandName = 'command1';
+		const duplicateGroupName = 'foo';
+		const commandWrapperDuplicate = getCommandWrapper(duplicateCommandName);
+		loadStub.onFirstCall().returns(commandWrapper1);
+		loadStub.onSecondCall().returns(commandWrapperDuplicate);
+
+		const { yargsCommandNames } = await loadCommands(yargsStub, config, loadStub);
+		assert.isTrue(loadStub.calledTwice);
+		const groupCommandSet = yargsCommandNames[ duplicateGroupName ];
+
+		assert.equal(1, groupCommandSet.size);
+		assert.isTrue(groupCommandSet.has(`${duplicateGroupName}-${duplicateCommandName}`));
 	}
+
 });

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -44,15 +44,15 @@ registerSuite({
 	},
 	'Should call strict for all commands'() {
 		registerCommands(yargsStub, commandsMap, {
-			'group1': [ 'group1-command1' ],
-			'group2': [ 'group2-command1', 'group2-command2' ]
+			'group1': new Set([ 'group1-command1' ]),
+			'group2': new Set([ 'group2-command1', 'group2-command2' ])
 		});
 		assert.equal(yargsStub.strict.callCount, 4);
 	},
 	'Should call yargs.command once for each yargsCommandName passed and once for the default command'() {
 		const key = 'group1-command1';
 		const { group, description } = commandsMap.get(key);
-		registerCommands(yargsStub, commandsMap, {'group1': [ key ]});
+		registerCommands(yargsStub, commandsMap, {'group1': new Set([ key ])});
 		assert.isTrue(yargsStub.command.calledThrice);
 		assert.isTrue(yargsStub.command.firstCall.calledWith(group, description), 'First call is for parent');
 		assert.isTrue(yargsStub.command.secondCall.calledWith('command1', key), 'Second call is sub-command');
@@ -60,7 +60,7 @@ registerSuite({
 	'Should run the passed command when yargs called with group name and command'() {
 		const key = 'group1-command1';
 		const { run } = commandsMap.get(key);
-		registerCommands(yargsStub, commandsMap, {'group1': [ key ]});
+		registerCommands(yargsStub, commandsMap, {'group1': new Set([ key ])});
 		yargsStub.command.secondCall.args[3]();
 		assert.isTrue(run.calledOnce);
 	},
@@ -70,7 +70,7 @@ registerSuite({
 			defaultRunStub = stub(defaultCommandWrapper, 'run').returns(Promise.resolve());
 			commandsMap.set('group1', defaultCommandWrapper);
 			const key = 'group1-command1';
-			registerCommands(yargsStub, commandsMap, {'group1': [ key ]});
+			registerCommands(yargsStub, commandsMap, {'group1': new Set([ key ])});
 		},
 		'afterEach'() {
 			defaultRegisterStub.restore();
@@ -106,7 +106,7 @@ registerSuite({
 		'version option'() {
 			commandsMap.set('group1', defaultCommandWrapper);
 			const key = 'group1-command1';
-			registerCommands(yargsStub, commandsMap, { 'group1': [ key ] });
+			registerCommands(yargsStub, commandsMap, { 'group1': new Set([ key ]) });
 
 			let versionString = yargsStub.version.lastCall.args[ 0 ]();
 
@@ -118,7 +118,7 @@ registerSuite({
 			defaultRunStub = stub(defaultCommandWrapper, 'run').returns(Promise.resolve());
 			commandsMap.set('group1', defaultCommandWrapper);
 			const key = 'group1-command1';
-			registerCommands(yargsStub, commandsMap, { 'group1': [ key ] });
+			registerCommands(yargsStub, commandsMap, { 'group1': new Set([ key ]) });
 
 			let output = '';
 			let consoleStub = stub(console, 'log', function (...lines: string[]) {


### PR DESCRIPTION
Fixes: https://github.com/dojo/cli/issues/63
Ensures that duplicate command names and descriptions are not shown.

- Order of precedence is CLI > Peer > Project
- Uses `Set` instead of `Array` to ensure unique command names
- Fixed tests
- Added test for bug scenario
