### PR TITLE
Fix help so it displays per grouping

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,12 +1,35 @@
 module.exports = function (grunt) {
+	var staticFiles = [ 'templates/**', 'config/**' ];
+
 	require('grunt-dojo2').initConfig(grunt, {
+		ts: {
+			dist: {
+				exclude: [
+					'./src/templates',
+					"./tests/**/*.ts"
+				]
+			}
+		},
 		copy: {
-			staticTestFiles: {
+			staticDevFiles: {
 				expand: true,
-				cwd: '.',
-				src: 'tests/**/*.json',
-				dest: '<%= tsconfig.compilerOptions.outDir %>'
+				cwd: 'src',
+				src: staticFiles,
+				dest: '<%= devDirectory %>/src'
+			},
+			staticDistFiles: {
+				expand: true,
+				cwd: 'src',
+				src: staticFiles,
+				dest: '<%= distDirectory %>'
 			}
 		}
 	});
+
+	grunt.registerTask('dev', grunt.config.get('devTasks').concat(['copy:staticDevFiles']));
+	grunt.registerTask('dist', grunt.config.get('distTasks').concat(['copy:staticDistFiles']));
+
+	grunt.registerTask('ci', [
+		'intern:node'
+	]);
 };

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "sinon": "^1.17.5",
     "sinon-as-promised": "^4.0.2",
     "tslint": "^3.11.0",
-    "typescript": "~2.1.4"
+    "typescript": "~2.1.5"
   }
 }

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,7 +1,7 @@
 import { CommandsMap } from '../command';
 import { Helper, OptionsHelper } from '../interfaces';
 import { join } from 'path';
-import { Argv, Options } from 'yargs';
+import { Argv } from 'yargs';
 import { yellow } from 'chalk';
 import allCommands from '../allCommands';
 const david = require('david');

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,5 +1,5 @@
 import { CommandsMap } from '../command';
-import { Helper } from '../interfaces';
+import { Helper, OptionsHelper } from '../interfaces';
 import { join } from 'path';
 import { Argv, Options } from 'yargs';
 import { yellow } from 'chalk';
@@ -122,7 +122,7 @@ function createOutput(myPackageDetails: PackageDetails, commandVersions: ModuleV
 	return output;
 }
 
