### PR TITLE
Fix unhandled promise rejections

### DIFF
--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -70,7 +70,7 @@ export function getCommandWrapperWithConfiguration(config: CommandWrapperConfig)
 		description,
 		path,
 		register: stub().returns('registered'),
-		run: stub().returns(runs ? Promise.resolve('success') : Promise.reject(new Error()))
+		run: stub().returns(runs ? 'success' : 'error')
 	};
 
 	if (eject) {

--- a/tests/unit/CommandHelper.ts
+++ b/tests/unit/CommandHelper.ts
@@ -46,6 +46,9 @@ registerSuite({
 		const key = 'group1-command1';
 		return commandHelper.run(key).then((response: string) => {
 			assert.equal(key, response);
+		})
+		.catch(() => {
+			assert.fail(null, null, 'commandHelper.run should not have rejected promise');
 		});
 	},
 	'Should run a command that exists with args and return a promise that resolves'() {
@@ -55,6 +58,9 @@ registerSuite({
 			assert.isTrue(mockCommand.runStub.called);
 			assert.equal(mockCommand.runStub.getCall(0).args[1], 'args');
 			assert.equal(key, response);
+		})
+		.catch(() => {
+			assert.fail(null, null, 'commandHelper.run should not have rejected promise');
 		});
 	},
 	'Should run a command that exists and return a rejected promise when it fails'() {
@@ -66,7 +72,10 @@ registerSuite({
 			(error: Error) => {
 				assert.equal(key, error.message);
 			}
-		);
+		)
+		.catch(() => {
+			assert.fail(null, null, 'commandHelper.run should not have rejected promise');
+		});
 	},
 	'Should not run a command that does not exist and return a rejected promise'() {
 		const key = 'nogroup-nocommand';
@@ -78,6 +87,9 @@ registerSuite({
 			(error: Error) => {
 				assert.equal(expectedErrorMsg, error.message);
 			}
-		);
+		)
+		.catch(() => {
+			assert.fail(null, null, 'commandHelper.run should not have rejected promise');
+		});
 	}
 });

--- a/tests/unit/allCommands.ts
+++ b/tests/unit/allCommands.ts
@@ -51,7 +51,8 @@ describe('AllCommands', () => {
 				assert.isTrue(mockLoadCommands.loadCommands.calledTwice, 'should call load commands twice');
 				assert.isTrue(mockLoadCommands.loadCommands.calledAfter(mockLoadCommands.enumerateInstalledCommands),
 					'should call loadcommands after both enumerations');
-			}).catch(() => {
+			})
+			.catch(() => {
 				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 			});
 	});
@@ -72,10 +73,12 @@ describe('AllCommands', () => {
 						assert.isTrue(mockLoadCommands.enumerateBuiltInCommands.calledOnce, 'should call builtin command enumerator once only');
 						assert.isTrue(mockLoadCommands.enumerateInstalledCommands.calledOnce, 'should call installed command enumerator once only');
 						assert.isTrue(mockLoadCommands.loadCommands.calledTwice, 'should call load commands twice only');
-					}).catch(() => {
+					})
+					.catch(() => {
 						assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 					});
-			}).catch(() => {
+			})
+			.catch(() => {
 				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 			});
 	});
@@ -96,10 +99,12 @@ describe('AllCommands', () => {
 						assert.isTrue(mockLoadCommands.enumerateBuiltInCommands.calledTwice, 'should call builtin command enumerator once');
 						assert.isTrue(mockLoadCommands.enumerateInstalledCommands.calledTwice, 'should call installed command enumerator once');
 						assert.equal(mockLoadCommands.loadCommands.callCount, 4, 'should call load commands twice only');
-					}).catch(() => {
+					})
+					.catch(() => {
 						assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 					});
-			}).catch(() => {
+			})
+			.catch(() => {
 				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 			});
 	});

--- a/tests/unit/allCommands.ts
+++ b/tests/unit/allCommands.ts
@@ -51,6 +51,8 @@ describe('AllCommands', () => {
 				assert.isTrue(mockLoadCommands.loadCommands.calledTwice, 'should call load commands twice');
 				assert.isTrue(mockLoadCommands.loadCommands.calledAfter(mockLoadCommands.enumerateInstalledCommands),
 					'should call loadcommands after both enumerations');
+			}).catch(() => {
+				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 			});
 	});
 
