### PR TITLE
Restricting configuration helpers to only working for a single command.

### DIFF
--- a/src/Helper.ts
+++ b/src/Helper.ts
@@ -1,5 +1,5 @@
-import { CommandHelper, Helper, ConfigurationHelper } from './interfaces';
 import { Yargs } from 'yargs';
+import { CommandHelper, Helper as HelperInterface, ConfigurationHelper } from './interfaces';
 
 /**
  * The Helper that is passed to each command's 'run' function. Provides
@@ -7,7 +7,7 @@ import { Yargs } from 'yargs';
  * a CommandHelper that allows tasks to 'run' and check the existance of
  * other tasks.
  */
-export default class implements Helper {
+class Helper implements HelperInterface {
 	constructor(commandHelper: CommandHelper, yargs: Yargs, context: any, configuration: ConfigurationHelper) {
 		this.command = commandHelper;
 		this.yargs = yargs;
@@ -18,4 +18,15 @@ export default class implements Helper {
 	yargs: Yargs;
 	context: any;
 	configuration: ConfigurationHelper;
+
+	sandbox(groupName: string, commandName?: string): HelperInterface {
+		return new Helper(
+			this.command,
+			this.yargs,
+			this.context,
+			this.configuration.sandbox(groupName, commandName)
+		);
+	}
 }
+
+export default Helper;

--- a/src/Helper.ts
+++ b/src/Helper.ts
@@ -1,5 +1,6 @@
 import { Yargs } from 'yargs';
-import { CommandHelper, Helper as HelperInterface, ConfigurationHelper } from './interfaces';
+import { ConfigurationHelperFactory } from './configurationHelper';
+import { CommandHelper, Helper } from './interfaces';
 
 /**
  * The Helper that is passed to each command's 'run' function. Provides
@@ -7,26 +8,26 @@ import { CommandHelper, Helper as HelperInterface, ConfigurationHelper } from '.
  * a CommandHelper that allows tasks to 'run' and check the existance of
  * other tasks.
  */
-class Helper implements HelperInterface {
-	constructor(commandHelper: CommandHelper, yargs: Yargs, context: any, configuration: ConfigurationHelper) {
+export class HelperFactory {
+	constructor(commandHelper: CommandHelper, yargs: Yargs, context: any, configurationFactory: ConfigurationHelperFactory) {
 		this.command = commandHelper;
 		this.yargs = yargs;
 		this.context = context;
-		this.configuration = configuration;
+		this.configurationFactory = configurationFactory;
 	};
 	command: CommandHelper;
 	yargs: Yargs;
 	context: any;
-	configuration: ConfigurationHelper;
+	configurationFactory: ConfigurationHelperFactory;
 
-	sandbox(groupName: string, commandName?: string): HelperInterface {
-		return new Helper(
-			this.command,
-			this.yargs,
-			this.context,
-			this.configuration.sandbox(groupName, commandName)
-		);
+	sandbox(groupName: string, commandName?: string): Helper {
+		return {
+			command: this.command,
+			yargs: this.yargs,
+			context: this.context,
+			configuration: this.configurationFactory.sandbox(groupName, commandName)
+		};
 	}
 }
 
-export default Helper;
+export default HelperFactory;

--- a/src/commands/eject.ts
+++ b/src/commands/eject.ts
@@ -8,6 +8,7 @@ import { CommandWrapper } from '../command';
 import { loadExternalCommands } from '../allCommands';
 import { deepAssign } from '@dojo/core/lang';
 import { installDependencies, installDevDependencies } from '../npmInstall';
+import configurationHelper from '../configurationHelper';
 
 const copiedFilesDir = 'config';
 const ejectedKey = 'ejected';
@@ -66,7 +67,7 @@ async function run(helper: Helper, args: EjectArgs): Promise<any> {
 						deepAssign(npmPackages, npm);
 						copy && copyFiles(commandKey, copy);
 						hints && allHints.push(...hints);
-						helper.configuration.save({ [ejectedKey]: true }, commandKey);
+						configurationHelper.sandbox(command.group, command.name).set({ [ejectedKey]: true });
 					});
 
 					if (Object.keys(npmPackages.dependencies).length) {

--- a/src/configurationHelper.ts
+++ b/src/configurationHelper.ts
@@ -33,9 +33,17 @@ class SingleCommandConfigurationHelper implements ConfigurationHelper {
 	/**
 	 * Retrieves the configurationFactory object from the file system
 	 *
-	 * @returns Promise - an object representation of .dojorc
+	 * @returns an object representation of .dojorc
 	 */
-	get(): Config {
+	get(): Config;
+	/**
+	 * Retrieves the configurationFactory object from the file system
+	 *
+	 * @param commandName - the command name that's accessing config
+	 * @returns an object representation of .dojorc
+	 */
+	get(commandName: string): Config;
+	get(commandName?: string): Config {
 		const config = getConfigFile();
 		return config[this._configurationKey] || {};
 	}
@@ -44,9 +52,18 @@ class SingleCommandConfigurationHelper implements ConfigurationHelper {
 	 * persists configurationFactory data to .dojorc
 	 *
 	 * @param config - the configurationFactory to save
+	 */
+	set(config: Config): void;
+	/**
+	 * @deprecated
+	 *
+	 * persists configurationFactory data to .dojorc
+	 *
+	 * @param config - the configurationFactory to save
 	 * @param commandName - the command name that's accessing config
 	 */
-	set(config: Config): void {
+	set(config: Config, commandName: string): void;
+	set(config: Config, commandName?: string): void {
 		if (!dojoRcPath) {
 			console.warn(red('You cannot save a config outside of a project directory'));
 			return;

--- a/src/configurationHelper.ts
+++ b/src/configurationHelper.ts
@@ -1,7 +1,7 @@
+import { red } from 'chalk';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { ConfigurationHelper, Config } from './interfaces';
-import { red } from 'chalk';
 const pkgDir = require('pkg-dir');
 
 const appPath = pkgDir.sync(process.cwd());
@@ -38,7 +38,29 @@ export function save(config: Config, commandName: string): void {
 	Object.assign(dojoRc, { [commandName]: commmandConfig});
 
 	writeConfigFile(dojoRc);
-};
+}
+
+export function sandbox(groupName: string, commandName?: string): ConfigurationHelper {
+	let key = `${groupName}`;
+
+	if (commandName) {
+		key += `-${commandName}`;
+	}
+
+	return {
+		save(config: Config) {
+			return save(config, key);
+		},
+
+		get(commandName) {
+			return get(key);
+		},
+
+		sandbox(groupName: string, commandName: string): ConfigurationHelper {
+			throw new Error(`This helper is already sandboxed for ${commandName}`);
+		}
+	};
+}
 
 /**
  * Retrieves the configuration object from the file system
@@ -52,7 +74,8 @@ export function get(commandName: string): Config {
 
 const configHelper: ConfigurationHelper = {
 	get,
-	save
+	save,
+	sandbox
 };
 
 export default configHelper;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,9 +5,8 @@ export interface Config {
 }
 
 export interface ConfigurationHelper {
-	save(config: Config, commandName: string): void;
-	get(commandName: string): {};
-	sandbox(groupName: string, commandName?: string): ConfigurationHelper;
+	set(config: Config): void;
+	get(): {};
 }
 
 export interface CommandHelper {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,6 +7,7 @@ export interface Config {
 export interface ConfigurationHelper {
 	save(config: Config, commandName: string): void;
 	get(commandName: string): {};
+	sandbox(groupName: string, commandName?: string): ConfigurationHelper;
 }
 
 export interface CommandHelper {

--- a/src/loadCommands.ts
+++ b/src/loadCommands.ts
@@ -1,8 +1,8 @@
-import { Config } from './config';
-import { CommandsMap, CommandWrapper } from './command';
 import * as globby from 'globby';
 import { resolve as pathResolve, join } from 'path';
-import { get as getConfig } from './configurationHelper';
+import { CommandsMap, CommandWrapper } from './command';
+import { Config } from './config';
+import configurationHelper from './configurationHelper';
 
 export type YargsCommandNames = Map<string, Set<string>>;
 
@@ -15,8 +15,8 @@ function setDefaultGroup(commandsMap: CommandsMap, commandName: string, commandW
 	commandsMap.set(commandName, commandWrapper);
 }
 
-function isEjected(command: string): boolean {
-	const config = getConfig(command);
+function isEjected(groupName: string, command: string): boolean {
+	const config: any = configurationHelper.sandbox(groupName, command).get();
 	return config && config['ejected'];
 }
 
@@ -68,7 +68,7 @@ export async function loadCommands(paths: string[], load: (path: string) => Comm
 				const {group, name} = commandWrapper;
 				const compositeKey = `${group}-${name}`;
 
-				if (!isEjected(compositeKey)) {
+				if (!isEjected(group, compositeKey)) {
 					if (!commandsMap.has(group)) {
 						// First of each type will be 'default' for now
 						setDefaultGroup(commandsMap, group, commandWrapper);

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -2,8 +2,8 @@ import * as chalk from 'chalk';
 import { Yargs, Argv, Options } from 'yargs';
 import { getGroupDescription, CommandsMap, CommandWrapper } from './command';
 import CommandHelper from './CommandHelper';
-import configurationHelper from './configurationHelper';
-import Helper from './Helper';
+import configurationHelperFactory from './configurationHelper';
+import HelperFactory from './Helper';
 import { CommandError } from './interfaces';
 import { YargsCommandNames } from './loadCommands';
 import { helpUsage, helpEpilog } from './text';
@@ -38,7 +38,7 @@ function reportError(error: CommandError) {
  * @param commandOptions The set of commandOption keys
  * @param commandsMap The map of composite keys to commands
  */
-function registerGroups(yargs: Yargs, helper: Helper, groupName: string, commandOptions: Set<string>, commandsMap: CommandsMap): void {
+function registerGroups(yargs: Yargs, helper: HelperFactory, groupName: string, commandOptions: Set<string>, commandsMap: CommandsMap): void {
 	const groupDescription = getGroupDescription(commandOptions, commandsMap);
 	const defaultCommand = <CommandWrapper> commandsMap.get(groupName);
 	const defaultCommandAvailable = !!(defaultCommand && defaultCommand.register && defaultCommand.run);
@@ -60,7 +60,7 @@ function registerGroups(yargs: Yargs, helper: Helper, groupName: string, command
 		// so we call default command, else, the subcommand will
 		// have been ran and we don't want to run the default.
 		if (defaultCommandAvailable && argv._.length === 1) {
-			return defaultCommand.run(helper, argv).catch(reportError);
+			return defaultCommand.run(helper.sandbox(groupName), argv).catch(reportError);
 		}
 	});
 }
@@ -74,7 +74,7 @@ function registerGroups(yargs: Yargs, helper: Helper, groupName: string, command
  * @param commandOptions The set of commandOption keys
  * @param commandsMap The map of composite keys to commands
  */
-function registerCommands(yargs: Yargs, helper: Helper, groupName: string, commandOptions: Set<string>, commandsMap: CommandsMap): void {
+function registerCommands(yargs: Yargs, helper: HelperFactory, groupName: string, commandOptions: Set<string>, commandsMap: CommandsMap): void {
 	[...commandOptions].filter((command: string) => {
 		return `${groupName}-` !== command;
 	}).forEach((command: string) => {
@@ -89,7 +89,7 @@ function registerCommands(yargs: Yargs, helper: Helper, groupName: string, comma
 				return optionsYargs;
 			},
 			(argv: Argv) => {
-				return run(helper, argv).catch(reportError);
+				return run(helper.sandbox(groupName, command), argv).catch(reportError);
 			}
 		)
 		.strict();
@@ -104,9 +104,9 @@ function registerCommands(yargs: Yargs, helper: Helper, groupName: string, comma
  * @param commandOptions The set of commandOption keys
  * @param commandsMap The map of composite keys to commands
  */
-function registerAliases(yargs: Yargs, helper: Helper, commandOptions: Set<string>, commandsMap: CommandsMap): void {
+function registerAliases(yargs: Yargs, helper: HelperFactory, commandOptions: Set<string>, commandsMap: CommandsMap): void {
 	[...commandOptions].forEach((command: string) => {
-		const {run, register, alias: aliases} = <CommandWrapper> commandsMap.get(command);
+		const { run, register, alias: aliases, group } = <CommandWrapper> commandsMap.get(command);
 		if (aliases) {
 			(Array.isArray(aliases) ? aliases : [aliases]).forEach((alias) => {
 				const { name, description, options: aliasOpts } = alias;
@@ -118,7 +118,7 @@ function registerAliases(yargs: Yargs, helper: Helper, commandOptions: Set<strin
 							if (!aliasOpts || !aliasOpts.some((option) => option.option === key)) {
 								aliasYargs.option(key, options);
 							}
-						}, helper);
+						}, helper.sandbox(group, command));
 						return aliasYargs;
 					},
 					(argv: Argv) => {
@@ -130,7 +130,7 @@ function registerAliases(yargs: Yargs, helper: Helper, commandOptions: Set<strin
 								};
 							}, argv);
 						}
-						return run(helper, argv).catch(reportError);
+						return run(helper.sandbox(group, command), argv).catch(reportError);
 					});
 			});
 		}
@@ -149,11 +149,12 @@ function registerAliases(yargs: Yargs, helper: Helper, commandOptions: Set<strin
 export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandNames: YargsCommandNames): void {
 	const helperContext = {};
 
-	const commandHelper = new CommandHelper(commandsMap, helperContext);
-	const helper = new Helper(commandHelper, yargs, helperContext, configurationHelper);
+	const commandHelper = new CommandHelper(commandsMap, helperContext, configurationHelperFactory);
+	const helperFactory = new HelperFactory(commandHelper, yargs, helperContext, configurationHelperFactory);
+
 	yargsCommandNames.forEach((commandOptions, commandName) => {
-		registerGroups(yargs, helper, commandName, commandOptions, commandsMap);
-		registerAliases(yargs, helper, commandOptions, commandsMap);
+		registerGroups(yargs, helperFactory, commandName, commandOptions, commandsMap);
+		registerAliases(yargs, helperFactory, commandOptions, commandsMap);
 	});
 
 	yargs.demand(1, '')

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -49,7 +49,7 @@ function registerGroups(yargs: Yargs, helper: Helper, groupName: string, command
 					group: `Default Command Options ('${defaultCommand.name}')`,
 					...options
 				});
-			}, helper);
+			}, helper.sandbox(groupName));
 		}
 		registerCommands(subYargs, helper, groupName, commandOptions, commandsMap);
 		return subYargs;
@@ -85,7 +85,7 @@ function registerCommands(yargs: Yargs, helper: Helper, groupName: string, comma
 			(optionsYargs: Yargs) => {
 				register((key: string, options: Options) => {
 					optionsYargs.option(key, options);
-				}, helper);
+				}, helper.sandbox(groupName, command));
 				return optionsYargs;
 			},
 			(argv: Argv) => {

--- a/tests/unit/CommandHelper.ts
+++ b/tests/unit/CommandHelper.ts
@@ -1,6 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { getCommandsMap, GroupDef } from '../support/testHelper';
+import configurationHelperFactory from '../../src/configurationHelper';
 const commandHelperCtor = require('intern/dojo/node!../../src/CommandHelper').default;
 
 const groupDef: GroupDef = [
@@ -26,11 +27,11 @@ registerSuite({
 	name: 'CommandHelper',
 	'beforeEach'() {
 		commandsMap = getCommandsMap(groupDef);
-		commandHelper = new commandHelperCtor(commandsMap, context);
+		commandHelper = new commandHelperCtor(commandsMap, context, configurationHelperFactory);
 	},
 	'Should set commandsMap and context'() {
-		assert.strictEqual(commandsMap, commandHelper.commandsMap);
-		assert.strictEqual(context, commandHelper.context);
+		assert.strictEqual(commandsMap, commandHelper._commandsMap);
+		assert.strictEqual(context, commandHelper._context);
 	},
 	'Should return exists = true when a queried command exists'() {
 		assert.isTrue(commandHelper.exists('group1', 'command1'));

--- a/tests/unit/configurationHelper.ts
+++ b/tests/unit/configurationHelper.ts
@@ -84,6 +84,15 @@ registerSuite({
 			const config = configurationHelper.sandbox('testGroupName', 'testCommandName').get();
 			assert.isTrue(mockFs.readFileSync.calledOnce);
 			assert.deepEqual(config, existingConfig);
+		},
+		'Should accept and ignore commandName parameter'() {
+			const newConfig = { foo: 'bar' };
+			mockFs.readFileSync = sinon.stub().returns(JSON.stringify({ 'testGroupName-testCommandName': {} }));
+			configurationHelper.sandbox('testGroupName', 'testCommandName').set(newConfig, 'invalid name');
+
+			assert.isTrue(mockFs.writeFileSync.calledOnce);
+			assert.equal(mockFs.writeFileSync.firstCall.args[0], dojoRcPath);
+			assert.equal(mockFs.writeFileSync.firstCall.args[1], JSON.stringify({ 'testGroupName-testCommandName': newConfig }, null, 2));
 		}
 	},
 	'package dir does not exist': {

--- a/tests/unit/configurationHelper.ts
+++ b/tests/unit/configurationHelper.ts
@@ -1,7 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import MockModule from '../support/MockModule';
 import { join, resolve as pathResolve } from 'path';
+import MockModule from '../support/MockModule';
 const sap = require('sinon-as-promised');
 const sinon = new sap(Promise);
 
@@ -46,41 +46,42 @@ registerSuite({
 		},
 		'Should write new config to file when save called'() {
 			const newConfig = { foo: 'bar' };
-			mockFs.readFileSync = sinon.stub().returns(JSON.stringify({ testCommandName: {} }));
-			configurationHelper.save(newConfig, 'testCommandName');
+			mockFs.readFileSync = sinon.stub().returns(JSON.stringify({ 'testGroupName-testCommandName': {} }));
+			configurationHelper.sandbox('testGroupName', 'testCommandName').set(newConfig);
+
 			assert.isTrue(mockFs.writeFileSync.calledOnce);
 			assert.equal(mockFs.writeFileSync.firstCall.args[0], dojoRcPath);
-			assert.equal(mockFs.writeFileSync.firstCall.args[1], JSON.stringify({ testCommandName: newConfig }, null, 2));
+			assert.equal(mockFs.writeFileSync.firstCall.args[1], JSON.stringify({ 'testGroupName-testCommandName': newConfig }, null, 2));
 		},
 		'Should merge new config with old when save called'() {
 			const newConfig = { foo: 'bar' };
 			const existingConfig = { existing: 'config' };
-			mockFs.readFileSync.returns(JSON.stringify({ testCommandName: existingConfig }));
-			configurationHelper.save(newConfig, 'testCommandName');
+			mockFs.readFileSync.returns(JSON.stringify({ 'testGroupName-testCommandName': existingConfig }));
+			configurationHelper.sandbox('testGroupName', 'testCommandName').set(newConfig);
 			assert.isTrue(mockFs.writeFileSync.calledOnce);
-			assert.equal(mockFs.writeFileSync.firstCall.args[1], JSON.stringify({ testCommandName: Object.assign(existingConfig, newConfig) }, null, 2));
+			assert.equal(mockFs.writeFileSync.firstCall.args[1], JSON.stringify({ 'testGroupName-testCommandName': Object.assign(existingConfig, newConfig) }, null, 2));
 		},
 		'Should merge new commandNames with existing command config when save called'() {
 			const newConfig = { foo: 'bar' };
 			const existingConfig = { existing: 'config' };
 			mockFs.readFileSync.returns(JSON.stringify({ existingCommandName: existingConfig }));
-			configurationHelper.save(newConfig, 'testCommandName');
+			configurationHelper.sandbox('testGroupName', 'testCommandName').set(newConfig);
 			assert.isTrue(mockFs.writeFileSync.calledOnce);
 			assert.deepEqual(mockFs.writeFileSync.firstCall.args[1], JSON.stringify({
 				existingCommandName: existingConfig,
-				testCommandName: newConfig
+				'testGroupName-testCommandName': newConfig
 			}, null, 2));
 		},
 		'Should return undefined config when no dojorc for commandName exists'() {
 			mockFs.existsSync.returns(false);
-			const config = configurationHelper.get('testCommandName');
+			const config = configurationHelper.sandbox('testGroupName', 'testCommandName').get();
 			assert.isTrue(mockFs.readFileSync.notCalled);
 			assert.deepEqual(config, {});
 		},
 		'Should return existing config when a dojorc entry exists'() {
 			const existingConfig = { existing: 'config' };
-			mockFs.readFileSync.returns(JSON.stringify({ testCommandName: existingConfig }));
-			const config = configurationHelper.get('testCommandName');
+			mockFs.readFileSync.returns(JSON.stringify({ 'testGroupName-testCommandName': existingConfig }));
+			const config = configurationHelper.sandbox('testGroupName', 'testCommandName').get();
 			assert.isTrue(mockFs.readFileSync.calledOnce);
 			assert.deepEqual(config, existingConfig);
 		}
@@ -110,13 +111,13 @@ registerSuite({
 			mockModule.destroy();
 		},
 		'Should return empty object when pkgdir returns null'() {
-			const config = configurationHelper.get('testCommandName');
+			const config = configurationHelper.sandbox('testGroupName', 'testCommandName').get();
 			assert.isFalse(mockFs.readFileSync.called);
 			assert.isFalse(mockPath.join.called);
 			assert.deepEqual(config, {});
 		},
 		'Should warn user when config save called outside of a pkgdir'() {
-			configurationHelper.save({}, 'testCommandName');
+			configurationHelper.sandbox('testGroupName', 'testCommandName').set({});
 			assert.isFalse(mockFs.writeFileSync.called);
 			assert.isTrue(consoleWarnStub.calledOnce);
 		}

--- a/tests/unit/loadCommands.ts
+++ b/tests/unit/loadCommands.ts
@@ -18,7 +18,6 @@ let goodConfig: Config;
 let mockModule: MockModule;
 let mockedLoadCommands: any;
 let testSandbox: any;
-let oldSandbox: any;
 
 function config(invalid = false): Config {
 	// tests are run in package-dir (from cli, using grunt test) - FIX to use pkg-dir
@@ -135,14 +134,12 @@ registerSuite({
 				'./configurationHelper'
 			]);
 			const configHelper = mockModule.getMock('./configurationHelper').default;
-			oldSandbox = configHelper.sandbox;
-			configHelper.sandbox = testSandbox.stub().returns({
-				get: testSandbox.stub().returns({ ejected: true })
+			testSandbox.stub(configHelper, 'sandbox', () => {
+				return { get: testSandbox.stub().returns({ ejected: true }) };
 			});
 			mockedLoadCommands = mockModule.getModuleUnderTest().loadCommands;
 		},
 		afterEach() {
-			mockModule.getMock('./configurationHelper').default.sandbox = oldSandbox;
 			mockModule.destroy();
 			testSandbox.restore();
 		},

--- a/tests/unit/loadCommands.ts
+++ b/tests/unit/loadCommands.ts
@@ -1,10 +1,10 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import { stub, SinonStub, sandbox } from 'sinon';
-import { getCommandWrapper, getYargsStub } from '../support/testHelper';
 import { join, resolve as pathResolve } from 'path';
+import { stub, SinonStub, sandbox } from 'sinon';
 import { Config } from '../../src/config';
 import MockModule from '../support/MockModule';
+import { getCommandWrapper, getYargsStub } from '../support/testHelper';
 const enumBuiltInCommands = require('intern/dojo/node!../../src/loadCommands').enumerateBuiltInCommands;
 const enumInstalledCommands = require('intern/dojo/node!../../src/loadCommands').enumerateInstalledCommands;
 const loadCommands = require('intern/dojo/node!../../src/loadCommands').loadCommands;
@@ -18,6 +18,7 @@ let goodConfig: Config;
 let mockModule: MockModule;
 let mockedLoadCommands: any;
 let testSandbox: any;
+let oldSandbox: any;
 
 function config(invalid = false): Config {
 	// tests are run in package-dir (from cli, using grunt test) - FIX to use pkg-dir
@@ -133,11 +134,15 @@ registerSuite({
 			mockModule.dependencies([
 				'./configurationHelper'
 			]);
-			const configHelper = mockModule.getMock('./configurationHelper');
-			configHelper.get = testSandbox.stub().returns({ ejected: true });
+			const configHelper = mockModule.getMock('./configurationHelper').default;
+			oldSandbox = configHelper.sandbox;
+			configHelper.sandbox = testSandbox.stub().returns({
+				get: testSandbox.stub().returns({ ejected: true })
+			});
 			mockedLoadCommands = mockModule.getModuleUnderTest().loadCommands;
 		},
 		afterEach() {
+			mockModule.getMock('./configurationHelper').default.sandbox = oldSandbox;
 			mockModule.destroy();
 			testSandbox.restore();
 		},


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Modifies the configuration helper to not allow it to be called with a command name. It is now _always_ called with the group and command of the command being run.

I'm not really convinced on this, as it seems to me that it was a lot of code to change for one simple task, but I think I like the direction it's going. 

Please give me your feedback!

Resolves #128 
