### PR TITLE
Adding ability to specify commands at the command line, issue #125

### DIFF
--- a/src/allCommands.ts
+++ b/src/allCommands.ts
@@ -39,7 +39,7 @@ export async function loadBuiltInCommands(): Promise<LoadedCommands> {
 
 export async function loadExplicitCommands(): Promise<LoadedCommands> {
 	const explicitCommandLoader = initExplicitCommandLoader();
-	const explicitCommandPaths = await enumerateExplicitCommands(config);
+	const explicitCommandPaths = enumerateExplicitCommands(config);
 	return await loadCommands(explicitCommandPaths, explicitCommandLoader);
 }
 

--- a/src/allCommands.ts
+++ b/src/allCommands.ts
@@ -2,11 +2,13 @@ import {
 	loadCommands,
 	enumerateInstalledCommands,
 	enumerateBuiltInCommands,
+	enumerateExplicitCommands,
 	LoadedCommands
 } from './loadCommands';
 import {
 	initCommandLoader,
-	createBuiltInCommandLoader }
+	createBuiltInCommandLoader, initExplicitCommandLoader
+}
 	from './command';
 import config from './config';
 
@@ -35,6 +37,12 @@ export async function loadBuiltInCommands(): Promise<LoadedCommands> {
 	return await loadCommands(builtInCommandsPaths, builtInCommandLoader);
 }
 