@@ -70,7 +72,11 @@ describe('AllCommands', () => {
 						assert.isTrue(mockLoadCommands.enumerateBuiltInCommands.calledOnce, 'should call builtin command enumerator once only');
 						assert.isTrue(mockLoadCommands.enumerateInstalledCommands.calledOnce, 'should call installed command enumerator once only');
 						assert.isTrue(mockLoadCommands.loadCommands.calledTwice, 'should call load commands twice only');
+					}).catch(() => {
+						assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 					});
+			}).catch(() => {
+				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 			});
 	});
 	it('should reset the command cache', () => {
@@ -90,7 +96,11 @@ describe('AllCommands', () => {
 						assert.isTrue(mockLoadCommands.enumerateBuiltInCommands.calledTwice, 'should call builtin command enumerator once');
 						assert.isTrue(mockLoadCommands.enumerateInstalledCommands.calledTwice, 'should call installed command enumerator once');
 						assert.equal(mockLoadCommands.loadCommands.callCount, 4, 'should call load commands twice only');
+					}).catch(() => {
+						assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 					});
+			}).catch(() => {
+				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 			});
 	});
 });

--- a/tests/unit/bin/dojo.ts
+++ b/tests/unit/bin/dojo.ts
@@ -51,7 +51,7 @@ describe('cli .bin', () => {
 
 		// Give a stacktrace for the unhandled rejections should they occur
 		process.on('unhandledRejection', (reason: string, p: any) => {
-			assert.fail('Unhandled Rejection at: Promise', p, 'reason:', reason);
+			assert.fail(null, null, 'Unhandled Rejection at: Promise' + p + 'reason:' + reason);
 		});
 	});
 
@@ -67,7 +67,7 @@ describe('cli .bin', () => {
 			}, 100);
 		})
 		.catch((error: Error) => {
-			assert.fail(error.message);
+			assert.fail(null, null, error.message);
 		});
 	});
 });

--- a/tests/unit/bin/dojo.ts
+++ b/tests/unit/bin/dojo.ts
@@ -48,6 +48,11 @@ describe('cli .bin', () => {
 		mockRegisterCommands = mockModule.getMock('./registerCommands');
 		mockRegisterCommands.default = sandbox.stub();
 		moduleUnderTest = mockModule.getModuleUnderTest();
+
+		// Give a stacktrace for the unhandled rejections should they occur
+		process.on('unhandledRejection', (reason: string, p: any) => {
+			assert.fail('Unhandled Rejection at: Promise', p, 'reason:', reason);
+		});
 	});
 
 	afterEach(() => {
@@ -60,6 +65,9 @@ describe('cli .bin', () => {
 			setTimeout(() => {
 				assert.isTrue(mockRegisterCommands.default.called);
 			}, 100);
+		})
+		.catch((error: Error) => {
+			assert.fail(error.message);
 		});
 	});
 });

--- a/tests/unit/commands/eject.ts
+++ b/tests/unit/commands/eject.ts
@@ -80,6 +80,7 @@ describe('eject command', () => {
 			group: 'command',
 			name: ''
 		});
+
 		const installedCommandWrapper2 = getCommandWrapperWithConfiguration({
 			group: 'version',
 			name: ''
@@ -93,6 +94,8 @@ describe('eject command', () => {
 		mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({commandsMap: commandMap});
 		return moduleUnderTest.run(helper, {}).then(() => {
 			assert.equal(consoleLogStub.args[0][0], runOutput);
+		}).catch(() => {
+			assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 		});
 	});
 
@@ -114,6 +117,8 @@ describe('eject command', () => {
 			return moduleUnderTest.run(helper, {}).then(() => {
 				assert.isTrue(setStub.calledOnce);
 				assert.isTrue(setStub.firstCall.calledWith({ ejected: true }));
+			}).catch(() => {
+				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 			});
 		});
 	});
@@ -128,6 +133,8 @@ describe('eject command', () => {
 			return moduleUnderTest.run(helper, {}).then(() => {
 				assert.isTrue(mockNpmInstall.installDependencies.calledOnce);
 				assert.isTrue(mockNpmInstall.installDevDependencies.calledOnce);
+			}).catch(() => {
+				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 			});
 		});
 	});
