### PR TITLE
Eject hint

### DIFF
--- a/src/commands/eject.ts
+++ b/src/commands/eject.ts
@@ -75,14 +75,16 @@ async function run(helper: Helper, args: EjectArgs): Promise<any> {
 				}, []);
 
 				if (toEject.length) {
+					const allHints: string[] = [];
 					toEject.forEach((command: EjectableCommandWrapper) => {
 						const commandKey = `${command.group}-${command.name}`;
 						console.log(green('\nejecting ') + commandKey);
 
-						const { npm = {}, copy }: EjectOutput = command.eject(helper);
+						const { npm = {}, copy, hints = [] }: EjectOutput = command.eject(helper);
 
 						deepAssign(npmPackages, npm);
 						copy && copyFiles(commandKey, copy);
+						allHints.push(...hints);
 						helper.configuration.save({ [ejectedKey]: true }, commandKey);
 					});
 
@@ -94,6 +96,13 @@ async function run(helper: Helper, args: EjectArgs): Promise<any> {
 					if (Object.keys(npmPackages.devDependencies).length) {
 						console.log(underline('\nrunning npm install devDependencies...'));
 						await installDevDependencies(npmPackages);
+					}
+
+					if (allHints.length > 0) {
+						console.log(underline('\nhints'));
+						allHints.forEach((hint) => {
+							console.log(' ' + hint);
+						});
 					}
 				}
 				else if (args.group && args.command) {

--- a/src/commands/eject.ts
+++ b/src/commands/eject.ts
@@ -80,11 +80,11 @@ async function run(helper: Helper, args: EjectArgs): Promise<any> {
 						const commandKey = `${command.group}-${command.name}`;
 						console.log(green('\nejecting ') + commandKey);
 
-						const { npm = {}, copy, hints = [] }: EjectOutput = command.eject(helper);
+						const { npm = {}, copy, hints }: EjectOutput = command.eject(helper);
 
 						deepAssign(npmPackages, npm);
 						copy && copyFiles(commandKey, copy);
-						allHints.push(...hints);
+						hints && allHints.push(...hints);
 						helper.configuration.save({ [ejectedKey]: true }, commandKey);
 					});
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -51,6 +51,7 @@ export interface FileCopyConfig {
 export interface EjectOutput {
 	npm?: NpmPackage;
 	copy?: FileCopyConfig;
+	hints?: string[];
 }
 
 /**

--- a/tests/support/eject/command-with-full-eject.ts
+++ b/tests/support/eject/command-with-full-eject.ts
@@ -23,6 +23,10 @@ export function eject(helper: any, npm: any, files: any) {
 				'./file1',
 				'./file2'
 			]
-		}
+		},
+		hints: [
+			'hint 1',
+			'hint 2'
+		]
 	};
 }

--- a/tests/support/eject/command-with-hints.ts
+++ b/tests/support/eject/command-with-hints.ts
@@ -23,6 +23,10 @@ export function eject(helper: any, npm: any, files: any) {
 				'./file1',
 				'./file2'
 			]
-		}
+		},
+		hints: [
+			'hint 1',
+			'hint 2'
+		]
 	};
 }

--- a/tests/unit/commands/eject.ts
+++ b/tests/unit/commands/eject.ts
@@ -257,17 +257,17 @@ describe('eject command', () => {
 	describe('eject hints', () => {
 		it('should show hints when supplied', () => {
 			const commandMap: CommandsMap = new Map<string, CommandWrapper>([
-				['apple', loadCommand('/command-with-full-eject')]
+				['apple', loadCommand('/command-with-hints')]
 			]);
 			const helper = getHelper();
 			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({commandsMap: commandMap});
 			return moduleUnderTest.run(helper, {}).then(() => {
 				const logCallCount = consoleLogStub.callCount;
-				assert.isTrue(consoleLogStub.callCount > 3);
+				assert.isTrue(consoleLogStub.callCount > 3, '1');
 				const hintsCall = logCallCount - 3;
-				assert.isTrue(consoleLogStub.getCall(hintsCall).calledWith(underline('hints')));
-				assert.isTrue(consoleLogStub.getCall(hintsCall + 1).calledWith(underline('hint 1')));
-				assert.isTrue(consoleLogStub.getCall(hintsCall + 2).calledWith(underline('hint 2')));
+				assert.isTrue(consoleLogStub.getCall(hintsCall).calledWith(underline('\nhints')), 'should underline hints');
+				assert.isTrue(consoleLogStub.getCall(hintsCall + 1).calledWith(' hint 1'), 'should show hint1');
+				assert.isTrue(consoleLogStub.getCall(hintsCall + 2).calledWith(' hint 2'), 'should show hint2');
 			});
 		});
 	});

--- a/tests/unit/commands/eject.ts
+++ b/tests/unit/commands/eject.ts
@@ -2,7 +2,7 @@ import { beforeEach, afterEach, describe, it } from 'intern!bdd';
 import * as assert from 'intern/chai!assert';
 import MockModule from '../../support/MockModule';
 import * as sinon from 'sinon';
-import { yellow } from 'chalk';
+import { yellow, underline } from 'chalk';
 require('sinon-as-promised')(Promise);
 
 import { join, resolve as pathResolve } from 'path';
@@ -250,6 +250,24 @@ describe('eject command', () => {
 			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({commandsMap: commandMap});
 			return moduleUnderTest.run(helper, {}).then(() => {
 				assert.isTrue(mockFsExtra.copySync.notCalled);
+			});
+		});
+	});
+
+	describe('eject hints', () => {
+		it('should show hints when supplied', () => {
+			const commandMap: CommandsMap = new Map<string, CommandWrapper>([
+				['apple', loadCommand('/command-with-full-eject')]
+			]);
+			const helper = getHelper();
+			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({commandsMap: commandMap});
+			return moduleUnderTest.run(helper, {}).then(() => {
+				const logCallCount = consoleLogStub.callCount;
+				assert.isTrue(consoleLogStub.callCount > 3);
+				const hintsCall = logCallCount - 3;
+				assert.isTrue(consoleLogStub.getCall(hintsCall).calledWith(underline('hints')));
+				assert.isTrue(consoleLogStub.getCall(hintsCall + 1).calledWith(underline('hint 1')));
+				assert.isTrue(consoleLogStub.getCall(hintsCall + 2).calledWith(underline('hint 2')));
 			});
 		});
 	});


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Allows eject commands to supply `hints` to be displayed after eject is complete.

![screenshot 2017-03-08 15 50 17](https://cloud.githubusercontent.com/assets/814453/23711170/fe7713a0-0416-11e7-86bd-1a4db5962da8.png)

Resolves #118 