+export async function loadExplicitCommands(): Promise<LoadedCommands> {
+	const explicitCommandLoader = initExplicitCommandLoader();
+	const explicitCommandPaths = await enumerateExplicitCommands(config);
+	return await loadCommands(explicitCommandPaths, explicitCommandLoader);
+}
+
 export default async function loadAllCommands(): Promise<LoadedCommands> {
 	if (loaded) {
 		return Promise.resolve(commands);
@@ -42,9 +50,10 @@ export default async function loadAllCommands(): Promise<LoadedCommands> {
 
 	const builtInCommands = await loadBuiltInCommands();
 	const installedCommands = await loadExternalCommands();
+	const explicitCommands = await loadExplicitCommands();
 
-	commands.commandsMap = new Map([...installedCommands.commandsMap, ...builtInCommands.commandsMap]);
-	commands.yargsCommandNames = new Map([...installedCommands.yargsCommandNames, ...builtInCommands.yargsCommandNames]);
+	commands.commandsMap = new Map([...installedCommands.commandsMap, ...builtInCommands.commandsMap, ...explicitCommands.commandsMap]);
+	commands.yargsCommandNames = new Map([...installedCommands.yargsCommandNames, ...builtInCommands.yargsCommandNames, ...explicitCommands.yargsCommandNames]);
 	loaded = true;
 	return Promise.resolve(commands);
 }

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,4 +1,5 @@
-import { Command } from './interfaces';
+import {Command} from './interfaces';
+
 const cliui = require('cliui');
 
 export interface CommandWrapper extends Command {
@@ -12,9 +13,9 @@ export type CommandsMap = Map<string, CommandWrapper>;
 /**
  * Function to create a loader instance, this allows the config to be injected
  * @param: searchPrefix A string that tells the command loader how cli commands will be named, ie.
- * 	'@dojo/cli-' is the default meaning commands could be
- * 		- '@dojo/cli-build-webpack'
- * 		- '@dojo/cli-serve-dist'
+ *    '@dojo/cli-' is the default meaning commands could be
+ *        - '@dojo/cli-build-webpack'
+ *        - '@dojo/cli-serve-dist'
  */
 export function initCommandLoader(searchPrefixes: string[]): (path: string) => CommandWrapper {
 	const commandRegExp = new RegExp(`(?:${searchPrefixes.join('|').replace('\/', '\\/')})-([^-]+)-(.+)$`);
@@ -24,9 +25,47 @@ export function initCommandLoader(searchPrefixes: string[]): (path: string) => C
 
 		try {
 			const command = convertModuleToCommand(module);
-			const { description, register, run, alias, eject } = command;
+			const {description, register, run, alias, eject} = command;
 			//  derive the group and name from the module directory name, e.g. dojo-cli-group-name
-			const [ , group, name] = <string[]> commandRegExp.exec(path);
+			const [, group, name] = <string[]> commandRegExp.exec(path);
+
+			return {
+				name,
+				group,
+				alias,
+				description,
+				register,
+				run,
+				path,
+				eject
+			};
+		} catch (err) {
+			throw new Error(`Path: ${path} returned module that does not satisfy the Command interface. ${err}`);
+		}
+	};
+}
+
+export function initExplicitCommandLoader(): (path: string) => CommandWrapper {
+	const commandRegExp = new RegExp(`cli-([^-]+)-([^/]+)`);
+
+	return function load(path: string): CommandWrapper {
+		let module = require(path);
+
+		try {
+			const command = convertModuleToCommand(module);
+			const {description, register, run, alias, eject} = command;
+			let {group = '', name = ''} = command;
+
+			//  derive the group and name from the module directory name, e.g. dojo-cli-group-name
+			const [, derivedGroup, derivedName] = <string[]> commandRegExp.exec(path);
+
+			if (!group) {
+				group = derivedGroup;
+			}
+
+			if (!name) {
+				name = derivedName;
+			}
 
 			return {
 				name,
@@ -55,7 +94,7 @@ export function createBuiltInCommandLoader(): (path: string) => CommandWrapper {
 		try {
 			const command = convertModuleToCommand(module);
 			//  derive the name and group of the built in commands from the command itself (these are optional props)
-			const { name = '', group = '', alias, description, register, run } = command;
+			const {name = '', group = '', alias, description, register, run} = command;
 
 			return {
 				name,
@@ -91,14 +130,14 @@ export function getGroupDescription(commandNames: Set<string>, commands: Command
 		return getMultiCommandDescription(commandNames, commands);
 	}
 	else {
-		const { description } = <CommandWrapper> commands.get(Array.from(commandNames.keys())[0]);
+		const {description} = <CommandWrapper> commands.get(Array.from(commandNames.keys())[0]);
 		return description;
 	}
 }
 
 function getMultiCommandDescription(commandNames: Set<string>, commands: CommandsMap): string {
 	const descriptions = Array.from(commandNames.keys(), (commandName) => {
-		const { name, description } = (<CommandWrapper> commands.get(commandName));
+		const {name, description} = (<CommandWrapper> commands.get(commandName));
 		return `${name}  \t${description}`;
 	});
 	const ui = cliui({

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,4 +1,4 @@
-import {Command} from './interfaces';
+import { Command } from './interfaces';
 
 const cliui = require('cliui');
 
@@ -25,9 +25,9 @@ export function initCommandLoader(searchPrefixes: string[]): (path: string) => C
 
 		try {
 			const command = convertModuleToCommand(module);
-			const {description, register, run, alias, eject} = command;
+			const { description, register, run, alias, eject } = command;
 			//  derive the group and name from the module directory name, e.g. dojo-cli-group-name
-			const [, group, name] = <string[]> commandRegExp.exec(path);
+			const [ , group, name ] = commandRegExp.exec(path) as string[];
 
 			return {
 				name,
@@ -39,22 +39,28 @@ export function initCommandLoader(searchPrefixes: string[]): (path: string) => C
 				path,
 				eject
 			};
-		} catch (err) {
+		}
+		catch (err) {
 			throw new Error(`Path: ${path} returned module that does not satisfy the Command interface. ${err}`);
 		}
 	};
 }
 
+/**
+ * Function to create a loader that loads explicit commands. This differs from the normal command loader by trying to
+ * find the command name/group from the command & filename.
+ * @returns A command loader
+ */
 export function initExplicitCommandLoader(): (path: string) => CommandWrapper {
-	const commandRegExp = new RegExp(`cli-([^-]+)-([^/]+)`);
+	const commandRegExp = /cli-([^-]+)-([^/]+)/;
 
 	return function load(path: string): CommandWrapper {
 		let module = require(path);
 
 		try {
 			const command = convertModuleToCommand(module);
-			const {description, register, run, alias, eject} = command;
-			let {group = '', name = ''} = command;
+			const { description, register, run, alias, eject } = command;
+			let { group = '', name = '' } = command;
 
 			//  derive the group and name from the module directory name, e.g. dojo-cli-group-name
 			if (commandRegExp.test(path)) {
@@ -89,14 +95,13 @@ export function initExplicitCommandLoader(): (path: string) => CommandWrapper {
  * Creates a builtIn command loader function.
  */
 export function createBuiltInCommandLoader(): (path: string) => CommandWrapper {
-
 	return function load(path: string): CommandWrapper {
 		const module = require(path);
 
 		try {
 			const command = convertModuleToCommand(module);
 			//  derive the name and group of the built in commands from the command itself (these are optional props)
-			const {name = '', group = '', alias, description, register, run} = command;
+			const { name = '', group = '', alias, description, register, run } = command;
 
 			return {
 				name,
@@ -132,7 +137,7 @@ export function getGroupDescription(commandNames: Set<string>, commands: Command
 		return getMultiCommandDescription(commandNames, commands);
 	}
 	else {
-		const {description} = <CommandWrapper> commands.get(Array.from(commandNames.keys())[0]);
+		const { description } = <CommandWrapper> commands.get(Array.from(commandNames.keys())[ 0 ]);
 		return description;
 	}
 }

--- a/src/command.ts
+++ b/src/command.ts
@@ -57,14 +57,16 @@ export function initExplicitCommandLoader(): (path: string) => CommandWrapper {
 			let {group = '', name = ''} = command;
 
 			//  derive the group and name from the module directory name, e.g. dojo-cli-group-name
-			const [, derivedGroup, derivedName] = <string[]> commandRegExp.exec(path);
+			if (commandRegExp.test(path)) {
+				const [, derivedGroup, derivedName] = <string[]> commandRegExp.exec(path);
 
-			if (!group) {
-				group = derivedGroup;
-			}
+				if (!group) {
+					group = derivedGroup;
+				}
 
-			if (!name) {
-				name = derivedName;
+				if (!name) {
+					name = derivedName;
+				}
 			}
 
 			return {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { join } from 'path';
+
 const pkgDir = require('pkg-dir');
 const packagePath = pkgDir.sync(__dirname);
 const yargs = require('yargs');
@@ -10,15 +11,7 @@ export type Config = {
 	explicitCommands: string[]
 };
 
-const explicitCommands: string[] = [];
-
-if (yargs.argv && yargs.argv.command) {
-	const paths = Array.isArray(yargs.argv.command) ? yargs.argv.command : [yargs.argv.command];
-
-	paths.forEach((path: string) => {
-		explicitCommands.push(path);
-	});
-}
+const explicitCommands: string[] = (yargs.argv && yargs.argv.command) ? [ ... Array.isArray(yargs.argv.command) ? yargs.argv.command : [ yargs.argv.command ] ] : [];
 
 export default {
 	searchPaths: [
@@ -26,7 +19,7 @@ export default {
 		join(__dirname, '..', '..'),
 		join(packagePath, 'node_modules')
 	],
-	searchPrefixes: ['@dojo/cli', 'dojo-cli'],
+	searchPrefixes: [ '@dojo/cli', 'dojo-cli' ],
 	builtInCommandLocation: join(__dirname, '/commands'),  // better to be relative to this file (like an import) than link to publish structure
 	explicitCommands
 } as Config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,12 +1,24 @@
 import { join } from 'path';
 const pkgDir = require('pkg-dir');
 const packagePath = pkgDir.sync(__dirname);
+const yargs = require('yargs');
 
 export type Config = {
 	searchPaths: string[],
 	searchPrefixes: string[],
-	builtInCommandLocation: string
+	builtInCommandLocation: string,
+	explicitCommands: string[]
 };
+
+const explicitCommands: string[] = [];
+
+if (yargs.argv && yargs.argv.command) {
+	const paths = Array.isArray(yargs.argv.command) ? yargs.argv.command : [yargs.argv.command];
+
+	paths.forEach((path: string) => {
+		explicitCommands.push(path);
+	});
+}
 
 export default {
 	searchPaths: [
@@ -14,6 +26,7 @@ export default {
 		join(__dirname, '..', '..'),
 		join(packagePath, 'node_modules')
 	],
-	searchPrefixes: [ '@dojo/cli', 'dojo-cli' ],
-	builtInCommandLocation: join(__dirname, '/commands')  // better to be relative to this file (like an import) than link to publish structure
+	searchPrefixes: ['@dojo/cli', 'dojo-cli'],
+	builtInCommandLocation: join(__dirname, '/commands'),  // better to be relative to this file (like an import) than link to publish structure
+	explicitCommands
 } as Config;

--- a/src/loadCommands.ts
+++ b/src/loadCommands.ts
@@ -44,8 +44,13 @@ export async function enumerateBuiltInCommands (config: Config): Promise <string
 	return globby(builtInCommandParentDirGlob, (<globby.Options> { ignore: '**/*.map' }));
 }
 
-export async function enumerateExplicitCommands (config: Config): Promise <string []> {
-	return Promise.resolve(config.explicitCommands);
+/**
+ * Return a list to the absolute path of all the explicitly specified commands
+ * @param {Config} config
+ * @returns {Promise<string[]>} The list of explicit commands
+ */
+export function enumerateExplicitCommands (config: Config): string [] {
+	return config.explicitCommands;
 }
 
 /**

--- a/src/loadCommands.ts
+++ b/src/loadCommands.ts
@@ -44,6 +44,10 @@ export async function enumerateBuiltInCommands (config: Config): Promise <string
 	return globby(builtInCommandParentDirGlob, (<globby.Options> { ignore: '**/*.map' }));
 }
 
+export async function enumerateExplicitCommands (config: Config): Promise <string []> {
+	return Promise.resolve(config.explicitCommands);
+}
+
 /**
  * Function to load commands given a search path and a load function. The load
  * function is injected for the purposes of abstraction and testing.

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -164,6 +164,9 @@ export default function(yargs: Yargs, commandsMap: CommandsMap, yargsCommandName
 		.epilog(helpEpilog)
 		.help('h')
 		.alias('h', 'help')
+		.option('command', {
+			describe: 'Specify the module ID of a command to load. Useful for running commands while developing.'
+		})
 		.strict()
 		.argv;
 }

--- a/tests/support/cli-nameless-command.ts
+++ b/tests/support/cli-nameless-command.ts
@@ -1,0 +1,9 @@
+export default {
+	description: 'test-description',
+	register() {
+		return 'registered';
+	},
+	run() {
+		return new Promise((resolve) => 'ran');
+	}
+};

--- a/tests/support/cli-test-command.ts
+++ b/tests/support/cli-test-command.ts
@@ -1,0 +1,11 @@
+export default {
+	description: 'test-description',
+	name: 'test-name',
+	group: 'test-group',
+	register() {
+		return 'registered';
+	},
+	run() {
+		return new Promise((resolve) => 'ran');
+	}
+};

--- a/tests/unit/allCommands.ts
+++ b/tests/unit/allCommands.ts
@@ -45,23 +45,26 @@ describe('AllCommands', () => {
 			.then(function(){
 				assert.isTrue(mockCommand.createBuiltInCommandLoader.calledOnce, 'should call builtin command loader');
 				assert.isTrue(mockCommand.initCommandLoader.calledOnce, 'should call installed command loader');
+				assert.isTrue(mockCommand.initExplicitCommandLoader.calledOnce, 'should call explicit command loader');
 				assert.isTrue(mockLoadCommands.enumerateBuiltInCommands.calledOnce, 'should call builtin command enumerator');
 				assert.isTrue(mockLoadCommands.enumerateInstalledCommands.calledOnce, 'should call installed command enumerator');
 				assert.isTrue(mockLoadCommands.enumerateInstalledCommands.calledAfter(mockLoadCommands.enumerateBuiltInCommands));
-				assert.isTrue(mockLoadCommands.loadCommands.calledTwice, 'should call load commands twice');
+				assert.isTrue(mockLoadCommands.loadCommands.calledThrice, 'should call load commands thrice');
 				assert.isTrue(mockLoadCommands.loadCommands.calledAfter(mockLoadCommands.enumerateInstalledCommands),
 					'should call loadcommands after both enumerations');
 			});
 	});
 
-	it('should perform initialsation only once', () => {
+	it('should perform initialisation only once', () => {
 		return moduleUnderTest.default()
 			.then(function(){
 				assert.isTrue(mockCommand.createBuiltInCommandLoader.calledOnce, 'should call builtin command loader once');
 				assert.isTrue(mockCommand.initCommandLoader.calledOnce, 'should call installed command loader once');
+				assert.isTrue(mockCommand.initExplicitCommandLoader.calledOnce, 'should call explicit command loader once');
 				assert.isTrue(mockLoadCommands.enumerateBuiltInCommands.calledOnce, 'should call builtin command enumerator once');
 				assert.isTrue(mockLoadCommands.enumerateInstalledCommands.calledOnce, 'should call installed command enumerator once');
-				assert.isTrue(mockLoadCommands.loadCommands.calledTwice, 'should call load commands twice');
+				assert.isTrue(mockLoadCommands.enumerateExplicitCommands.calledOnce, 'should call installed command enumerator once only');
+				assert.isTrue(mockLoadCommands.loadCommands.calledThrice, 'should call load commands thrice');
 
 				moduleUnderTest.default()
 					.then(function(){
@@ -69,6 +72,7 @@ describe('AllCommands', () => {
 						assert.isTrue(mockCommand.initCommandLoader.calledOnce, 'should call installed command loader once only');
 						assert.isTrue(mockLoadCommands.enumerateBuiltInCommands.calledOnce, 'should call builtin command enumerator once only');
 						assert.isTrue(mockLoadCommands.enumerateInstalledCommands.calledOnce, 'should call installed command enumerator once only');
+						assert.isTrue(mockLoadCommands.enumerateExplicitCommands.calledOnce, 'should call installed command enumerator once only');
 						assert.isTrue(mockLoadCommands.loadCommands.calledTwice, 'should call load commands twice only');
 					});
 			});
@@ -78,18 +82,22 @@ describe('AllCommands', () => {
 			.then(function(){
 				assert.isTrue(mockCommand.createBuiltInCommandLoader.calledOnce, 'should call builtin command loader once');
 				assert.isTrue(mockCommand.initCommandLoader.calledOnce, 'should call installed command loader once');
+				assert.isTrue(mockCommand.initCommandLoader.calledOnce, 'should call explicit command loader once');
 				assert.isTrue(mockLoadCommands.enumerateBuiltInCommands.calledOnce, 'should call builtin command enumerator once');
 				assert.isTrue(mockLoadCommands.enumerateInstalledCommands.calledOnce, 'should call installed command enumerator once');
-				assert.isTrue(mockLoadCommands.loadCommands.calledTwice, 'should call load commands twice only');
+				assert.isTrue(mockLoadCommands.enumerateExplicitCommands.calledOnce, 'should call explicit command enumerator once');
+				assert.isTrue(mockLoadCommands.loadCommands.calledThrice, 'should call load commands twice only');
 
 				moduleUnderTest.reset();
 				moduleUnderTest.default()
 					.then(function(){
 						assert.isTrue(mockCommand.createBuiltInCommandLoader.calledTwice, 'should call builtin command loader once');
 						assert.isTrue(mockCommand.initCommandLoader.calledTwice, 'should call installed command loader once');
+						assert.isTrue(mockCommand.initCommandLoader.calledTwice, 'should call explicit command loader once');
 						assert.isTrue(mockLoadCommands.enumerateBuiltInCommands.calledTwice, 'should call builtin command enumerator once');
 						assert.isTrue(mockLoadCommands.enumerateInstalledCommands.calledTwice, 'should call installed command enumerator once');
-						assert.equal(mockLoadCommands.loadCommands.callCount, 4, 'should call load commands twice only');
+						assert.isTrue(mockLoadCommands.enumerateExplicitCommands.calledTwice, 'should call explicit command enumerator once');
+						assert.equal(mockLoadCommands.loadCommands.callCount, 6, 'should call load commands twice only');
 					});
 			});
 	});

--- a/tests/unit/command.ts
+++ b/tests/unit/command.ts
@@ -7,6 +7,8 @@ const command: typeof UnitUnderTest = require('intern/dojo/node!../../src/comman
 const expectedCommand = require('intern/dojo/node!../support/test-prefix-foo-bar');
 const expectedBuiltInCommand = require('intern/dojo/node!../support/commands/test-prefix-foo-bar');
 const expectedEsModuleCommand = require('intern/dojo/node!../support/esmodule-prefix-foo-bar').default;
+const expectedExplicitCommand = require('intern/dojo/node!../support/cli-test-command').default;
+const expectedNamelessExplicitCommand = require('intern/dojo/node!../support/cli-nameless-command').default;
 
 const testGroup = 'foo';
 const testName = 'bar';
@@ -113,6 +115,39 @@ registerSuite({
 	'load builtin command that does not meet Command interface': {
 		'setup'() {
 			loader = command.createBuiltInCommandLoader();
+		},
+		'Should throw an error when attempting to load'() {
+			try {
+				commandWrapper = loader(getBuiltInCommandPath(true));
+				assert.fail(null, null, 'Should not get here');
+			}
+			catch (error) {
+				assert.isTrue(error instanceof Error);
+				assert.isTrue(error.message.indexOf('does not satisfy the Command interface') > -1);
+			}
+		}
+	},
+	'load explicit commands': {
+		'beforeEach'() {
+			loader = command.initExplicitCommandLoader();
+			commandWrapper = loader('../tests/support/cli-test-command');
+		},
+		'Should get group and name from filename'() {
+			commandWrapper = loader('../tests/support/cli-nameless-command');
+
+			assert.equal('nameless', commandWrapper.group);
+			assert.equal('command', commandWrapper.name);
+			assert.equal(expectedNamelessExplicitCommand.description, commandWrapper.description);
+		},
+		'Should get group, name, and description from loaded file'() {
+			assert.equal(expectedExplicitCommand.group, commandWrapper.group);
+			assert.equal(expectedExplicitCommand.name, commandWrapper.name);
+			assert.equal(expectedExplicitCommand.description, commandWrapper.description);
+		}
+	},
+	'load explicit command that does not meet command interface': {
+		'setup'() {
+			loader = command.initExplicitCommandLoader();
 		},
 		'Should throw an error when attempting to load'() {
 			try {

--- a/tests/unit/command.ts
+++ b/tests/unit/command.ts
@@ -139,6 +139,12 @@ registerSuite({
 			assert.equal('command', commandWrapper.name);
 			assert.equal(expectedNamelessExplicitCommand.description, commandWrapper.description);
 		},
+		'Should not error if filename is not the right format'() {
+			commandWrapper = loader('../tests/support/test-prefix-foo-bar');
+			assert.isUndefined(commandWrapper.group);
+			assert.isUndefined(commandWrapper.name);
+			assert.equal(expectedNamelessExplicitCommand.description, commandWrapper.description);
+		},
 		'Should get group, name, and description from loaded file'() {
 			assert.equal(expectedExplicitCommand.group, commandWrapper.group);
 			assert.equal(expectedExplicitCommand.name, commandWrapper.name);

--- a/tests/unit/config.ts
+++ b/tests/unit/config.ts
@@ -1,6 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { resolve } from 'path';
+import MockModule from '../support/MockModule';
 
 const config = require('intern/dojo/node!./../../src/config').default;
 const expectedSearchPrefixes = [ '@dojo/cli', 'dojo-cli' ];
@@ -29,5 +30,40 @@ registerSuite({
 		const paths = config.searchPaths;
 		const expectedPath = resolve('node_modules');
 		assert.equal(paths[2], expectedPath);
-	}
+	},
+	'explicit commands': (function() {
+		let mockModule: any;
+		let yargs: any;
+
+		return {
+			'beforeEach'() {
+				mockModule = new MockModule('../../src/config');
+				mockModule.dependencies(['yargs']);
+				yargs = mockModule.getMock('yargs');
+			},
+			'afterEach'() {
+				mockModule.destroy();
+			},
+			'no arguments'() {
+				yargs.ctor.argv = undefined;
+				const config = mockModule.getModuleUnderTest().default;
+				assert.equal(config.explicitCommands.length, 0);
+			},
+			'arguments but not commands'() {
+				yargs.ctor.argv = {'test': 1};
+				const config = mockModule.getModuleUnderTest().default;
+				assert.equal(config.explicitCommands.length, 0);
+			},
+			'single argument'() {
+				yargs.ctor.argv = {command: 'one'};
+				const config = mockModule.getModuleUnderTest().default;
+				assert.deepEqual(config.explicitCommands, ['one']);
+			},
+			'multiple arguments'() {
+				yargs.ctor.argv = {command: ['one', 'two']};
+				const config = mockModule.getModuleUnderTest().default;
+				assert.deepEqual(config.explicitCommands, ['one', 'two']);
+			}
+		};
+	})()
 });

--- a/tests/unit/loadCommands.ts
+++ b/tests/unit/loadCommands.ts
@@ -7,6 +7,7 @@ import MockModule from '../support/MockModule';
 import { getCommandWrapper, getYargsStub } from '../support/testHelper';
 const enumBuiltInCommands = require('intern/dojo/node!../../src/loadCommands').enumerateBuiltInCommands;
 const enumInstalledCommands = require('intern/dojo/node!../../src/loadCommands').enumerateInstalledCommands;
+const enumExplicitCommands = require('intern/dojo/node!../../src/loadCommands').enumerateExplicitCommands;
 const loadCommands = require('intern/dojo/node!../../src/loadCommands').loadCommands;
 
 let loadStub: SinonStub;
@@ -24,12 +25,14 @@ function config(invalid = false): Config {
 	const config: Config = {
 		searchPaths: [ '_build/tests/support' ],
 		searchPrefixes: [ 'test-prefix' ],
-		builtInCommandLocation: join(pathResolve('.'), '/_build/tests/support/commands')
+		builtInCommandLocation: join(pathResolve('.'), '/_build/tests/support/commands'),
+		explicitCommands: []
 	};
 	const badConfig: Config = {
 		searchPaths: [ 'just/garbage', 'yep/really/bad/paths/here' ],
 		searchPrefixes: [ 'bad-prefix' ],
-		builtInCommandLocation : 'dirThatDoesNotExist'
+		builtInCommandLocation : 'dirThatDoesNotExist',
+		explicitCommands: ['dirThatDoesNotExist']
 	};
 
 	return invalid ? badConfig : config;
@@ -60,6 +63,13 @@ registerSuite({
 		async 'Should successfully enumerate builtin commands'() {
 			const builtInPaths = await enumBuiltInCommands(goodConfig);
 			assert.equal(builtInPaths.length, 2);   // includes invalid commands
+		},
+		async 'Should successfully enumerate explicit commands'() {
+			const emptyPaths = await enumExplicitCommands(goodConfig);
+			assert.equal(emptyPaths.length, 0);
+
+			const singlePath = await enumExplicitCommands({...goodConfig, explicitCommands: ['/some/path']});
+			assert.equal(singlePath.length, 1);
 		}
 	},
 	'unsuccessful enumeration': {

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -93,14 +93,14 @@ registerSuite({
 		},
 		'should register options'() {
 			registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ 'group1-command1' ])}));
-			assert.isTrue(yargsStub.option.calledTwice);
+			assert.isTrue(yargsStub.option.calledThrice);
 		},
 		'should not register provided options'() {
 			const key = 'group1-command1';
 			const command = commandsMap.get(key);
 			command.register = stub().callsArgWith(0, 'w', {}).returns(key),
 			registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ key ])}));
-			assert.isTrue(yargsStub.option.calledOnce);
+			assert.isTrue(yargsStub.option.calledTwice);
 		},
 		'should register when alias is an array'() {
 			const key = 'group1-command1';
@@ -117,7 +117,7 @@ registerSuite({
 				}
 			];
 			registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ key ])}));
-			assert.isTrue(yargsStub.option.calledTwice);
+			assert.isTrue(yargsStub.option.calledThrice);
 		},
 		'should augment argv when run'() {
 			const key = 'group1-command1';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds an option to specify one or more explicit commands to load. This is helpful if you have a command that is:

* Not in `node_modules`
* Does't follow the `@dojo/cli` or `dojo-cli` convention
* Is in development

Specify the module ID at runtime,

```shell
dojo --command=/Projects/dojo2/cli-test-intern/dist/umd/index
```

Module group and name will be read from command description if available, if not available, they will try to be extracted from the file name (looks for `cli-(group)-(name)` pattern).

Resolves #125 
