### PR TITLE
Update to TypeScript 2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,6 @@
     "remap-istanbul": "^0.6.4",
     "sinon": "^1.17.5",
     "sinon-as-promised": "^4.0.2",
-    "typescript": "~2.3.2"
+    "typescript": "~2.4.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,13 @@
 {
-	"version": "2.1.5",
 	"compilerOptions": {
 		"declaration": false,
 		"module": "umd",
-		"noImplicitAny": true,
-		"noImplicitThis": true,
-		"strictNullChecks": true,
+		"moduleResolution": "node",
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,
-		"target": "es6",
-		"moduleResolution": "node"
+		"strict": true,
+		"target": "es2017"
 	},
 	"include": [
 		"./typings/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
 		"removeComments": false,
 		"sourceMap": true,
 		"strict": true,
-		"target": "es2017"
+		"target": "es2016"
 	},
 	"include": [
 		"./typings/index.d.ts",


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR updates to TypeScript 2.4, migrates to `--strict` and does a bit of `tsconfig.conf` cleanup.

Refs: dojo/meta#189
