### PR TITLE
Add create app command to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "typings.json"
   ],
   "dependencies": {
+    "@dojo/cli-create-app": "2.0.0-alpha.7",
     "chalk": "^1.1.3",
     "cliui": "^3.2.0",
     "cross-spawn": "^4.0.0",


### PR DESCRIPTION
Add `@dojo/cli-create-app` as a dependency to `@dojo/cli` so it is a default command for consumers.