### PR TITLE
Correctly structure the manifest

### DIFF
--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -40,7 +40,10 @@ export interface VersionArgs extends Argv {
 }
 
 type DavidDependencies = {
-	[dependencyName: string]: { stable: string }
+	[dependencyName: string]: {
+		stable: string;
+		latest: string;
+	}
 }
 
 /**
@@ -51,15 +54,11 @@ type DavidDependencies = {
  * @returns {{name, version, group}[]}
  */
 function areCommandsOutdated(moduleVersions: ModuleVersion[]): Promise<any> {
-	// convert [ModuleVersion] = [{commandPackageName: commandPackageVersion}]
-	const deps: {}[] = moduleVersions
-		.map((command) => {
-			let obj: {
-				[commandName: string]: string
-			} = {};
-			obj[command.name] = command.version;
-			return obj;
-		});
+	const deps: { [index: string]: string } = {};
+
+	moduleVersions.forEach((command) => {
+		deps[command.name] = command.version;
+	});
 
 	// create fake manifest (package.json) with just the dev-dependencies that we want to check
 	const manifest = {
@@ -68,14 +67,14 @@ function areCommandsOutdated(moduleVersions: ModuleVersion[]): Promise<any> {
 
 	return new Promise((resolve, reject) => {
 		// we want to fetch the latest stable version for our devDependencies
-		david.getUpdatedDependencies(manifest, { dev: true, stable: true }, function (err: any, deps: DavidDependencies) {
+		david.getUpdatedDependencies(manifest, { dev: true }, function (err: any, deps: DavidDependencies) {
 			if (err) {
 				reject(err);
 			}
 			resolve(moduleVersions.map((command) => {
 				const canBeUpdated = deps[command.name];    // david returns all deps that can be updated
 				const versionStr = canBeUpdated ?
-					`${command.version} ${yellow(`(can be updated to ${deps[command.name].stable})`)}.` :
+					`${command.version} ${yellow(`(can be updated to ${deps[command.name].latest})`)}.` :
 					`${command.version} (on latest stable version).`;
 				return {
 					name: command.name,

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -36,7 +36,7 @@ interface PackageDetails {
 }
 
 export interface VersionArgs extends Argv {
-	outdated: string;
+	outdated: boolean;
 }
 
 type DavidDependencies = {
@@ -219,7 +219,7 @@ function createVersionsString(commandsMap: CommandsMap, checkOutdated: boolean):
 }
 
 function run(helper: Helper, args: VersionArgs): Promise<any> {
-	const checkOutdated = args.outdated !== undefined;
+	const checkOutdated = args.outdated;
 	if (checkOutdated) {
 		console.log('Fetching latest version information...');
 	}

--- a/tests/unit/commands/version.ts
+++ b/tests/unit/commands/version.ts
@@ -54,6 +54,7 @@ describe('version command', () => {
 
 		const helper = {commandsMap: commandMap, command: 'version'};
 		return moduleUnderTest.run(helper, {}).then(() => {
+			assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
 			assert.equal((<sinon.SinonStub> console.log).args[0][0], noCommandOutput);
 		});
 	});
@@ -73,6 +74,7 @@ describe('version command', () => {
 
 		const helper = {commandsMap: commandMap, command: 'version'};
 		return moduleUnderTest.run(helper, {}).then(() => {
+			assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
 			assert.equal((<sinon.SinonStub> console.log).args[0][0], noCommandOutput);
 		});
 	});
@@ -98,6 +100,7 @@ describe('version command', () => {
 
 		const helper = {commandsMap: commandMap, command: 'version'};
 		return moduleUnderTest.run(helper, {}).then(() => {
+			assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
 			assert.equal((<sinon.SinonStub> console.log).args[0][0], expectedOutput);
 		});
 	});
@@ -123,7 +126,8 @@ describe('version command', () => {
 		]);
 
 		const helper = {commandsMap: commandMap, command: 'version'};
-		return moduleUnderTest.run(helper, {}).then(() => {
+		return moduleUnderTest.run(helper, { outdated: false }).then(() => {
+			assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
 			assert.equal((<sinon.SinonStub> console.log).args[0][0], expectedOutput);
 		});
 	});

--- a/tests/unit/commands/version.ts
+++ b/tests/unit/commands/version.ts
@@ -53,7 +53,7 @@ describe('version command', () => {
 		const commandMap: CommandsMap = new Map<string, CommandWrapper>();
 
 		const helper = {commandsMap: commandMap, command: 'version'};
-		return moduleUnderTest.run(helper, {}).then(() => {
+		return moduleUnderTest.run(helper, { outdated: false }).then(() => {
 			assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
 			assert.equal((<sinon.SinonStub> console.log).args[0][0], noCommandOutput);
 		});

--- a/tests/unit/commands/version.ts
+++ b/tests/unit/commands/version.ts
@@ -128,7 +128,7 @@ describe('version command', () => {
 		});
 	});
 
-	it('should run and return current versions and latest stable version on success', () => {
+	it('should run and return current versions and latest version on success', () => {
 		const latestStableInfo: any = {};
 		mockDavid.getUpdatedDependencies = sandbox.stub().yields(null, latestStableInfo);
 		const installedCommandWrapper = getCommandWrapperWithConfiguration({
@@ -150,9 +150,9 @@ describe('version command', () => {
 		});
 	});
 
-	it('should run and return current versions and upgrade to latest stable version on success', () => {
+	it('should run and return current versions and upgrade to latest version on success', () => {
 		const latestStableInfo: any = {};
-		latestStableInfo[validPackageInfo.name] = {'stable': '1.2.3'};
+		latestStableInfo[validPackageInfo.name] = {'latest': '1.2.3'};
 		mockDavid.getUpdatedDependencies = sandbox.stub().yields(null, latestStableInfo);
 		const installedCommandWrapper = getCommandWrapperWithConfiguration({
 			group: 'apple',
@@ -160,7 +160,7 @@ describe('version command', () => {
 			path: join(pathResolve('.'), '_build/tests/support/valid-package')
 		});
 
-		const expectedOutput = `${outputPrefix()}The currently installed groups are:\n\n${installedCommandWrapper.group} (${validPackageInfo.name}) ${validPackageInfo.version} \u001b[33m(can be updated to ${latestStableInfo[validPackageInfo.name].stable})\u001b[39m.\n${outputSuffix()}`;
+		const expectedOutput = `${outputPrefix()}The currently installed groups are:\n\n${installedCommandWrapper.group} (${validPackageInfo.name}) ${validPackageInfo.version} \u001b[33m(can be updated to ${latestStableInfo[validPackageInfo.name].latest})\u001b[39m.\n${outputSuffix()}`;
 
 		const commandMap: CommandsMap = new Map<string, CommandWrapper>([
 			['installedCommand1', installedCommandWrapper]

--- a/tests/unit/commands/version.ts
+++ b/tests/unit/commands/version.ts
@@ -73,7 +73,7 @@ describe('version command', () => {
 		]);
 
 		const helper = {commandsMap: commandMap, command: 'version'};
-		return moduleUnderTest.run(helper, {}).then(() => {
+		return moduleUnderTest.run(helper, { outdated: false }).then(() => {
 			assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
 			assert.equal((<sinon.SinonStub> console.log).args[0][0], noCommandOutput);
 		});
@@ -99,7 +99,7 @@ describe('version command', () => {
 		]);
 
 		const helper = {commandsMap: commandMap, command: 'version'};
-		return moduleUnderTest.run(helper, {}).then(() => {
+		return moduleUnderTest.run(helper, { outdated: false }).then(() => {
 			assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
 			assert.equal((<sinon.SinonStub> console.log).args[0][0], expectedOutput);
 		});
@@ -148,7 +148,7 @@ describe('version command', () => {
 		]);
 
 		const helper = {commandsMap: commandMap, command: 'version' };
-		return moduleUnderTest.run(helper, {'outdated': true}).then(() => {
+		return moduleUnderTest.run(helper, { 'outdated': true }).then(() => {
 			assert.equal('Fetching latest version information...', (<sinon.SinonStub> console.log).args[0][0]);
 			assert.equal((<sinon.SinonStub> console.log).args[1][0], expectedOutput);
 		});
@@ -171,7 +171,7 @@ describe('version command', () => {
 		]);
 
 		const helper = {commandsMap: commandMap, command: 'version' };
-		return moduleUnderTest.run(helper, {'outdated': true}).then(() => {
+		return moduleUnderTest.run(helper, { 'outdated': true }).then(() => {
 			assert.equal('Fetching latest version information...', (<sinon.SinonStub> console.log).args[0][0]);
 			assert.equal((<sinon.SinonStub> console.log).args[1][0], expectedOutput);
 		});
@@ -193,7 +193,7 @@ describe('version command', () => {
 		]);
 
 		const helper = {commandsMap: commandMap, command: 'version' };
-		return moduleUnderTest.run(helper, {'outdated': true}).then(() => {
+		return moduleUnderTest.run(helper, { 'outdated': true }).then(() => {
 			assert.equal('Fetching latest version information...', (<sinon.SinonStub> console.log).args[0][0]);
 			assert.equal((<sinon.SinonStub> console.log).args[1][0], expectedOutput);
 		});


### PR DESCRIPTION
Also fix issue that meant outdated check was run even when the `-o` flag wasn't passed