### PR TITLE
fix: fixed intern to 3.3.2 to resolve typings dispute

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "grunt-ts": "^5.5.1",
     "grunt-tslint": "^3.1.0",
     "grunt-typings": ">=0.1.5",
-    "intern": "^3.2.3",
+    "intern": "3.3.2",
     "istanbul": "^0.4.3",
     "mockery": "^1.7.0",
     "remap-istanbul": "^0.6.4",


### PR DESCRIPTION
Re-raised due to commit history violation (even though we squash) 😉 