### PR TITLE
Remove `dirname` module and use `__dirname` directly

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
-import dirname from './dirname';
+
 const pkgDir = require('pkg-dir');
-const packagePath = pkgDir.sync(dirname);
+const packagePath = pkgDir.sync(__dirname);
 
 export type Config = {
 	searchPaths: string[],

--- a/src/dirname.ts
+++ b/src/dirname.ts
@@ -1,1 +1,0 @@
-export default __dirname;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,9 @@ import loadCommands from './loadCommands';
 import registerCommands from './registerCommands';
 import { initCommandLoader } from './command';
 import { join } from 'path';
-import dirname from './dirname';
 const pkgDir = require('pkg-dir');
 
-const packagePath = pkgDir.sync(dirname);
+const packagePath = pkgDir.sync(__dirname);
 const packageJsonFilePath = join(packagePath, 'package.json');
 const pkg = <any> require(packageJsonFilePath);
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,4 @@
 import { CommandsMap } from './command';
-import dirname from './dirname';
 import {
 	versionNoRegisteredCommands,
 	versionRegisteredCommands,
@@ -9,7 +8,7 @@ import {
 import { join } from 'path';
 
 const pkgDir = require('pkg-dir');
-const packagePath = pkgDir.sync(dirname);
+const packagePath = pkgDir.sync(__dirname);
 
 /**
  * The details of one command group's module.

--- a/tests/unit/config.ts
+++ b/tests/unit/config.ts
@@ -1,6 +1,5 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import * as mockery from 'mockery';
 import { resolve } from 'path';
 
 const config = require('intern/dojo/node!./../../src/config').default;
@@ -8,12 +7,6 @@ const expectedSearchPrefix = 'dojo-cli';
 
 registerSuite({
 	name: 'config',
-	'setup'() {
-	},
-	'teardown'() {
-		mockery.deregisterAll();
-		mockery.disable();
-	},
 	'Should provide a search prefix'() {
 		const prefix = config.searchPrefix;
 		assert.isTrue(typeof prefix === 'string');

--- a/tests/unit/config.ts
+++ b/tests/unit/config.ts
@@ -1,29 +1,14 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import * as mockery from 'mockery';
-import { SinonStub, stub } from 'sinon';
-import { join } from 'path';
+import { resolve } from 'path';
 
-const fakePackageRoot = 'fakePackageRoot';
-const fakeGlobalModuleRoot = 'fakeGlobalModuleRoot';
+const config = require('intern/dojo/node!./../../src/config').default;
 const expectedSearchPrefix = 'dojo-cli';
-const pkgDirStub: SinonStub = stub().returns(join(fakeGlobalModuleRoot, fakePackageRoot));
-let config: any;
 
 registerSuite({
 	name: 'config',
 	'setup'() {
-		mockery.enable({
-			warnOnUnregistered: false
-		});
-
-		mockery.registerMock('./dirname', { 'default': fakePackageRoot });
-		mockery.registerMock('pkg-dir', { 'sync': pkgDirStub });
-
-		config = require('intern/dojo/node!./../../src/config').default;
-	},
-	'beforeEach'() {
-		pkgDirStub.reset();
 	},
 	'teardown'() {
 		mockery.deregisterAll();
@@ -40,13 +25,12 @@ registerSuite({
 	},
 	'Should look in the global package node_modules first'() {
 		const paths = config.searchPaths;
-		const expectedPath = join(fakeGlobalModuleRoot, fakePackageRoot, 'node_modules');
+		const expectedPath = resolve('node_modules');
 		assert.equal(paths[0], expectedPath);
 	},
 	'Should look in global peer packages second'() {
 		const paths = config.searchPaths;
-		assert.equal(paths[1], fakeGlobalModuleRoot);
-		assert.equal(-1, paths[1].indexOf(fakePackageRoot));
+		assert.equal(paths[1], resolve('..'));
 	},
 	'Should look in current working directory node_modules last'() {
 		const paths = config.searchPaths;


### PR DESCRIPTION
Don't think we need to wrap the `__dirname` built in as long as we do not need to reference `__dirname` in tests (which we do not)