### PR TITLE
Fix: correctly load .dojorc commands

### DIFF
--- a/src/CommandHelper.ts
+++ b/src/CommandHelper.ts
@@ -28,7 +28,7 @@ export class SingleCommandHelper implements CommandHelper {
 		const command = getCommand(this._commandsMap, group, commandName);
 		if (command) {
 			const helper = new HelperFactory(this, yargs, this._context, this._configurationFactory);
-			return command.run(helper.sandbox(group, commandName), args);
+			return command.run(helper.sandbox(group, command.name), args);
 		}
 		else {
 			return Promise.reject(new Error('The command does not exist'));

--- a/src/loadCommands.ts
+++ b/src/loadCommands.ts
@@ -68,7 +68,7 @@ export async function loadCommands(paths: string[], load: (path: string) => Comm
 				const {group, name} = commandWrapper;
 				const compositeKey = `${group}-${name}`;
 
-				if (!isEjected(group, compositeKey)) {
+				if (!isEjected(group, name)) {
 					if (!commandsMap.has(group)) {
 						// First of each type will be 'default' for now
 						setDefaultGroup(commandsMap, group, commandWrapper);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Updates the cli helper to take a simplified command name (e.g., "webpack" or "intern") instead of a composite of the group and command (e.g., "build-webpack" or "test-intern"), so that when looking up data from a `.dojorc`, the correct key is used (e.g., "build-webpack" instead of just "build" or "build-build-webpack").

Verified with `@dojo/examples/todo-mvc-kitchensink`, using both the `$ dojo build` and `$ dojo test` cli commands. Note that `@dojo/cli-test-intern` currently does not ask for `.dojorc` data, but a quick change to the local source confirmed that these changes will work whenever that update is made.

Resolves #148 