@@ -143,6 +150,8 @@ describe('eject command', () => {
 				assert.isTrue(consoleLogStub.secondCall.calledWith(` ${yellow('creating')} .${sep}config${sep}test-group-test-eject${sep}file1`));
 				assert.isTrue(consoleLogStub.thirdCall.calledWith(` ${yellow('creating')} .${sep}config${sep}test-group-test-eject${sep}file2`));
 				assert.isTrue(mockFsExtra.copySync.calledTwice);
+			}).catch(() => {
+				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 			});
 		});
 
@@ -154,6 +163,8 @@ describe('eject command', () => {
 			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({commandsMap: commandMap});
 			return moduleUnderTest.run(helper, {}).then(() => {
 				assert.isTrue(mockFsExtra.copySync.notCalled);
+			}).catch(() => {
+				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 			});
 		});
 	});
@@ -172,6 +183,8 @@ describe('eject command', () => {
 				assert.isTrue(consoleLogStub.getCall(hintsCall).calledWith(underline('\nhints')), 'should underline hints');
 				assert.isTrue(consoleLogStub.getCall(hintsCall + 1).calledWith(' hint 1'), 'should show hint1');
 				assert.isTrue(consoleLogStub.getCall(hintsCall + 2).calledWith(' hint 2'), 'should show hint2');
+			}).catch(() => {
+				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 			});
 		});
 	});

--- a/tests/unit/commands/version.ts
+++ b/tests/unit/commands/version.ts
@@ -60,6 +60,9 @@ describe('version command', () => {
 		return moduleUnderTest.run(helper, { outdated: false }).then(() => {
 			assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
 			assert.equal((<sinon.SinonStub> console.log).args[0][0], noCommandOutput);
+		})
+		.catch(() => {
+			assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 		});
 	});
 
@@ -81,6 +84,9 @@ describe('version command', () => {
 		return moduleUnderTest.run(helper, { outdated: false }).then(() => {
 			assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
 			assert.equal((<sinon.SinonStub> console.log).args[0][0], noCommandOutput);
+		})
+		.catch(() => {
+			assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 		});
 	});
 
@@ -107,6 +113,9 @@ describe('version command', () => {
 		return moduleUnderTest.run(helper, { outdated: false }).then(() => {
 			assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
 			assert.equal((<sinon.SinonStub> console.log).args[0][0], expectedOutput);
+		})
+		.catch(() => {
+			assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 		});
 	});
 
@@ -135,6 +144,9 @@ describe('version command', () => {
 		return moduleUnderTest.run(helper, { outdated: false }).then(() => {
 			assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
 			assert.equal((<sinon.SinonStub> console.log).args[0][0], expectedOutput);
+		})
+		.catch(() => {
+			assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 		});
 	});
 
@@ -158,6 +170,9 @@ describe('version command', () => {
 		return moduleUnderTest.run(helper, { 'outdated': true }).then(() => {
 			assert.equal('Fetching latest version information...', (<sinon.SinonStub> console.log).args[0][0]);
 			assert.equal((<sinon.SinonStub> console.log).args[1][0], expectedOutput);
+		})
+		.catch(() => {
+			assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 		});
 	});
 
@@ -182,6 +197,9 @@ describe('version command', () => {
 		return moduleUnderTest.run(helper, { 'outdated': true }).then(() => {
 			assert.equal('Fetching latest version information...', (<sinon.SinonStub> console.log).args[0][0]);
 			assert.equal((<sinon.SinonStub> console.log).args[1][0], expectedOutput);
+		})
+		.catch(() => {
+			assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 		});
 	});
 
@@ -205,6 +223,9 @@ describe('version command', () => {
 		return moduleUnderTest.run(helper, { 'outdated': true }).then(() => {
 			assert.equal('Fetching latest version information...', (<sinon.SinonStub> console.log).args[0][0]);
 			assert.equal((<sinon.SinonStub> console.log).args[1][0], expectedOutput);
+		})
+		.catch(() => {
+			assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 		});
 	});
 


### PR DESCRIPTION
**Type:** Bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #150. It appears the issue was that stub.resolves is used but a promise was being returned back too, creating a double stacked promise. Simply returning a string resolved it.  I've also handled potentially failing promises in the tests themselves, and set process to give a stack trace for any unhandled promises in future.

On another note you still get two 'test error message' from the tests even though it implies they all passed. Any ideas on that? It's the same on master too.


