### PR TITLE
Readme Update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ The CLI has the following in-built groups:
 
 `dojo version` - provides information on the versions of installed commands and the cli itself.
 
-To use non-basic groups and commands like `dojo create app` or `dojo build` you need to install them separately, e.g. with `npm i dojo-cli-create-app -g`.
+`dojo create app` and `dojo build` are not installed by default with dojo-cli. To use them, you must install them separately, e.g. with `npm i dojo-cli-create-app -g`.
 
 ## How do I contribute?
 

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ The CLI has the following format:
 
 `dojo group [command]` - where [command] is optional
 
-e.g. 
+e.g.
 
 `dojo build`
 
@@ -67,6 +67,8 @@ The CLI has the following in-built options:
 The CLI has the following in-built groups:
 
 `dojo version` - provides information on the versions of installed commands and the cli itself.
+
+To use non-basic groups and commands like `dojo create app` or `dojo build` you need to install them separately, e.g. with `npm i dojo-cli-create-app -g`.
 
 ## How do I contribute?
 


### PR DESCRIPTION
Update dojo-cli readme to mention non-basic groups and commands are not installed by default.