-function register(options: (key: string, options: Options) => void): void {
+function register(helper: Helper, options: OptionsHelper): void {
 	options('o', {
 		alias: 'outdated',
 		describe: 'Output a list of installed commands and check if any can be updated to a more recent stable version.',

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,7 +1,7 @@
 import { CommandsMap } from '../command';
 import { Helper } from '../interfaces';
 import { join } from 'path';
-import { Yargs, Argv } from 'yargs';
+import { Argv, Options } from 'yargs';
 import { yellow } from 'chalk';
 import allCommands from '../allCommands';
 const david = require('david');
@@ -122,14 +122,13 @@ function createOutput(myPackageDetails: PackageDetails, commandVersions: ModuleV
 	return output;
 }
 
-function register(helper: Helper): Yargs {
-	helper.yargs.option('o', {
+function register(options: (key: string, options: Options) => void): void {
+	options('o', {
 		alias: 'outdated',
 		describe: 'Output a list of installed commands and check if any can be updated to a more recent stable version.',
 		demand: false,
 		type: 'boolean'
 	});
-	return helper.yargs;
 }
 
 /**

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -122,7 +122,7 @@ function createOutput(myPackageDetails: PackageDetails, commandVersions: ModuleV
 	return output;
 }
 
-function register(helper: Helper, options: OptionsHelper): void {
+function register(options: OptionsHelper): void {
 	options('o', {
 		alias: 'outdated',
 		describe: 'Output a list of installed commands and check if any can be updated to a more recent stable version.',

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -18,7 +18,7 @@ export type OptionsHelper = (key: string, options: Options) => void;
  */
 export interface Command {
 	description: string;
-	register(helper: Helper, options: OptionsHelper): void;
+	register(options: OptionsHelper): void;
 	run(helper: Helper, args?: Argv): Promise<any>;
 	name?: string;
 	group?: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { Argv, Yargs } from 'yargs';
+import { Argv, Yargs, Options } from 'yargs';
 
 export interface CommandHelper {
 	run(group: string, commandName?: string, args?: Argv): Promise<any>;
@@ -16,7 +16,7 @@ export interface Helper {
  */
 export interface Command {
 	description: string;
-	register(helper: Helper): Yargs;
+	register(options: (key: string, options: Options) => void): void;
 	run(helper: Helper, args?: Argv): Promise<any>;
 	name?: string;
 	group?: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,12 +11,14 @@ export interface Helper {
 	context: any;
 }
 
+export type OptionsHelper = (key: string, options: Options) => void;
+
 /**
  * Inbuilt commands specify their name and group - installed commands have these props parsed out of their package dir name
  */
 export interface Command {
 	description: string;
-	register(options: (key: string, options: Options) => void): void;
+	register(helper: Helper, options: OptionsHelper): void;
 	run(helper: Helper, args?: Argv): Promise<any>;
 	name?: string;
 	group?: string;

--- a/src/loadCommands.ts
+++ b/src/loadCommands.ts
@@ -65,12 +65,12 @@ export async function loadCommands(paths: string[], load: (path: string) => Comm
 				if (!commandsMap.has(group)) {
 					// First of each type will be 'default' for now
 					setDefaultGroup(commandsMap, group, commandWrapper);
-						yargsCommandNames.set(group, new Set());
-					}
+					yargsCommandNames.set(group, new Set());
+				}
 
-					if (!commandsMap.has(compositeKey)) {
-						commandsMap.set(compositeKey, commandWrapper);
-					}
+				if (!commandsMap.has(compositeKey)) {
+					commandsMap.set(compositeKey, commandWrapper);
+				}
 
 				const groupCommandNames = yargsCommandNames.get(group);
 				if (groupCommandNames) {

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -42,7 +42,7 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 					description,
 					(yargs: Yargs) => {
 						register((key: string, options: Options) => {
-							options.group = command;
+							options.group = name;
 							yargs.option(key, options);
 						});
 						return yargs;

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -23,8 +23,19 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 
 	yargsCommandNames.forEach((commandOptions, commandName) => {
 		const groupDescription = getGroupDescription(commandOptions, commandsMap);
+		const defaultCommand = <CommandWrapper> commandsMap.get(commandName);
+		const defaultCommandAvailable = !!(defaultCommand && defaultCommand.register && defaultCommand.run);
 		const reportError = (error: Error) => console.error(chalk.red.bold(error.message));
 		yargs.command(commandName, groupDescription, (yargs: Yargs) => {
+			if (defaultCommandAvailable) {
+				defaultCommand.register((key: string, options: Options) => {
+					yargs.option(key, {
+						group: `Default Command Options ('${defaultCommand.name}')`,
+						...options
+					});
+				});
+			}
+
 			[...commandOptions].filter((command: string) => {
 				return `${commandName}-` !== command;
 			}).forEach((command: string) => {
@@ -33,7 +44,7 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 					name,
 					description,
 					(yargs: Yargs) => {
-						register(helper, (key: string, options: Options) => {
+						register((key: string, options: Options) => {
 							yargs.option(key, options);
 						});
 						return yargs;
@@ -45,6 +56,15 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 				.strict();
 			});
 			return yargs;
+		},
+		(argv: Argv) => {
+			// argv._ is an array of commands.
+			// if `dojo example` was called, it will only be size one,
+			// so we call default command, else, the subcommand will
+			// have been ran and we don't want to run the default.
+			if (defaultCommandAvailable && argv._.length === 1) {
+				return defaultCommand.run(helper, argv).catch(reportError);
+			}
 		});
 	});
 

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -29,12 +29,10 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 		yargs.command(commandName, groupDescription, (yargs: Yargs) => {
 			// Register the default command so that options show
 			if (defaultCommandAvailable) {
-				defaultCommand.register((() => {
-					return (key: string, options: Options) => {
-						options.group = defaultCommand.name;
-						yargs.option(key, options);
-					};
-				})());
+				defaultCommand.register((key: string, options: Options) => {
+					options.group = defaultCommand.name;
+					yargs.option(key, options);
+				});
 			}
 
 			commandOptions.forEach((command: string) => {
@@ -43,12 +41,10 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 					name,
 					description,
 					(yargs: Yargs) => {
-						register((() => {
-							return (key: string, options: Options) => {
-								options.group = command;
-								yargs.option(key, options);
-							};
-						})());
+						register((key: string, options: Options) => {
+							options.group = command;
+							yargs.option(key, options);
+						});
 						return yargs;
 					},
 					(argv: Argv) => {

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -23,26 +23,17 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 
 	yargsCommandNames.forEach((commandOptions, commandName) => {
 		const groupDescription = getGroupDescription(commandOptions, commandsMap);
-		const defaultCommand = <CommandWrapper> commandsMap.get(commandName);
-		const defaultCommandAvailable = !!(defaultCommand && defaultCommand.register && defaultCommand.run);
 		const reportError = (error: Error) => console.error(chalk.red.bold(error.message));
 		yargs.command(commandName, groupDescription, (yargs: Yargs) => {
-			// Register the default command so that options show
-			if (defaultCommandAvailable) {
-				defaultCommand.register((key: string, options: Options) => {
-					options.group = defaultCommand.name;
-					yargs.option(key, options);
-				});
-			}
-
-			commandOptions.forEach((command: string) => {
+			[...commandOptions].filter((command: string) => {
+				return `${commandName}-` !== command;
+			}).forEach((command: string) => {
 				const {name, description, register, run} = <CommandWrapper> commandsMap.get(command);
 				yargs.command(
 					name,
 					description,
 					(yargs: Yargs) => {
-						register((key: string, options: Options) => {
-							options.group = name;
+						register(helper, (key: string, options: Options) => {
 							yargs.option(key, options);
 						});
 						return yargs;
@@ -54,15 +45,6 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 				.strict();
 			});
 			return yargs;
-		},
-		(argv: Argv) => {
-			// argv._ is an array of commands.
-			// if `dojo example` was called, it will only be size one,
-			// so we call default command, else, the subcommand will
-			// have been ran and we don't want to run the default.
-			if (defaultCommandAvailable && argv._.length === 1) {
-				return defaultCommand.run(helper, argv).catch(reportError);
-			}
 		});
 	});
 

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -1,4 +1,4 @@
-import { Yargs, Argv } from 'yargs';
+import { Yargs, Argv, Options } from 'yargs';
 import { getGroupDescription, CommandsMap, CommandWrapper } from './command';
 import CommandHelper from './CommandHelper';
 import Helper from './Helper';
@@ -29,7 +29,12 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 		yargs.command(commandName, groupDescription, (yargs: Yargs) => {
 			// Register the default command so that options show
 			if (defaultCommandAvailable) {
-				defaultCommand.register(helper);
+				defaultCommand.register((() => {
+					return (key: string, options: Options) => {
+						options.group = defaultCommand.name;
+						yargs.option(key, options);
+					};
+				})());
 			}
 
 			commandOptions.forEach((command: string) => {
@@ -38,7 +43,12 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 					name,
 					description,
 					(yargs: Yargs) => {
-						register(helper);
+						register((() => {
+							return (key: string, options: Options) => {
+								options.group = command;
+								yargs.option(key, options);
+							};
+						})());
 						return yargs;
 					},
 					(argv: Argv) => {

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -29,7 +29,7 @@ export function getCommandsMap(groupDef: GroupDef, withOptions?: boolean) {
 				group: group.groupName,
 				description: compositeKey,
 				register: (withOptions ?
-					stub().callsArgWith(0, 'key', {}) : 
+					stub().callsArgWith(0, 'key', {}) :
 					stub()).returns(compositeKey),
 				runStub,
 				run: runStub.returns(command.fails ?

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -28,7 +28,7 @@ export function getCommandsMap(groupDef: GroupDef) {
 				name: command.commandName,
 				group: group.groupName,
 				description: compositeKey,
-				register: stub().callsArgWith(0, 'key', {}).returns(compositeKey),
+				register: stub().callsArgWith(1, 'key', {}).returns(compositeKey),
 				runStub,
 				run: runStub.returns(command.fails ?
 					Promise.reject(new Error(compositeKey)) :

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -17,7 +17,7 @@ export interface CommandWrapperConfig {
 	runs?: boolean;
 }
 
-export function getCommandsMap(groupDef: GroupDef) {
+export function getCommandsMap(groupDef: GroupDef, withOptions?: boolean) {
 	const commands = new Map();
 
 	groupDef.forEach((group) => {
@@ -28,7 +28,9 @@ export function getCommandsMap(groupDef: GroupDef) {
 				name: command.commandName,
 				group: group.groupName,
 				description: compositeKey,
-				register: stub().returns(compositeKey),
+				register: (withOptions ?
+					stub().callsArgWith(0, 'key', {}) : 
+					stub()).returns(compositeKey),
 				runStub,
 				run: runStub.returns(command.fails ?
 					Promise.reject(new Error(compositeKey)) :
@@ -41,7 +43,7 @@ export function getCommandsMap(groupDef: GroupDef) {
 	return commands;
 };
 
-const yargsFunctions = [ 'demand', 'usage', 'epilog', 'help', 'alias', 'strict' ];
+const yargsFunctions = [ 'demand', 'usage', 'epilog', 'help', 'alias', 'strict', 'option' ];
 export function getYargsStub() {
 	const yargsStub: any = {};
 	yargsFunctions.forEach((fnc) => {

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -17,7 +17,7 @@ export interface CommandWrapperConfig {
 	runs?: boolean;
 }
 
-export function getCommandsMap(groupDef: GroupDef, withOptions?: boolean) {
+export function getCommandsMap(groupDef: GroupDef) {
 	const commands = new Map();
 
 	groupDef.forEach((group) => {
@@ -28,9 +28,7 @@ export function getCommandsMap(groupDef: GroupDef, withOptions?: boolean) {
 				name: command.commandName,
 				group: group.groupName,
 				description: compositeKey,
-				register: (withOptions ?
-					stub().callsArgWith(0, 'key', {}) :
-					stub()).returns(compositeKey),
+				register: stub().callsArgWith(0, 'key', {}).returns(compositeKey),
 				runStub,
 				run: runStub.returns(command.fails ?
 					Promise.reject(new Error(compositeKey)) :

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -28,7 +28,7 @@ export function getCommandsMap(groupDef: GroupDef) {
 				name: command.commandName,
 				group: group.groupName,
 				description: compositeKey,
-				register: stub().callsArgWith(1, 'key', {}).returns(compositeKey),
+				register: stub().callsArgWith(0, 'key', {}).returns(compositeKey),
 				runStub,
 				run: runStub.returns(command.fails ?
 					Promise.reject(new Error(compositeKey)) :

--- a/tests/unit/commands/version.ts
+++ b/tests/unit/commands/version.ts
@@ -38,10 +38,10 @@ describe('version command', () => {
 	});
 
 	it('should register supported arguments', () => {
-		const helper = { yargs: { option: sandbox.stub() } };
-		moduleUnderTest.register(helper);
+		const options = sandbox.stub();
+		moduleUnderTest.register(options);
 		assert.deepEqual(
-			helper.yargs.option.firstCall.args,
+			options.args[0],
 			[ 'o', {
 				alias: 'outdated',
 				describe: 'Output a list of installed commands and check if any can be updated to a more recent stable version.',

--- a/tests/unit/commands/version.ts
+++ b/tests/unit/commands/version.ts
@@ -39,7 +39,7 @@ describe('version command', () => {
 
 	it('should register supported arguments', () => {
 		const options = sandbox.stub();
-		moduleUnderTest.register(null, options);
+		moduleUnderTest.register(options);
 		assert.deepEqual(
 			options.firstCall.args,
 			[ 'o', {

--- a/tests/unit/commands/version.ts
+++ b/tests/unit/commands/version.ts
@@ -41,7 +41,7 @@ describe('version command', () => {
 		const options = sandbox.stub();
 		moduleUnderTest.register(options);
 		assert.deepEqual(
-			options.args[0],
+			options.firstCall.args,
 			[ 'o', {
 				alias: 'outdated',
 				describe: 'Output a list of installed commands and check if any can be updated to a more recent stable version.',

--- a/tests/unit/commands/version.ts
+++ b/tests/unit/commands/version.ts
@@ -39,7 +39,7 @@ describe('version command', () => {
 
 	it('should register supported arguments', () => {
 		const options = sandbox.stub();
-		moduleUnderTest.register(options);
+		moduleUnderTest.register(null, options);
 		assert.deepEqual(
 			options.firstCall.args,
 			[ 'o', {

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -71,6 +71,7 @@ registerSuite({
 		const key = 'group1-command1';
 		registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ key ])}));
 		assert.isTrue(yargsStub.option.called);
+		assert.equal(yargsStub.option.firstCall.args[1].group, 'command1');
 	},
 	'default command': {
 		'beforeEach'() {
@@ -86,6 +87,7 @@ registerSuite({
 		},
 		'Should register the default command'() {
 			assert.isTrue(defaultRegisterStub.calledOnce);
+			assert.equal(yargsStub.option.secondCall.args[1].group, 'command1');
 		},
 		'Should run default command when yargs called with only group name'() {
 			yargsStub.command.firstCall.args[3]({'_': ['group']});

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -67,6 +67,11 @@ registerSuite({
 		yargsStub.command.secondCall.args[3]();
 		assert.isTrue(run.calledOnce);
 	},
+	'Should call into register method'() {
+		const key = 'group1-command1';
+		registerCommands(yargsStub, getCommandsMap(groupDef, true), createYargsCommandNames({'group1': new Set([ key ])}));
+		assert.isTrue(yargsStub.option.called);
+	},
 	'default command': {
 		'beforeEach'() {
 			defaultRegisterStub = stub(defaultCommandWrapper, 'register');

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -69,7 +69,7 @@ registerSuite({
 	},
 	'Should call into register method'() {
 		const key = 'group1-command1';
-		registerCommands(yargsStub, getCommandsMap(groupDef, true), createYargsCommandNames({'group1': new Set([ key ])}));
+		registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ key ])}));
 		assert.isTrue(yargsStub.option.called);
 	},
 	'default command': {

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -1,8 +1,10 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import { stub, SinonStub } from 'sinon';
 import { getCommandsMap, getYargsStub, GroupDef } from '../support/testHelper';
 
 const { 'default': registerCommands } = require('intern/dojo/node!../../src/registerCommands');
+const defaultCommandWrapper = require('intern/dojo/node!../support/test-prefix-foo-bar');
 
 const groupDef: GroupDef = [
 	{
@@ -16,6 +18,10 @@ const groupDef: GroupDef = [
 ];
 let commandsMap: any;
 let yargsStub: any;
+let defaultRegisterStub: SinonStub;
+let defaultRunStub: SinonStub;
+let consoleErrorStub: SinonStub;
+const errorMessage = 'test error message';
 
 function createYargsCommandNames(obj: any): Map<string, Set<any>> {
 	const map = new Map();
@@ -65,5 +71,43 @@ registerSuite({
 		const key = 'group1-command1';
 		registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ key ])}));
 		assert.isTrue(yargsStub.option.called);
+	},
+	'default command': {
+		'beforeEach'() {
+			const key = 'group1-command1';
+			defaultRegisterStub = stub(defaultCommandWrapper, 'register').callsArgWith(0, 'key', {}).returns(key);
+			defaultRunStub = stub(defaultCommandWrapper, 'run').returns(Promise.resolve());
+			commandsMap.set('group1', defaultCommandWrapper);
+			registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ key ])}));
+		},
+		'afterEach'() {
+			defaultRegisterStub.restore();
+			defaultRunStub .restore();
+		},
+		'Should register the default command'() {
+			assert.isTrue(defaultRegisterStub.calledOnce);
+		},
+		'Should run default command when yargs called with only group name'() {
+			yargsStub.command.firstCall.args[3]({'_': ['group']});
+			assert.isTrue(defaultRunStub.calledOnce);
+		},
+		'Should not run default command when yargs called with group name and command'() {
+			yargsStub.command.firstCall.args[3]({'_': ['group', 'command']});
+			assert.isFalse(defaultRunStub.called);
+		},
+		'error message': {
+			'beforeEach'() {
+				consoleErrorStub = stub(console, 'error');
+				defaultRunStub.returns(Promise.reject(new Error(errorMessage)));
+			},
+			'afterEach'() {
+				consoleErrorStub.restore();
+			},
+			async 'Should show error message if the run command rejects'() {
+				await yargsStub.command.firstCall.args[3]({'_': ['group']});
+				assert.isTrue(consoleErrorStub.calledOnce);
+				assert.isTrue(consoleErrorStub.firstCall.calledWithMatch(errorMessage));
+			}
+		}
 	}
 });

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -74,7 +74,7 @@ registerSuite({
 	},
 	'default command': {
 		'beforeEach'() {
-			defaultRegisterStub = stub(defaultCommandWrapper, 'register');
+			defaultRegisterStub = stub(defaultCommandWrapper, 'register').callsArgWith(0, 'key', {});
 			defaultRunStub = stub(defaultCommandWrapper, 'run').returns(Promise.resolve());
 			commandsMap.set('group1', defaultCommandWrapper);
 			const key = 'group1-command1';

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -1,10 +1,8 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import { stub, SinonStub } from 'sinon';
 import { getCommandsMap, getYargsStub, GroupDef } from '../support/testHelper';
 
 const { 'default': registerCommands } = require('intern/dojo/node!../../src/registerCommands');
-const defaultCommandWrapper = require('intern/dojo/node!../support/test-prefix-foo-bar');
 
 const groupDef: GroupDef = [
 	{
@@ -18,10 +16,6 @@ const groupDef: GroupDef = [
 ];
 let commandsMap: any;
 let yargsStub: any;
-let defaultRegisterStub: SinonStub;
-let defaultRunStub: SinonStub;
-let consoleErrorStub: SinonStub;
-const errorMessage = 'test error message';
 
 function createYargsCommandNames(obj: any): Map<string, Set<any>> {
 	const map = new Map();
@@ -71,45 +65,5 @@ registerSuite({
 		const key = 'group1-command1';
 		registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ key ])}));
 		assert.isTrue(yargsStub.option.called);
-		assert.equal(yargsStub.option.firstCall.args[1].group, 'command1');
-	},
-	'default command': {
-		'beforeEach'() {
-			defaultRegisterStub = stub(defaultCommandWrapper, 'register').callsArgWith(0, 'key', {});
-			defaultRunStub = stub(defaultCommandWrapper, 'run').returns(Promise.resolve());
-			commandsMap.set('group1', defaultCommandWrapper);
-			const key = 'group1-command1';
-			registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ key ])}));
-		},
-		'afterEach'() {
-			defaultRegisterStub.restore();
-			defaultRunStub .restore();
-		},
-		'Should register the default command'() {
-			assert.isTrue(defaultRegisterStub.calledOnce);
-			assert.equal(yargsStub.option.secondCall.args[1].group, 'command1');
-		},
-		'Should run default command when yargs called with only group name'() {
-			yargsStub.command.firstCall.args[3]({'_': ['group']});
-			assert.isTrue(defaultRunStub.calledOnce);
-		},
-		'Should not run default command when yargs called with group name and command'() {
-			yargsStub.command.firstCall.args[3]({'_': ['group', 'command']});
-			assert.isFalse(defaultRunStub.called);
-		},
-		'error message': {
-			'beforeEach'() {
-				consoleErrorStub = stub(console, 'error');
-				defaultRunStub.returns(Promise.reject(new Error(errorMessage)));
-			},
-			'afterEach'() {
-				consoleErrorStub.restore();
-			},
-			async 'Should show error message if the run command rejects'() {
-				await yargsStub.command.firstCall.args[3]({'_': ['group']});
-				assert.isTrue(consoleErrorStub.calledOnce);
-				assert.isTrue(consoleErrorStub.firstCall.calledWithMatch(errorMessage));
-			}
-		}
 	}
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,16 @@
 {
-	"version": "2.0.0",
+	"version": "2.1.5",
 	"compilerOptions": {
 		"declaration": false,
 		"module": "umd",
 		"noImplicitAny": true,
+		"noImplicitThis": true,
+		"strictNullChecks": true,
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,
 		"target": "es6",
-		"noImplicitThis": true,
-		"strictNullChecks": true,
-		"baseUrl": "node_modules",
- 		"paths": {}
+		"moduleResolution": "node"
 	},
 	"include": [
 		"./typings/index.d.ts",


### PR DESCRIPTION
<img width="586" alt="screen shot 2016-12-06 at 7 15 38 pm" src="https://cloud.githubusercontent.com/assets/78551/20969603/bc178000-bc57-11e6-8efd-34f64970115e.png">

Shows sub commands and the default command's options as well as global options
<img width="588" alt="screen shot 2016-12-07 at 8 31 42 am" src="https://cloud.githubusercontent.com/assets/78551/20969611/c03d8512-bc57-11e6-9c7e-3495238c675c.png">
<img width="593" alt="screen shot 2016-12-07 at 8 32 11 am" src="https://cloud.githubusercontent.com/assets/78551/20969614/c1f65b0e-bc57-11e6-89e5-648fe04e764d.png">


<!--
Thank you for Contributing to Dojo 2.

Please make sure you have read our Contributing Guidelines
available at: https://github.com/dojo/meta/blob/master/CONTRIBUTING.md
before submitting a PR.

-->

**Type:** bug

**Description:** 

Fix help display so that it displays options per grouping

**Related Issue:** #58

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [x] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged