### PR TITLE
Parse dashed command names properly

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -17,7 +17,7 @@ export type CommandsMap = Map<string, CommandWrapper>;
  * 		- '@dojo/cli-serve-dist'
  */
 export function initCommandLoader(searchPrefixes: string[]): (path: string) => CommandWrapper {
-	const commandRegExp = new RegExp(`(${searchPrefixes.join('|').replace('\/', '\\/')})-(.*)-(.*)`);
+	const commandRegExp = new RegExp(`(?:${searchPrefixes.join('|').replace('\/', '\\/')})-([^-]+)-(.+)$`);
 
 	return function load(path: string): CommandWrapper {
 		let module = require(path);
@@ -26,7 +26,7 @@ export function initCommandLoader(searchPrefixes: string[]): (path: string) => C
 			const command = convertModuleToCommand(module);
 			const { description, register, run, alias, eject } = command;
 			//  derive the group and name from the module directory name, e.g. dojo-cli-group-name
-			const [ , , group, name] = <string[]> commandRegExp.exec(path);
+			const [ , group, name] = <string[]> commandRegExp.exec(path);
 
 			return {
 				name,

--- a/tests/support/dash-names-foo-bar-baz.ts
+++ b/tests/support/dash-names-foo-bar-baz.ts
@@ -1,0 +1,7 @@
+export const description = 'test-description';
+export function register() {
+	return 'registered';
+};
+export function	run() {
+	return new Promise((resolve) => 'ran');
+}

--- a/tests/support/dash-names-foo-bar-baz.ts
+++ b/tests/support/dash-names-foo-bar-baz.ts
@@ -2,6 +2,6 @@ export const description = 'test-description';
 export function register() {
 	return 'registered';
 };
-export function	run() {
+export function run() {
 	return new Promise((resolve) => 'ran');
 }

--- a/tests/unit/command.ts
+++ b/tests/unit/command.ts
@@ -1,7 +1,9 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { getCommandsMap, GroupDef } from '../support/testHelper';
-const command = require('intern/dojo/node!../../src/command');
+import * as UnitUnderTest from '../../src/command';
+
+const command: typeof UnitUnderTest = require('intern/dojo/node!../../src/command');
 const expectedCommand = require('intern/dojo/node!../support/test-prefix-foo-bar');
 const expectedBuiltInCommand = require('intern/dojo/node!../support/commands/test-prefix-foo-bar');
 const expectedEsModuleCommand = require('intern/dojo/node!../support/esmodule-prefix-foo-bar').default;
@@ -11,6 +13,7 @@ const testName = 'bar';
 const testSearchPrefixes = [ 'test-prefix' ];
 const testEsModuleSearchPrefixes = [ 'esmodule-prefix' ];
 const testEsModuleFailSearchPrefixes = [ 'esmodule-fail' ];
+const testSearchPrefixesDashedNames = [ 'dash-names' ];
 let commandWrapper: any;
 const groupDef: GroupDef = [
 	{
@@ -120,6 +123,16 @@ registerSuite({
 				assert.isTrue(error instanceof Error);
 				assert.isTrue(error.message.indexOf('does not satisfy the Command interface') > -1);
 			}
+		}
+	},
+	'load of commands parsed correctly': {
+		'setup'() {
+			loader = command.initCommandLoader(testSearchPrefixesDashedNames);
+			commandWrapper = loader('../tests/support/dash-names-foo-bar-baz');
+		},
+		'Should parse group names correctly'() {
+			assert.equal('foo', commandWrapper.group);
+			assert.equal('bar-baz', commandWrapper.name);
 		}
 	},
 	'getGroupDescription': {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR fixes issues when a command has a dash in it's name.  Commands like `cli-foo-bar-baz` will be parsed as a group of `foo` and a name of `bar-baz`.  Previously, these were being parsed as `foo-bar` and `baz`.

This will mean that group names cannot be dashed.

Resolves #142
