### PR TITLE
Update .travis.yml to run tests with colors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 - travis_retry npm install
 script:
 - grunt
-- grunt intern:node --test-reporter
+- grunt intern:node --test-reporter --color
 - grunt uploadCoverage
 - grunt doc
 notifications:


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

CI currently fails on Travis because it's not running `grunt` in a color terminal. Passing `--color` to `grunt intern:node` should fix this.