### PR TITLE
Migrate to @dojo scoped package(s)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dojo-cli",
+  "name": "@dojo/cli",
   "version": "2.0.0-pre",
   "description": "Dojo 2 CLI utility",
   "homepage": "http://dojotoolkit.org",
@@ -37,8 +37,8 @@
   "devDependencies": {
     "@types/sinon-as-promised": "^4.0.5",
     "codecov.io": "0.1.6",
-    "dojo-interfaces": "^2.0.0-alpha.6",
-    "dojo-loader": ">=2.0.0-beta.7",
+    "@dojo/interfaces": "2.0.0-alpha.11",
+    "@dojo/loader": "2.0.0-beta.7",
     "dts-generator": "~1.7.0",
     "glob": "^7.0.3",
     "grunt": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/sinon-as-promised": "^4.0.5",
     "codecov.io": "0.1.6",
     "@dojo/interfaces": "2.0.0-alpha.11",
-    "@dojo/loader": "2.0.0-beta.7",
+    "@dojo/loader": "2.0.0-beta.9",
     "dts-generator": "~1.7.0",
     "glob": "^7.0.3",
     "grunt": "~1.0.1",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # @dojo/cli
 
-[![Build Status](https://travis-ci.org/dojo/cli.svg?branch=master)](https://travis-ci.org/dojo/cli) [![codecov](https://codecov.io/gh/dojo/cli/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/cli) [![npm version](https://badge.fury.io/js/@dojo/cli.svg)](http://badge.fury.io/js/@dojo/cli)
+[![Build Status](https://travis-ci.org/dojo/cli.svg?branch=master)](https://travis-ci.org/dojo/cli) [![codecov](https://codecov.io/gh/dojo/cli/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/cli) [![npm version](https://badge.fury.io/js/%40dojo%2Fcli.svg)](https://badge.fury.io/js/%40dojo%2Fcli)
 
 The CLI is the officially supported way to create and maintain Dojo 2 apps.
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
-# dojo-cli
+# @dojo/cli
 
-[![Build Status](https://travis-ci.org/dojo/cli.svg?branch=master)](https://travis-ci.org/dojo/cli) [![codecov](https://codecov.io/gh/dojo/cli/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/cli) [![npm version](https://badge.fury.io/js/dojo-cli.svg)](http://badge.fury.io/js/dojo-cli)
+[![Build Status](https://travis-ci.org/dojo/cli.svg?branch=master)](https://travis-ci.org/dojo/cli) [![codecov](https://codecov.io/gh/dojo/cli/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/cli) [![npm version](https://badge.fury.io/js/@dojo/cli.svg)](http://badge.fury.io/js/@dojo/cli)
 
 The CLI is the officially supported way to create and maintain Dojo 2 apps.
 
@@ -16,7 +16,7 @@ Getting the cli
 
 You can install from npm:
 
-`npm i dojo-cli -g`
+`npm i @dojo/cli -g`
 
 In a terminal, run:
 
@@ -29,7 +29,7 @@ dojo help
 
 Usage: dojo <command> [subCommand] [options]
 
-Hey there, here are all the things you can do with dojo-cli:
+Hey there, here are all the things you can do with @dojo/cli:
 ...
 ```
 
@@ -39,7 +39,7 @@ You can list all your global npm dependencies by running:
 
 `npm list -g –depth=0`
 
-If you don't see `dojo-cli` in the list of global dependencies, then please re-install and make sure the installation runs without errors.
+If you don't see `@dojo/cli` in the list of global dependencies, then please re-install and make sure the installation runs without errors.
 
 ## How to use
 
@@ -68,7 +68,7 @@ The CLI has the following in-built groups:
 
 `dojo version` - provides information on the versions of installed commands and the cli itself.
 
-`dojo create app` and `dojo build` are not installed by default with dojo-cli. To use them, you must install them separately, e.g. with `npm i dojo-cli-create-app -g`.
+`dojo create app` and `dojo build` are not installed by default with @dojo/cli. To use them, you must install them separately, e.g. with `npm i @dojo/cli-create-app -g`.
 
 ## How do I contribute?
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -12,9 +12,9 @@ export type CommandsMap = Map<string, CommandWrapper>;
 /**
  * Function to create a loader instance, this allows the config to be injected
  * @param: searchPrefix A string that tells the command loader how cli commands will be named, ie.
- * 	'dojo-cli-' is the default meaning commands could be
- * 		- 'dojo-cli-build-webpack'
- * 		- 'dojo-cli-serve-dist'
+ * 	'@dojo/cli-' is the default meaning commands could be
+ * 		- '@dojo/cli-build-webpack'
+ * 		- '@dojo/cli-serve-dist'
  */
 export function initCommandLoader(searchPrefixes: string[]): (path: string) => CommandWrapper {
 	const commandRegExp = new RegExp(`(${searchPrefixes.join('|')})-(.*)-(.*)`);

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -9,7 +9,7 @@ const pkgDir = require('pkg-dir');
 
 // exported for tests
 export const versionCurrentVersion = `
-You are currently running dojo-cli {version}
+You are currently running @dojo/cli {version}
 `;
 export const versionNoRegisteredCommands = `
 There are no registered commands available.`;

--- a/src/text.ts
+++ b/src/text.ts
@@ -4,7 +4,7 @@ export const helpUsage = `${bold('dojo help')}
 
 Usage: dojo <group> <command> [options]
 
-Hey there, here are all the things you can do with dojo-cli:`;
+Hey there, here are all the things you can do with @dojo/cli:`;
 
 export const helpEpilog = `For more information on any of these commands just run them with '-h'.
 

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -12,7 +12,7 @@ export const proxyUrl = 'http://localhost:9000/';
 export const capabilities = {
 	'browserstack.debug': false,
 	project: 'Dojo 2',
-	name: 'dojo-cli'
+	name: '@dojo/cli'
 };
 
 // Support running unit tests from a web server that isn't the intern proxy
@@ -26,7 +26,7 @@ export const initialBaseUrl: string | null = (function () {
 // The desired AMD loader to use when running unit tests (client.html/client.js). Omit to use the default Dojo
 // loader
 export const loaders = {
-	'host-node': 'dojo-loader'
+	'host-node': '@dojo/loader'
 };
 
 // Configuration options for the module loader; any AMD configuration options supported by the specified AMD loader

--- a/tests/support/MockModule.ts
+++ b/tests/support/MockModule.ts
@@ -1,4 +1,4 @@
-import { RootRequire } from 'dojo-interfaces/loader';
+import { RootRequire } from '@dojo/interfaces/loader';
 declare const require: RootRequire;
 
 import * as mockery from 'mockery';

--- a/tests/unit/commands/version.ts
+++ b/tests/unit/commands/version.ts
@@ -212,7 +212,7 @@ describe('version command', () => {
 		return `\n`;
 	}
 	function outputSuffix() {
-		return `\nYou are currently running dojo-cli 1.0.0\n`;
+		return `\nYou are currently running @dojo/cli 1.0.0\n`;
 	}
 
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue

**Description:**

Update `package.json` and all dependency references to use `@dojo` namespace.

Related to https://github.com/dojo/meta/issues/129