### PR TITLE
Adding the ability to set exit codes from command rejections

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -65,3 +65,8 @@ export interface Command {
 	group?: string;
 	alias?: Alias[] | Alias;
 }
+
+export interface CommandError {
+	exitCode?: number;
+	message: string;
+}

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -179,6 +179,33 @@ registerSuite({
 				assert.isTrue(consoleErrorStub.calledOnce);
 				assert.isTrue(consoleErrorStub.firstCall.calledWithMatch(errorMessage));
 			}
-		}
+		},
+		'status codes call process exit': (function () {
+			let processExitStub: SinonStub;
+
+			return {
+				'beforeEach'() {
+					processExitStub = stub(process, 'exit');
+				},
+				'afterEach'() {
+					processExitStub.restore();
+				},
+				async 'Should not exit process if no status code is returned'() {
+					defaultRunStub.returns(Promise.reject(new Error(errorMessage)));
+
+					await yargsStub.command.firstCall.args[ 3 ]({ '_': [ 'group' ] });
+					assert.isFalse(processExitStub.called);
+				},
+				async 'Should exit process if status code is returned'() {
+					defaultRunStub.returns(Promise.reject({
+						message: errorMessage,
+						exitCode: 1
+					}));
+
+					await yargsStub.command.firstCall.args[ 3 ]({ '_': [ 'group' ] });
+					assert.isTrue(processExitStub.called);
+				}
+			};
+		})()
 	}
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Commands can now reject with `CommandError`s now instead of regular errors. These are backwards compatible with the current `Error` objects.

```ts
return Promise.reject({
    message: 'Some error message',
    exitCode: 1
});
```

If `exitCode` is returned, and not undefined, the process will be exited with that exit code.

Part of https://github.com/dojo/cli-test-intern/issues/7
