### PR TITLE
Cli configuration helpers

### DIFF
--- a/src/CommandHelper.ts
+++ b/src/CommandHelper.ts
@@ -1,6 +1,7 @@
 import { CommandsMap } from './command';
 import { CommandHelper, Command } from './interfaces';
 import Helper from './Helper';
+import ConfigurationHelper from './ConfigurationHelper';
 import * as yargs from 'yargs';
 
 function getCommand(commandsMap: CommandsMap, group: string, commandName?: string): Command | undefined {
@@ -16,13 +17,15 @@ export default class implements CommandHelper {
 	constructor(commandsMap: CommandsMap, context: any) {
 		this.commandsMap = commandsMap;
 		this.context = context;
+		this.configuration = new ConfigurationHelper();
 	};
 	private commandsMap: CommandsMap;
 	private context: any;
+	private configuration: ConfigurationHelper;
 	run(group: string, commandName?: string, args?: yargs.Argv): Promise<any> {
 		const command = getCommand(this.commandsMap, group, commandName);
 		if (command) {
-			const helper = new Helper(this, yargs, this.context);
+			const helper = new Helper(this, yargs, this.context, this.configuration);
 			return command.run(helper, args);
 		}
 		else {

--- a/src/ConfigurationHelper.ts
+++ b/src/ConfigurationHelper.ts
@@ -1,0 +1,52 @@
+import { existsSync, writeFile } from 'fs';
+import { join } from 'path';
+import { red } from 'chalk';
+import { ConfigurationHelper } from './interfaces';
+const pkgDir = require('pkg-dir');
+
+const appPath = pkgDir.sync(process.cwd());
+
+/**
+ * ConfigurationHelper class which is passed into each command's run function
+ * allowing commands to persist and retrieve .dojorc config object
+ */
+export default class implements ConfigurationHelper {
+	/**
+	 * persists configuration data to .dojorc
+	 * checks for collisions
+	 * 
+	 * @param config - the configuration to save
+	 * @returns Promise - this an indicator of success/failure
+	 */
+	async save(config: any = {}): Promise<any> {
+		const dojoRc = this.get() || {};
+		Object.keys(config).forEach((key) => {
+			if (key in dojoRc) {
+				throw Error(`${red('ERROR')} .dojorc already contains a '${key}' property`);
+			}
+			dojoRc[key] = config[key];
+		});
+		return new Promise((resolve, reject) => {
+			writeFile('.dojorc', JSON.stringify(dojoRc), { flag: 'wr' }, (error: Error) => {
+				if (error) {
+					reject(error);
+					return;
+				}
+				resolve(true);
+			});
+		});
+	};
+
+	/**
+	 * retrieves the configuration object from the file system 
+	 * or undefined if configuration does not exist
+	 * 
+	 * @returns an object representation of .dojorc
+	 */
+	get() {
+		const path = join(appPath, '.dojorc');
+		if (existsSync(path)) {
+			return require(path);
+		}
+	}
+};

--- a/src/ConfigurationHelper.ts
+++ b/src/ConfigurationHelper.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { red } from 'chalk';
 import { ConfigurationHelper } from './interfaces';
 const pkgDir = require('pkg-dir');
+const packageName = pkgDir.sync(__dirname).split('/').pop();
 
 const appPath = pkgDir.sync(process.cwd());
 
@@ -20,25 +21,26 @@ export default class implements ConfigurationHelper {
 	 */
 	async save(config: any = {}): Promise<any> {
 		const dojoRc = this.get() || {};
+		const section = dojoRc[packageName] = dojoRc[packageName] || {};
 		Object.keys(config).forEach((key) => {
-			if (key in dojoRc) {
-				throw Error(`${red('ERROR')} .dojorc already contains a '${key}' property`);
+			if (key in section) {
+				throw Error(`${red('ERROR')} .dojorc#${packageName} already contains a '${key}' property`);
 			}
-			dojoRc[key] = config[key];
+			section[key] = config[key];
 		});
 		return new Promise((resolve, reject) => {
-			writeFile('.dojorc', JSON.stringify(dojoRc), { flag: 'wr' }, (error: Error) => {
+			writeFile(join(appPath, '.dojorc'), JSON.stringify(dojoRc), { flag: 'wr' }, (error: Error) => {
 				if (error) {
 					reject(error);
 					return;
 				}
-				resolve(true);
+				resolve();
 			});
 		});
 	};
 
 	/**
-	 * retrieves the configuration object from the file system 
+	 * Retrieves the configuration object from the file system 
 	 * or undefined if configuration does not exist
 	 * 
 	 * @returns an object representation of .dojorc

--- a/src/Helper.ts
+++ b/src/Helper.ts
@@ -1,4 +1,4 @@
-import { CommandHelper, Helper } from './interfaces';
+import { CommandHelper, Helper, ConfigurationHelper } from './interfaces';
 import { Yargs } from 'yargs';
 
 /**
@@ -8,12 +8,14 @@ import { Yargs } from 'yargs';
  * other tasks.
  */
 export default class implements Helper {
-	constructor(commandHelper: CommandHelper, yargs: Yargs, context: any) {
+	constructor(commandHelper: CommandHelper, yargs: Yargs, context: any, configuration: ConfigurationHelper) {
 		this.command = commandHelper;
 		this.yargs = yargs;
 		this.context = context;
+		this.configuration = configuration;
 	};
 	command: CommandHelper;
 	yargs: Yargs;
 	context: any;
+	configuration: ConfigurationHelper;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,7 +2,7 @@ import { Argv, Yargs } from 'yargs';
 
 export interface ConfigurationHelper {
 	save(config: any): Promise<any>;
-	get(): any;
+	get(): Promise<any>;
 }
 
 export interface CommandHelper {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,10 @@
 import { Argv, Yargs } from 'yargs';
 
+export interface ConfigurationHelper {
+	save(config: any): Promise<any>;
+	get(): any;
+}
+
 export interface CommandHelper {
 	run(group: string, commandName?: string, args?: Argv): Promise<any>;
 	exists(group: string, commandName?: string): boolean;
@@ -9,6 +14,7 @@ export interface Helper {
 	yargs: Yargs;
 	command: CommandHelper;
 	context: any;
+	configuration: ConfigurationHelper;
 }
 
 /**

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -1,6 +1,7 @@
 import { Yargs, Argv } from 'yargs';
 import { getGroupDescription, CommandsMap, CommandWrapper } from './command';
 import CommandHelper from './CommandHelper';
+import ComfigurationHelper from './ConfigurationHelper';
 import Helper from './Helper';
 import { helpUsage, helpEpilog } from './text';
 import * as chalk from 'chalk';
@@ -18,8 +19,9 @@ import { YargsCommandNames } from './loadCommands';
 export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandNames: YargsCommandNames): void {
 	const helperContext = {};
 
+	const configurationHelper = new ComfigurationHelper();
 	const commandHelper = new CommandHelper(commandsMap, helperContext);
-	const helper = new Helper(commandHelper, yargs, helperContext);
+	const helper = new Helper(commandHelper, yargs, helperContext, configurationHelper);
 
 	yargsCommandNames.forEach((commandOptions, commandName) => {
 		const groupDescription = getGroupDescription(commandOptions, commandsMap);

--- a/tests/support/MockModule.ts
+++ b/tests/support/MockModule.ts
@@ -63,7 +63,13 @@ export default class MockModule {
 			.map((dep) => unload(dep));
 
 		dependencies.forEach((dependencyName) => {
-			let dependency = load(resolvePath(this.basePath, dependencyName));
+			let dependency;
+			try {
+				dependency = load(resolvePath(this.basePath, dependencyName));
+			}
+			catch (e) {
+				dependency = {};
+			}
 			const mock: any = {};
 
 			for (let prop in dependency) {

--- a/tests/unit/ConfigurationHelper.ts
+++ b/tests/unit/ConfigurationHelper.ts
@@ -51,6 +51,12 @@ registerSuite({
 			assert.equal(success, true);
 		});
 	},
+	'Should still write config when one does not exist'() {
+		mockFs.existsSync = sinon.stub().returns();
+		return configurationHelper.save({ blah: { blah1: '' } }).then((success: boolean) => {
+			assert.equal(success, true);
+		});
+	},
 	'Should throw error when collision'() {
 		return configurationHelper.save({ food: { blah1: '' } }).catch((error: Error) => {
 			assert.equal(error.message, `${red('ERROR')} .dojorc already contains a 'food' property`);

--- a/tests/unit/ConfigurationHelper.ts
+++ b/tests/unit/ConfigurationHelper.ts
@@ -47,19 +47,19 @@ registerSuite({
 		mockModule.destroy();
 	},
 	'Should write config to .dojorc'() {
-		return configurationHelper.save({ blah: { blah1: '' } }).then((success: boolean) => {
-			assert.equal(success, true);
+		return configurationHelper.save({ blah: { blah1: '' } }).then(() => {
+			assert.equal(true, true);
 		});
 	},
 	'Should still write config when one does not exist'() {
 		mockFs.existsSync = sinon.stub().returns();
-		return configurationHelper.save({ blah: { blah1: '' } }).then((success: boolean) => {
-			assert.equal(success, true);
+		return configurationHelper.save({ blah: { blah1: '' } }).then(() => {
+			assert.equal(true, true);
 		});
 	},
 	'Should throw error when collision'() {
 		return configurationHelper.save({ food: { blah1: '' } }).catch((error: Error) => {
-			assert.equal(error.message, `${red('ERROR')} .dojorc already contains a 'food' property`);
+			assert.equal(error.message, `${red('ERROR')} .dojorc#support already contains a 'food' property`);
 		});
 	},
 	'Should reject when error in writing file'() {

--- a/tests/unit/ConfigurationHelper.ts
+++ b/tests/unit/ConfigurationHelper.ts
@@ -1,0 +1,74 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { red } from 'chalk';
+import MockModule from '../support/MockModule';
+import { join, resolve as pathResolve } from 'path';
+const sap = require('sinon-as-promised');
+const sinon = new sap(Promise);
+
+let sandbox: any;
+let mockModule: MockModule;
+let mockPkgDir: any;
+let mockFs: any;
+let mockPath: any;
+let moduleUnderTest: any;
+let mockDojoRc: any;
+let configurationHelper: any;
+
+const packagePath = join(pathResolve('.'), '/_build/tests/support');
+
+registerSuite({
+	name: 'Configuration Helper',
+	'beforeEach'() {
+		sandbox = sinon.sandbox.create();
+		mockModule = new MockModule('../../src/ConfigurationHelper');
+		mockModule.dependencies([
+			'pkg-dir',
+			'fs',
+			'path',
+			`${packagePath}/.dojorc`]);
+		mockPkgDir = mockModule.getMock('pkg-dir');
+		mockPkgDir.ctor.sync = sandbox.stub().returns(packagePath);
+		mockFs = mockModule.getMock('fs');
+		mockFs.existsSync = sinon.stub().returns(true);
+		mockFs.writeFile = sinon.stub().callsArg(3);
+		mockPath = mockModule.getMock('path');
+		mockPath.join = sinon.stub().returns(`${packagePath}/.dojorc`);
+		mockDojoRc = mockModule.getMock(`${packagePath}/.dojorc`);
+		mockDojoRc.food = {
+			apple: '',
+			pear: ''
+		};
+		moduleUnderTest = mockModule.getModuleUnderTest().default;
+		configurationHelper = new moduleUnderTest();
+	},
+	'afterEach'() {
+		sandbox.restore();
+		mockModule.destroy();
+	},
+	'Should write config to .dojorc'() {
+		return configurationHelper.save({ blah: { blah1: '' } }).then((success: boolean) => {
+			assert.equal(success, true);
+		});
+	},
+	'Should throw error when collision'() {
+		return configurationHelper.save({ food: { blah1: '' } }).catch((error: Error) => {
+			assert.equal(error.message, `${red('ERROR')} .dojorc already contains a 'food' property`);
+		});
+	},
+	'Should reject when error in writing file'() {
+		mockFs.writeFile = sinon.stub().callsArgWith(3, 'bad file write');
+		return configurationHelper.save({ blah: { blah1: '' } }).catch((error: Error) => {
+			assert.equal(error, 'bad file write');
+		});
+	},
+	'Should retrieve the dojorc'() {
+		const dojoRc = configurationHelper.get();
+		assert.equal(dojoRc, mockDojoRc);
+	},
+	'Should return undefined'() {
+		mockFs.existsSync = sinon.stub().returns();
+		const dojoRc = configurationHelper.get();
+		assert.equal(dojoRc, undefined);
+	}
+});

--- a/tests/unit/ConfigurationHelper.ts
+++ b/tests/unit/ConfigurationHelper.ts
@@ -1,6 +1,5 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import { red } from 'chalk';
 import MockModule from '../support/MockModule';
 import { join, resolve as pathResolve } from 'path';
 const sap = require('sinon-as-promised');
@@ -57,11 +56,6 @@ registerSuite({
 			assert.equal(true, true);
 		});
 	},
-	'Should throw error when collision'() {
-		return configurationHelper.save({ food: { blah1: '' } }).catch((error: Error) => {
-			assert.equal(error.message, `${red('ERROR')} .dojorc#support already contains a 'food' property`);
-		});
-	},
 	'Should reject when error in writing file'() {
 		mockFs.writeFile = sinon.stub().callsArgWith(3, 'bad file write');
 		return configurationHelper.save({ blah: { blah1: '' } }).catch((error: Error) => {
@@ -69,12 +63,14 @@ registerSuite({
 		});
 	},
 	'Should retrieve the dojorc'() {
-		const dojoRc = configurationHelper.get();
-		assert.equal(dojoRc, mockDojoRc);
+		configurationHelper.get().then((dojoRc: any) => {
+			assert.equal(dojoRc, mockDojoRc);
+		});
 	},
 	'Should return undefined'() {
 		mockFs.existsSync = sinon.stub().returns();
-		const dojoRc = configurationHelper.get();
-		assert.equal(dojoRc, undefined);
+		configurationHelper.get().then((dojoRc: any) => {
+			assert.equal(dojoRc, undefined);
+		});
 	}
 });

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,6 +1,7 @@
 import './allCommands';
 import './command';
 import './CommandHelper';
+import './ConfigurationHelper';
 import './config';
 import './index';
 import './loadCommands';


### PR DESCRIPTION
Adds a `ConfigurationHelper` that provides two methods `save` and `get` for supporting configuration within cli commands. refs #88