### PR TITLE
Add Prettier with tslint plugin and precommit hook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 The following has been addressed in the PR:
 
 * [ ] There is a related issue
-* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
+* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
 * [ ] Unit or Functional tests are included in the PR
 
 <!--

--- a/README.md
+++ b/README.md
@@ -102,7 +102,17 @@ This action is one-way and you cannot go back to having the tools managed by the
 ## How do I contribute?
 
 We appreciate your interest!  Please see the [Dojo 2 Meta Repository](https://github.com/dojo/meta#readme) for the
-Contributing Guidelines and Style Guide.
+Contributing Guidelines.
+
+### Code Style
+
+This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the projects `package.json`.
+
+An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
+
+```bash
+npm run prettier
+```
 
 ### Installation of source
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,39 +1,37 @@
 {
   "name": "@dojo/cli",
-  "version": "0.4.1-pre",
+  "version": "0.6.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@dojo/cli-create-app": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@dojo/cli-create-app/-/cli-create-app-0.3.0.tgz",
-      "integrity": "sha512-XHxFjZcAVH3eVSJIuaIhOolHWJer8XI7cZiy4/sORAYq0/rdqPPmskttPWAIVK9EJbJ62rzRRDP5268KtBSnkQ==",
+    "@dojo/core": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@dojo/core/-/core-0.3.1.tgz",
+      "integrity": "sha512-PEwqxpsuTTG0b2wwy0TLHEFf/R6ZBE4zizo4EXzGUVRc5O44w5Hbn+NN48v/o8hwQRKxmX3ywLI0Z1CMZ6NM6w==",
       "requires": {
-        "chalk": "1.1.3",
-        "cross-spawn": "4.0.2",
-        "ejs": "2.5.7",
-        "fs-extra": "0.30.0",
-        "ora": "0.3.0",
-        "pkg-dir": "1.0.0"
+        "tslib": "1.8.1"
       }
     },
-    "@dojo/core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@dojo/core/-/core-0.3.0.tgz",
-      "integrity": "sha512-SnmiQcbPUqtjzy1sOmkLvg3C6UFUaXDNUNqHzGaF2QM1Ebp1Lw+j+BE+E6uJgxISlgckjAZ6myjwFI+obZ316w=="
-    },
     "@dojo/has": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@dojo/has/-/has-0.1.1.tgz",
-      "integrity": "sha512-McwwBLpM0R0zsIy0+1WkHFXYYNalMOPJydqW3dd089K+AaOCto4AtFKA6+GDEuXDgJE9cMG5tX48hFwIL3dtxQ=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@dojo/has/-/has-0.1.2.tgz",
+      "integrity": "sha512-122xXU9xHjG/EayITIAiIdKVphZTZ2wM9IEBArarkBQzXZP1shGAbTJq7NHWUoTemw48tvTxr+OOi7wVCm7IXg=="
     },
     "@dojo/interfaces": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.0.tgz",
-      "integrity": "sha512-sgqHsKraTjKDoLfWece/E/ip29CsV3z+vEDSIzuBSWtXDEau6/pDRhbhuSnxjBB1bvvB8Drn93xWkO+PqqQ0Dg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.1.tgz",
+      "integrity": "sha512-/bIJJb9q02MxSlfA9G3n6AMTlD80fDx7qDRss/8HxeJ26ix/F/tCnX521c3XrWm/HOBEWp7GiRX5E0hQdIuCNw==",
       "dev": true,
       "requires": {
-        "@types/yargs": "8.0.2"
+        "@types/yargs": "8.0.3"
+      },
+      "dependencies": {
+        "@types/yargs": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.3.tgz",
+          "integrity": "sha512-YdxO7zGQf2qJeMgR0fNO8QTlj88L2zCP5GOddovoTyetgLiNDOUXcWzhWKb4EdZZlOjLQUA0JM8lW7VcKQL+9w==",
+          "dev": true
+        }
       }
     },
     "@dojo/loader": {
@@ -43,13 +41,13 @@
       "dev": true
     },
     "@dojo/shim": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.3.tgz",
-      "integrity": "sha512-DzpD1D90D1vsHuqPqGb78JFfykf0Nvbel+iAupYVPEwq+LVxAZPDC8nGZRsAaVfWSsFLuKPcbRRIInf+emCFAw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.5.tgz",
+      "integrity": "sha512-RhUPwaMmxWRTTKA3rO5gwRwRvoyVZNRsZMsQof852AwZq2bReUOYy4K9Ed6wF5SKQrJngVxNxiaGFddaZLLwSg==",
       "requires": {
         "intersection-observer": "0.4.3",
         "pepjs": "0.4.3",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@theintern/digdug": {
@@ -58,13 +56,21 @@
       "integrity": "sha512-BTcYNMxOnGlTEaOYqab9WygE2sLz9ZRWRsuTwUttceewzEDn/Ok/4lWdIgwwX+bb3MybvFPU1wBkq8Co+Bfqyw==",
       "dev": true,
       "requires": {
-        "@dojo/core": "0.3.0",
-        "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.2.0",
-        "@dojo/shim": "0.2.3",
+        "@dojo/core": "0.3.1",
+        "@dojo/has": "0.1.2",
+        "@dojo/interfaces": "0.2.1",
+        "@dojo/shim": "0.2.5",
         "decompress": "4.2.0",
         "semver": "5.4.1",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        }
       }
     },
     "@theintern/leadfoot": {
@@ -73,19 +79,19 @@
       "integrity": "sha512-J9wLAMjAU+Wyv5jGmHdVN4xnuyaD24kK7mAoLUPBLRNxflkJoTo9Ph5g4BKUHp+xpKd/IMU00ulgMMf++Xqm4A==",
       "dev": true,
       "requires": {
-        "@dojo/core": "0.3.0",
-        "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.2.0",
-        "@dojo/shim": "0.2.3",
+        "@dojo/core": "0.3.1",
+        "@dojo/has": "0.1.2",
+        "@dojo/interfaces": "0.2.1",
+        "@dojo/shim": "0.2.5",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.5",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@types/babel-types": {
-      "version": "6.25.2",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
-      "integrity": "sha512-+3bMuktcY4a70a0KZc8aPJlEOArPuAKQYHU5ErjkOqGJdx8xuEEVK6nWogqigBOJ8nKPxRpyCUDTCPmZ3bUxGA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.0.tgz",
+      "integrity": "sha512-PyWcbX0W4r4GcgXLI0Vu4jyJ/Erueo3PwjgvQcOmWAOBW0ObhzBBciEX+sHvjkNE0umI6nqD192FDKvYZTL91A==",
       "dev": true
     },
     "@types/benchmark": {
@@ -101,19 +107,13 @@
       "dev": true,
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "6.0.92"
+        "@types/node": "8.5.9"
       }
     },
     "@types/chai": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
-      "integrity": "sha512-m812CONwdZn/dMzkIJEY0yAs4apyTkTORgfB2UsMOxgkUbC205AHnm4T8I0I5gPg9MHrFc1dJ35iS75c0CJkjg==",
-      "dev": true
-    },
-    "@types/chalk": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
-      "integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk=",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.10.tgz",
+      "integrity": "sha512-Ejh1AXTY8lm+x91X/yar3G2z4x9RyKwdTVdyyu7Xj3dNB35fMNCnEWqTO9FgS3zjzlRNqk1MruYhgb8yhRN9rA==",
       "dev": true
     },
     "@types/charm": {
@@ -122,8 +122,14 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "8.5.9"
       }
+    },
+    "@types/configstore": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-2.1.1.tgz",
+      "integrity": "sha1-zR6FU2M60xhcPy8jns/10mQ+krY=",
+      "dev": true
     },
     "@types/detect-indent": {
       "version": "5.0.0",
@@ -137,6 +143,27 @@
       "integrity": "sha512-q3zfJvaTroV5BjAAR+peTHEGAAhGrPX0z2EzCzpt2mwFA+qzUn2nigJLqSekXRtdULKmT8am7zjvTMZSapIgHw==",
       "dev": true
     },
+    "@types/ejs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-2.5.0.tgz",
+      "integrity": "sha512-mm6fwe7oF2ltOovvKf4ulneGAERJJOo4BFgp5cKDG194byeFOdTpB8Tsuqa9MGJeNydd/D5eh4vmYFOYylR8Rw==",
+      "dev": true
+    },
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
+      "dev": true
+    },
+    "@types/execa": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@types/execa/-/execa-0.8.1.tgz",
+      "integrity": "sha512-7dsoPp7r33mdPcxukSrs9WVQgI96fiqffC7K4XvXJnSrTtJov3x1CJUgid7msJ8yCbfkmXJoKJ3HXyQIwZD0NQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.5.9"
+      }
+    },
     "@types/express": {
       "version": "4.0.39",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.39.tgz",
@@ -144,36 +171,38 @@
       "dev": true,
       "requires": {
         "@types/body-parser": "1.16.8",
-        "@types/express-serve-static-core": "4.0.57",
+        "@types/express-serve-static-core": "4.11.1",
         "@types/serve-static": "1.13.1"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.0.57",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.57.tgz",
-      "integrity": "sha512-QLAHjdLwEICm3thVbXSKRoisjfgMVI4xJH/HU8F385BR2HI7PmM6ax4ELXf8Du6sLmSpySXMYaI+xc//oQ/IFw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.1.tgz",
+      "integrity": "sha512-EehCl3tpuqiM8RUb+0255M8PhhSwTtLfmO7zBBdv0ay/VTd/zmrqDfQdZFsa5z/PVMbH2yCMZPXsnrImpATyIw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/events": "1.1.0",
+        "@types/node": "8.5.9"
       }
     },
     "@types/fs-extra": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-0.0.34.tgz",
-      "integrity": "sha1-Tv8v9bBqWjv8VErdOm7TTN+JIzU=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-qtxDULQKUenuaDLW003CgC+0T0eiAfH3BrH+vSt87GLzbz5EZ6Ox6mv9rMttvhDOatbb9nYh0E1m7ydoYwUrAg==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "8.5.9"
       }
     },
     "@types/glob": {
-      "version": "5.0.33",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
-      "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
+      "version": "5.0.35",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
+      "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "dev": true,
       "requires": {
-        "@types/minimatch": "3.0.1",
-        "@types/node": "6.0.92"
+        "@types/events": "1.1.0",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "8.5.9"
       }
     },
     "@types/globby": {
@@ -182,7 +211,7 @@
       "integrity": "sha512-EZellBZNOrvIre0bkGJdx+uDohIU8ICMsz8DCtxxJOPhP+R4uOREmHk9rbKlKaVGM/ol552yzZYKvzLEhz148g==",
       "dev": true,
       "requires": {
-        "@types/glob": "5.0.33"
+        "@types/glob": "5.0.35"
       }
     },
     "@types/grunt": {
@@ -191,7 +220,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "8.5.9"
       }
     },
     "@types/handlebars": {
@@ -213,9 +242,9 @@
       "dev": true
     },
     "@types/inquirer": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.32.tgz",
-      "integrity": "sha1-pKCOg3QcUAp8PI53dgFPf4plhw0=",
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.36.tgz",
+      "integrity": "sha512-fbqtdP4EOpbWaN+MtGArjo6CSVbPOzNtu8g6wporjg3pdk7cAq8opK4yKfP0gWLoVkbCIT1e/rSVbpYlV8FNrg==",
       "dev": true,
       "requires": {
         "@types/rx": "4.1.1",
@@ -235,14 +264,22 @@
       "dev": true
     },
     "@types/istanbul-lib-instrument": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.0.tgz",
-      "integrity": "sha512-BWj7zRtwVU5KzuYL/zNuVoSvYWIpT02smNMpQwQbJjwEyITEGSKsxVIT4b2bzXCWFMq76ss0sdY/5yw3NwTlIA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz",
+      "integrity": "sha512-Ll2qAzv7NItqVliZZ8OMAgAvGstddK2995/7X5YPU84lD3CFnqDfP4sTu5Q1GKReh5Ttw3shKR2e3Fe6Xo0C7A==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "6.25.2",
+        "@types/babel-types": "7.0.0",
         "@types/istanbul-lib-coverage": "1.1.0",
-        "@types/source-map": "0.1.29"
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "@types/istanbul-lib-report": {
@@ -255,13 +292,21 @@
       }
     },
     "@types/istanbul-lib-source-maps": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.0.tgz",
-      "integrity": "sha512-GxjyOSIZC/HETEo61MOjM72qdZH0F9UwfuXCKhmgqhVC7PSjE61BU2I/2eZwQ43+kSdkxKvnOBqqNZi1HHHNEA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
+      "integrity": "sha512-K0IvmTFbI2GjLG0O4AOLPV2hFItE5Bg/TY41IBZIThhLhYthJc3VjpZpM8/sIaIVtnQcX8b2k3muPDvsvhk+Fg==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "1.1.0",
-        "@types/source-map": "0.1.29"
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "@types/istanbul-reports": {
@@ -281,9 +326,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.87",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz",
-      "integrity": "sha512-AqRC+aEF4N0LuNHtcjKtvF9OTfqZI0iaBoe3dA6m/W+/YZJBZjBmW/QIZ8fBeXC6cnytSY9tBoFBqZ9uSCeVsw==",
+      "version": "4.14.96",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.96.tgz",
+      "integrity": "sha512-9QQXhOGVLTW+ALWBXMBKlXWsBnWfCPYX7NjgVhPUZGqJNad0jtAfqKgBh56uVPm2XUmh9IIAkadJmJoGhEpJYA==",
       "dev": true
     },
     "@types/marked": {
@@ -305,9 +350,9 @@
       "dev": true
     },
     "@types/minimatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
-      "integrity": "sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
     "@types/mockery": {
@@ -317,9 +362,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "6.0.92",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.92.tgz",
-      "integrity": "sha512-awEYSSTn7dauwVCYSx2CJaPTu0Z1Ht2oR1b2AD3CYao6ZRb+opb6EL43fzmD7eMFgMHzTBWSUzlWSD+S8xN0Nw==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.9.tgz",
+      "integrity": "sha512-s+c3AjymyAccTI4hcgNFK4mToH8l+hyPDhu4LIkn71lRy56FLijGu00fyLgldjM/846Pmk9N4KFUs2P8GDs0pA==",
       "dev": true
     },
     "@types/platform": {
@@ -334,7 +379,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "8.5.9"
       }
     },
     "@types/rx": {
@@ -469,7 +514,7 @@
       "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.0.57",
+        "@types/express-serve-static-core": "4.11.1",
         "@types/mime": "2.0.0"
       }
     },
@@ -485,23 +530,14 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "8.5.9"
       }
     },
     "@types/sinon": {
-      "version": "1.16.36",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-1.16.36.tgz",
-      "integrity": "sha1-dLtu15KFl8Gz+xsAkAXpTcbq41c=",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.1.3.tgz",
+      "integrity": "sha512-Xxn32Q3mAJHOMU20bxcT6HiPksUJEkZA+nyZS4NhLo8kKb8hLhkBgp5OeW/BI3+9QmdrvDRk3caYNqtYb+TEbA==",
       "dev": true
-    },
-    "@types/sinon-as-promised": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@types/sinon-as-promised/-/sinon-as-promised-4.0.7.tgz",
-      "integrity": "sha512-aGLbqBL0CZkL+doP850EyaDCCi0zy4+TQvkOQhDbZT6bwWATw11kX4FnntCoNpe2I73/j9CEmjRasd6Ir0thRw==",
-      "dev": true,
-      "requires": {
-        "@types/sinon": "1.16.36"
-      }
     },
     "@types/source-map": {
       "version": "0.1.29",
@@ -521,13 +557,13 @@
       "integrity": "sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "8.5.9"
       }
     },
     "@types/update-notifier": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/update-notifier/-/update-notifier-1.0.2.tgz",
-      "integrity": "sha512-NwfqJ7OT7MgzgV+SiWJr7jMdBezFIWuBSmCOmScvesL/SV8A17SUQR0sCI+shxo+4THHPNGgzaLzfbjQMYLHFA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/update-notifier/-/update-notifier-1.0.3.tgz",
+      "integrity": "sha512-BLStNhP2DFF7funARwTcoD6tetRte8NK3Sc59mn7GNALCN975jOlKX3dGvsFxXr/HwQMxxCuRn9IWB3WQ7odHQ==",
       "dev": true
     },
     "@types/ws": {
@@ -536,13 +572,13 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "8.5.9"
       }
     },
     "@types/yargs": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha512-Upj9YsBZRgjEVPvsaeGru48d2JiyzBNZkmkebHyoaQ+UM9wqj/rp5mkilRjSq/Ga45yfd/zwrNuML9f2gGfVpw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-10.0.1.tgz",
+      "integrity": "sha512-EvK+v8864qaRCjtqcJa7iUKWYTIvbdSZ4MJd99QTcBpq2FbVllwW7ldRBesBYINgj2Mn0yMQ2yZZJPej1DcJFA==",
       "dev": true
     },
     "abbrev": {
@@ -600,27 +636,54 @@
       "dev": true
     },
     "ansi-align": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
-      "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "2.1.1"
+      }
+    },
+    "ansi-cyan": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
       }
     },
     "ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+    },
+    "ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+      "requires": {
+        "color-convert": "1.9.1"
+      }
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
     },
     "any-observable": {
       "version": "0.2.0",
@@ -682,10 +745,10 @@
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
-    "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+    "arr-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+      "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
       "dev": true
     },
     "array-filter": {
@@ -718,6 +781,12 @@
       "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
       "dev": true
     },
+    "array-slice": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+      "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+      "dev": true
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -740,7 +809,8 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
     },
     "asn1": {
       "version": "0.1.11",
@@ -757,9 +827,9 @@
       "optional": true
     },
     "assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "async": {
@@ -788,7 +858,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000795",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -811,6 +881,48 @@
         "chalk": "1.1.3",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "babel-generator": {
@@ -855,14 +967,14 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
           "dev": true
         }
       }
@@ -926,12 +1038,6 @@
       "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
       "dev": true
     },
-    "beeper": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-      "dev": true
-    },
     "benchmark": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
@@ -939,7 +1045,7 @@
       "dev": true,
       "requires": {
         "lodash": "4.17.4",
-        "platform": "1.3.4"
+        "platform": "1.3.5"
       }
     },
     "big.js": {
@@ -1004,7 +1110,7 @@
         "bytes": "2.2.0",
         "content-type": "1.0.4",
         "debug": "2.2.0",
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "http-errors": "1.3.1",
         "iconv-lite": "0.4.13",
         "on-finished": "2.3.0",
@@ -1052,19 +1158,17 @@
       }
     },
     "boxen": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
-      "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "requires": {
-        "ansi-align": "1.1.0",
-        "camelcase": "2.1.1",
-        "chalk": "1.1.3",
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "2.3.0",
         "cli-boxes": "1.0.0",
-        "filled-array": "1.1.0",
-        "object-assign": "4.1.1",
-        "repeating": "2.0.1",
-        "string-width": "1.0.2",
-        "widest-line": "1.0.0"
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
+        "widest-line": "2.0.0"
       }
     },
     "brace-expansion": {
@@ -1093,8 +1197,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000778",
-        "electron-to-chromium": "1.3.28"
+        "caniuse-db": "1.0.30000795",
+        "electron-to-chromium": "1.3.31"
       }
     },
     "buffer": {
@@ -1117,7 +1221,8 @@
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
     },
     "bytes": {
       "version": "2.2.0",
@@ -1126,9 +1231,9 @@
       "dev": true
     },
     "camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
     "camelcase-keys": {
       "version": "2.1.0",
@@ -1138,6 +1243,14 @@
       "requires": {
         "camelcase": "2.1.1",
         "map-obj": "1.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        }
       }
     },
     "caniuse-api": {
@@ -1147,15 +1260,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000795",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000778",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000778.tgz",
-      "integrity": "sha1-Fnxg6VQqKqYFN8RG+ziB2FOjByo=",
+      "version": "1.0.30000795",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000795.tgz",
+      "integrity": "sha1-ZE8D+rAN2L0Wk+Xh5w2Gsxxc/s4=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1186,25 +1299,28 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.2",
+        "assertion-error": "1.1.0",
         "check-error": "1.0.2",
         "deep-eql": "3.0.1",
         "get-func-name": "2.0.0",
         "pathval": "1.1.0",
-        "type-detect": "4.0.5"
+        "type-detect": "4.0.7"
       }
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "requires": {
-        "ansi-styles": "2.2.1",
+        "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "supports-color": "4.5.0"
       }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
     },
     "charm": {
       "version": "1.0.2",
@@ -1251,6 +1367,48 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "cli-boxes": {
@@ -1265,10 +1423,17 @@
       "requires": {
         "ansi-regex": "2.1.1",
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-iterator": "2.0.3",
         "memoizee": "0.4.11",
         "timers-ext": "0.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        }
       }
     },
     "cli-color-tty": {
@@ -1280,17 +1445,18 @@
       }
     },
     "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-spinners": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.2.0.tgz",
-      "integrity": "sha1-hQeHN5E7iA9uyf/ntl6D7Hd2KE8="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+      "dev": true
     },
     "cli-table": {
       "version": "0.3.1",
@@ -1308,6 +1474,43 @@
       "requires": {
         "slice-ansi": "0.0.4",
         "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
       }
     },
     "cli-width": {
@@ -1316,12 +1519,12 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+      "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
         "wrap-ansi": "2.1.0"
       }
     },
@@ -1329,12 +1532,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
       "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
-      "dev": true
-    },
-    "clone-stats": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
       "dev": true
     },
     "coa": {
@@ -1382,7 +1579,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1390,8 +1586,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "0.3.0",
@@ -1451,19 +1646,16 @@
       }
     },
     "configstore": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
-      "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
       "requires": {
-        "dot-prop": "3.0.0",
+        "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1",
-        "os-tmpdir": "1.0.2",
-        "osenv": "0.1.4",
-        "uuid": "2.0.3",
-        "write-file-atomic": "1.3.4",
-        "xdg-basedir": "2.0.0"
+        "make-dir": "1.1.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "content-disposition": {
@@ -1559,11 +1751,12 @@
       }
     },
     "cross-spawn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
         "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
     },
@@ -1590,8 +1783,7 @@
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-      "dev": true
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
     "csproj2ts": {
       "version": "0.0.7",
@@ -1601,7 +1793,7 @@
       "requires": {
         "es6-promise": "2.3.0",
         "lodash": "3.10.1",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "xml2js": "0.4.19"
       },
       "dependencies": {
@@ -1668,6 +1860,45 @@
         "postcss-modules-values": "1.3.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
         "postcss": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
@@ -1677,6 +1908,15 @@
             "chalk": "1.1.3",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -1786,7 +2026,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "date-fns": {
@@ -1806,17 +2046,17 @@
       }
     },
     "david": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/david/-/david-9.0.0.tgz",
-      "integrity": "sha1-IkLf7e5kvOXu7/WsWzryXcuytf0=",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/david/-/david-11.0.0.tgz",
+      "integrity": "sha1-A52pQnBy+3dn9NqlalTsok3MK8M=",
       "requires": {
         "async": "2.6.0",
         "cli-color-tty": "2.0.0",
         "cli-table": "0.3.1",
         "exit": "0.1.2",
         "minimist": "1.2.0",
-        "npm": "3.10.10",
-        "semver": "5.4.1",
+        "npm": "4.6.1",
+        "semver": "5.5.0",
         "xtend": "4.0.1"
       }
     },
@@ -1847,6 +2087,14 @@
         "make-dir": "1.1.0",
         "pify": "2.3.0",
         "strip-dirs": "2.1.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "decompress-tar": {
@@ -1909,6 +2157,22 @@
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true
+        },
+        "get-stream": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+          "dev": true,
+          "requires": {
+            "object-assign": "4.1.1",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
         }
       }
     },
@@ -1924,7 +2188,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.5"
+        "type-detect": "4.0.7"
       }
     },
     "deep-equal": {
@@ -1951,6 +2215,17 @@
       "dev": true,
       "requires": {
         "strip-bom": "2.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        }
       }
     },
     "defined": {
@@ -1965,9 +2240,9 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
     "destroy": {
@@ -1988,9 +2263,9 @@
       "dev": true
     },
     "dot-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
         "is-obj": "1.0.1"
       }
@@ -2027,19 +2302,10 @@
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
-    "duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "requires": {
-        "readable-stream": "2.3.3"
-      }
-    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-      "dev": true
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -2053,9 +2319,9 @@
       "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
     },
     "electron-to-chromium": {
-      "version": "1.3.28",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
-      "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
+      "version": "1.3.31",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
+      "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA==",
       "dev": true
     },
     "elegant-spinner": {
@@ -2071,15 +2337,15 @@
       "dev": true
     },
     "encodeurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "end-of-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
         "once": "1.4.0"
@@ -2094,9 +2360,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.37",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
-      "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
+      "version": "0.10.38",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
+      "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
       "requires": {
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
@@ -2108,7 +2374,7 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-symbol": "3.1.1"
       }
     },
@@ -2124,7 +2390,7 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "es6-weak-map": {
@@ -2133,7 +2399,7 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -2174,16 +2440,6 @@
         }
       }
     },
-    "eslint-plugin-prettier": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz",
-      "integrity": "sha512-P0EohHM1MwL36GX5l1TOEYyt/5d7hcxrX3CqCjibTN3dH7VCAy2kjsC/WB6dUHnpB4mFkZq1Ndfh2DYQ2QMEGQ==",
-      "dev": true,
-      "requires": {
-        "fast-diff": "1.1.2",
-        "jest-docblock": "21.2.0"
-      }
-    },
     "esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
@@ -2214,7 +2470,7 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "eventemitter2": {
@@ -2224,16 +2480,16 @@
       "dev": true
     },
     "execa": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
-      "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
-      "dev": true,
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+      "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
       "requires": {
-        "cross-spawn-async": "2.2.5",
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
         "is-stream": "1.1.0",
-        "npm-run-path": "1.0.0",
-        "object-assign": "4.1.1",
-        "path-key": "1.0.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
         "strip-eof": "1.0.0"
       }
     },
@@ -2245,7 +2501,8 @@
     "exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
@@ -2278,8 +2535,8 @@
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "encodeurl": "1.0.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
         "finalhandler": "1.0.6",
@@ -2330,13 +2587,13 @@
       }
     },
     "external-editor": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
-      "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "requires": {
-        "extend": "3.0.1",
-        "spawn-sync": "1.0.15",
-        "tmp": "0.0.29"
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.19",
+        "tmp": "0.0.33"
       }
     },
     "extglob": {
@@ -2347,22 +2604,6 @@
       "requires": {
         "is-extglob": "1.0.0"
       }
-    },
-    "fancy-log": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "time-stamp": "1.1.0"
-      }
-    },
-    "fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
-      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2444,11 +2685,6 @@
         }
       }
     },
-    "filled-array": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
-      "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q="
-    },
     "finalhandler": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
@@ -2456,7 +2692,7 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
@@ -2479,12 +2715,11 @@
       "dev": true
     },
     "find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "locate-path": "2.0.0"
       }
     },
     "findup-sync": {
@@ -2549,12 +2784,12 @@
       }
     },
     "formatio": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
-        "samsam": "1.1.2"
+        "samsam": "1.3.0"
       }
     },
     "forwarded": {
@@ -2576,15 +2811,13 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-      "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "requires": {
         "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.2"
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
       }
     },
     "fs.realpath": {
@@ -2649,14 +2882,9 @@
       "dev": true
     },
     "get-stream": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-      "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-      "dev": true,
-      "requires": {
-        "object-assign": "4.1.1",
-        "pinkie-promise": "2.0.1"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "getobject": {
       "version": "0.1.0",
@@ -2742,7 +2970,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-      "dev": true,
       "requires": {
         "ini": "1.3.5"
       }
@@ -2763,6 +2990,13 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
       }
     },
     "globule": {
@@ -2776,34 +3010,21 @@
         "minimatch": "3.0.4"
       }
     },
-    "glogg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-      "dev": true,
-      "requires": {
-        "sparkles": "1.0.0"
-      }
-    },
     "got": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
-      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
         "create-error-class": "3.0.2",
-        "duplexer2": "0.1.4",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
         "is-redirect": "1.0.0",
         "is-retry-allowed": "1.1.0",
         "is-stream": "1.1.0",
         "lowercase-keys": "1.0.0",
-        "node-status-codes": "1.0.0",
-        "object-assign": "4.1.1",
-        "parse-json": "2.2.0",
-        "pinkie-promise": "2.0.1",
-        "read-all-stream": "3.1.0",
-        "readable-stream": "2.3.3",
-        "timed-out": "3.1.3",
-        "unzip-response": "1.0.2",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
         "url-parse-lax": "1.0.0"
       }
     },
@@ -2911,6 +3132,48 @@
       "requires": {
         "chalk": "1.1.3",
         "file-sync-cmp": "0.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "grunt-contrib-watch": {
@@ -2940,9 +3203,9 @@
       }
     },
     "grunt-dojo2": {
-      "version": "2.0.0-beta2.15",
-      "resolved": "https://registry.npmjs.org/grunt-dojo2/-/grunt-dojo2-2.0.0-beta2.15.tgz",
-      "integrity": "sha512-inDpdjlZrb6F5VTIlMDDCPxN1wtM27axEW9feHrmzh/x1CyelfzsvfkbbmqkP/XHlVrGNmHkO8BuTSDqCDn+BA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-dojo2/-/grunt-dojo2-0.1.1.tgz",
+      "integrity": "sha512-vHz5uCmHEDxvNHcWYRBuvB7xa34g+25oLbsXzbcBPtYTJJtwrKy4YQ8gl1hHWQUSFvLJfj+CE15yU4mdmLzBxA==",
       "dev": true,
       "requires": {
         "codecov.io": "0.1.6",
@@ -2958,7 +3221,7 @@
         "grunt-ts": "5.5.1",
         "grunt-tslint": "4.0.1",
         "grunt-typings": "0.1.5",
-        "intern": "4.1.3",
+        "intern": "4.1.5",
         "istanbul-lib-coverage": "1.1.1",
         "istanbul-lib-report": "1.1.2",
         "istanbul-reports": "1.1.3",
@@ -2968,7 +3231,7 @@
         "postcss-cssnext": "2.11.0",
         "postcss-import": "9.1.0",
         "postcss-modules": "0.6.4",
-        "remap-istanbul": "0.9.5",
+        "remap-istanbul": "0.10.1",
         "resolve-from": "2.0.0",
         "shelljs": "0.7.8",
         "tslint": "4.5.1",
@@ -2977,81 +3240,11 @@
         "umd-wrapper": "0.1.0"
       },
       "dependencies": {
-        "ansi-align": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-          "dev": true,
-          "requires": {
-            "string-width": "2.1.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "boxen": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-          "dev": true,
-          "requires": {
-            "ansi-align": "2.0.0",
-            "camelcase": "4.1.0",
-            "chalk": "2.3.0",
-            "cli-boxes": "1.0.0",
-            "string-width": "2.1.1",
-            "term-size": "1.2.0",
-            "widest-line": "2.0.0"
-          }
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
         "colors": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
           "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
           "dev": true
-        },
-        "configstore": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-          "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
-          "dev": true,
-          "requires": {
-            "dot-prop": "4.2.0",
-            "graceful-fs": "4.1.11",
-            "make-dir": "1.1.0",
-            "unique-string": "1.0.0",
-            "write-file-atomic": "2.3.0",
-            "xdg-basedir": "3.0.0"
-          }
         },
         "diff": {
           "version": "3.4.0",
@@ -3059,38 +3252,28 @@
           "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
           "dev": true
         },
-        "dot-prop": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+        "execa": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
+          "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
           "dev": true,
           "requires": {
-            "is-obj": "1.0.1"
+            "cross-spawn-async": "2.2.5",
+            "is-stream": "1.1.0",
+            "npm-run-path": "1.0.0",
+            "object-assign": "4.1.1",
+            "path-key": "1.0.0",
+            "strip-eof": "1.0.0"
           }
         },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
-        "got": {
-          "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "create-error-class": "3.0.2",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-redirect": "1.0.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.0",
-            "safe-buffer": "5.1.1",
-            "timed-out": "4.0.1",
-            "unzip-response": "2.0.1",
-            "url-parse-lax": "1.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "grunt-tslint": {
@@ -3099,72 +3282,38 @@
           "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
           "dev": true
         },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+        "npm-run-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
+          "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
+          "dev": true,
+          "requires": {
+            "path-key": "1.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
+          "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "latest-version": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+        "pkg-dir": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
-            "package-json": "4.0.1"
+            "find-up": "1.1.2"
           }
-        },
-        "package-json": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-          "dev": true,
-          "requires": {
-            "got": "6.7.1",
-            "registry-auth-token": "3.3.1",
-            "registry-url": "3.1.0",
-            "semver": "5.4.1"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        },
-        "timed-out": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "dev": true
         },
         "tslint": {
           "version": "4.5.1",
@@ -3182,55 +3331,6 @@
             "tsutils": "1.9.1",
             "update-notifier": "2.3.0"
           }
-        },
-        "unzip-response": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-          "dev": true
-        },
-        "update-notifier": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-          "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
-          "dev": true,
-          "requires": {
-            "boxen": "1.3.0",
-            "chalk": "2.3.0",
-            "configstore": "3.1.1",
-            "import-lazy": "2.1.0",
-            "is-installed-globally": "0.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "3.1.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "3.0.0"
-          }
-        },
-        "widest-line": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-          "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
-          "dev": true,
-          "requires": {
-            "string-width": "2.1.1"
-          }
-        },
-        "write-file-atomic": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-          "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "xdg-basedir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-          "dev": true
         }
       }
     },
@@ -3277,10 +3377,50 @@
         "lodash": "4.3.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
         "lodash": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
           "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
@@ -3332,6 +3472,48 @@
         "chalk": "1.1.3",
         "diff": "2.2.3",
         "postcss": "5.2.18"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "grunt-text-replace": {
@@ -3352,7 +3534,7 @@
         "lodash": "2.4.1",
         "ncp": "0.5.1",
         "rimraf": "2.2.6",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "strip-bom": "2.0.0",
         "typescript": "1.8.9",
         "underscore": "1.5.1",
@@ -3370,6 +3552,15 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz",
           "integrity": "sha1-xZWXVpsU2VatKcrMQr3d9fDqT0w=",
           "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
         },
         "typescript": {
           "version": "1.8.9",
@@ -3398,76 +3589,137 @@
       "dev": true,
       "requires": {
         "typings-core": "1.6.1"
-      }
-    },
-    "gulp-util": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-      "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
-      "dev": true,
-      "requires": {
-        "array-differ": "1.0.0",
-        "array-uniq": "1.0.3",
-        "beeper": "1.1.1",
-        "chalk": "1.1.3",
-        "dateformat": "1.0.12",
-        "fancy-log": "1.3.0",
-        "gulplog": "1.0.0",
-        "has-gulplog": "0.1.0",
-        "lodash._reescape": "3.0.0",
-        "lodash._reevaluate": "3.0.0",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.template": "3.6.2",
-        "minimist": "1.2.0",
-        "multipipe": "0.1.2",
-        "object-assign": "3.0.0",
-        "replace-ext": "0.0.1",
-        "through2": "2.0.1",
-        "vinyl": "0.5.3"
       },
       "dependencies": {
-        "lodash.template": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-          "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+        "configstore": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+          "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
           "dev": true,
           "requires": {
-            "lodash._basecopy": "3.0.1",
-            "lodash._basetostring": "3.0.1",
-            "lodash._basevalues": "3.0.0",
-            "lodash._isiterateecall": "3.0.9",
-            "lodash._reinterpolate": "3.0.0",
-            "lodash.escape": "3.2.0",
-            "lodash.keys": "3.1.2",
-            "lodash.restparam": "3.6.1",
-            "lodash.templatesettings": "3.1.1"
+            "dot-prop": "3.0.0",
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "os-tmpdir": "1.0.2",
+            "osenv": "0.1.4",
+            "uuid": "2.0.3",
+            "write-file-atomic": "1.3.4",
+            "xdg-basedir": "2.0.0"
           }
         },
-        "lodash.templatesettings": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-          "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+        "detect-indent": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "3.0.0",
-            "lodash.escape": "3.2.0"
+            "repeating": "2.0.1"
           }
         },
-        "object-assign": {
+        "dot-prop": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+          "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+          "dev": true,
+          "requires": {
+            "is-obj": "1.0.1"
+          }
+        },
+        "popsicle": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-8.2.0.tgz",
+          "integrity": "sha1-/0QBAFyrQ6lBipFBBhHAAZdxLSE=",
+          "dev": true,
+          "requires": {
+            "any-promise": "1.3.0",
+            "arrify": "1.0.1",
+            "concat-stream": "1.6.0",
+            "form-data": "2.3.1",
+            "make-error-cause": "1.2.2",
+            "throwback": "1.1.1",
+            "tough-cookie": "2.3.3",
+            "xtend": "4.0.1"
+          }
+        },
+        "promise-finally": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/promise-finally/-/promise-finally-2.2.1.tgz",
+          "integrity": "sha1-ImFsS6kCkW6Yi9RsVNfKoIkQzXc=",
+          "dev": true,
+          "requires": {
+            "any-promise": "1.3.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "typings-core": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/typings-core/-/typings-core-1.6.1.tgz",
+          "integrity": "sha1-zkspMeovGbuPPay+xpmDrE6WSjc=",
+          "dev": true,
+          "requires": {
+            "any-promise": "1.3.0",
+            "array-uniq": "1.0.3",
+            "configstore": "2.1.0",
+            "debug": "2.6.9",
+            "detect-indent": "4.0.0",
+            "graceful-fs": "4.1.11",
+            "has": "1.0.1",
+            "invariant": "2.2.2",
+            "is-absolute": "0.2.6",
+            "listify": "1.0.0",
+            "lockfile": "1.0.3",
+            "make-error-cause": "1.2.2",
+            "mkdirp": "0.5.1",
+            "object.pick": "1.3.0",
+            "parse-json": "2.2.0",
+            "popsicle": "8.2.0",
+            "popsicle-proxy-agent": "3.0.0",
+            "popsicle-retry": "3.2.1",
+            "popsicle-rewrite": "1.0.0",
+            "popsicle-status": "2.0.1",
+            "promise-finally": "2.2.1",
+            "rc": "1.2.4",
+            "rimraf": "2.6.2",
+            "sort-keys": "1.1.2",
+            "string-template": "1.0.0",
+            "strip-bom": "2.0.0",
+            "thenify": "3.3.0",
+            "throat": "3.2.0",
+            "touch": "1.0.0",
+            "typescript": "2.6.2",
+            "xtend": "4.0.1",
+            "zip-object": "0.1.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
+          }
+        },
+        "xdg-basedir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+          "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
+          "dev": true,
+          "requires": {
+            "os-homedir": "1.0.2"
+          }
         }
-      }
-    },
-    "gulplog": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-      "dev": true,
-      "requires": {
-        "glogg": "1.0.0"
       }
     },
     "handlebars": {
@@ -3511,24 +3763,23 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
       }
     },
     "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-      "dev": true
-    },
-    "has-gulplog": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "dev": true,
-      "requires": {
-        "sparkles": "1.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "hawk": {
       "version": "1.1.1",
@@ -3573,7 +3824,8 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "dev": true
     },
     "html-comment-regex": {
       "version": "1.1.1",
@@ -3635,7 +3887,7 @@
       "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
       "dev": true,
       "requires": {
-        "is-ci": "1.0.10",
+        "is-ci": "1.1.0",
         "normalize-path": "1.0.0",
         "strip-indent": "2.0.0"
       },
@@ -3657,8 +3909,7 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-      "dev": true
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
@@ -3681,8 +3932,7 @@
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-      "dev": true
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -3724,82 +3974,51 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-2.0.0.tgz",
-      "integrity": "sha1-4TUWh7kNFQykA86qPO+x4wZb70s=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-4.0.2.tgz",
+      "integrity": "sha512-+f3qDNeZpkhFJ61NBA9jXDrGGhoQuqfEum9A681c9oHoIbGgVqjogKynjB/vNVP+nVu9w3FbFQ35c0ibU0MaIQ==",
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.3.0",
+        "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "1.1.1",
+        "external-editor": "2.1.0",
         "figures": "2.0.0",
         "lodash": "4.17.4",
-        "mute-stream": "0.0.6",
-        "pinkie-promise": "2.0.1",
+        "mute-stream": "0.0.7",
         "run-async": "2.3.0",
-        "rx": "4.1.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
         "string-width": "2.1.1",
-        "strip-ansi": "3.0.1",
+        "strip-ansi": "4.0.0",
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "requires": {
-                "ansi-regex": "3.0.0"
-              }
-            }
-          }
-        }
       }
     },
     "intern": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.3.tgz",
-      "integrity": "sha512-IWaqzIwc+KQcoyiG+INvvv9L0fPKmgDSj+LySSWgnPc0VnYT1vgEmmxpwSlMPHDtfMMqq28/5/tsQVRx4EM2bQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.5.tgz",
+      "integrity": "sha512-wY3xxstQ2zHpOU/ktjMcyvzmzazyjvlcipD79RqDGm+kyMdJcyI+00qfHvPlzrwhGwX+XVs2+tqwJCiSMKzYUg==",
       "dev": true,
       "requires": {
-        "@dojo/core": "0.3.0",
-        "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.2.0",
-        "@dojo/shim": "0.2.3",
+        "@dojo/core": "0.3.1",
+        "@dojo/has": "0.1.2",
+        "@dojo/interfaces": "0.2.1",
+        "@dojo/shim": "0.2.5",
         "@theintern/digdug": "2.0.4",
         "@theintern/leadfoot": "2.0.3",
         "@types/benchmark": "1.0.31",
-        "@types/chai": "4.0.8",
+        "@types/chai": "4.0.10",
         "@types/charm": "1.0.1",
         "@types/diff": "3.2.2",
         "@types/express": "4.0.39",
         "@types/http-errors": "1.5.34",
         "@types/istanbul-lib-coverage": "1.1.0",
         "@types/istanbul-lib-hook": "1.0.0",
-        "@types/istanbul-lib-instrument": "1.7.0",
+        "@types/istanbul-lib-instrument": "1.7.1",
         "@types/istanbul-lib-report": "1.1.0",
-        "@types/istanbul-lib-source-maps": "1.2.0",
+        "@types/istanbul-lib-source-maps": "1.2.1",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.87",
+        "@types/lodash": "4.14.96",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -3824,12 +4043,12 @@
         "lodash": "4.17.4",
         "mime-types": "2.1.17",
         "minimatch": "3.0.4",
-        "platform": "1.3.4",
+        "platform": "1.3.5",
         "resolve": "1.4.0",
         "shell-quote": "1.6.1",
         "source-map": "0.5.7",
         "statuses": "1.3.1",
-        "tslib": "1.8.0",
+        "tslib": "1.8.1",
         "ws": "2.3.1"
       },
       "dependencies": {
@@ -3842,7 +4061,7 @@
             "bytes": "2.4.0",
             "content-type": "1.0.4",
             "debug": "2.6.7",
-            "depd": "1.1.1",
+            "depd": "1.1.2",
             "http-errors": "1.6.2",
             "iconv-lite": "0.4.15",
             "on-finished": "2.3.0",
@@ -3882,6 +4101,14 @@
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
             "statuses": "1.3.1"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+              "dev": true
+            }
           }
         },
         "iconv-lite": {
@@ -3993,14 +4220,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
       "requires": {
         "builtin-modules": "1.1.1"
       }
     },
     "is-ci": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
-      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
         "ci-info": "1.1.2"
@@ -4043,17 +4271,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-glob": {
       "version": "1.1.3",
@@ -4065,7 +4291,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-      "dev": true,
       "requires": {
         "global-dirs": "0.1.1",
         "is-path-inside": "1.0.1"
@@ -4109,7 +4334,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
       }
@@ -4191,7 +4415,8 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
     },
     "is-windows": {
       "version": "0.2.0",
@@ -4266,6 +4491,12 @@
             "path-is-absolute": "1.0.1"
           }
         },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
         "nopt": {
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -4319,7 +4550,7 @@
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
         "istanbul-lib-coverage": "1.1.1",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "istanbul-lib-report": {
@@ -4334,6 +4565,12 @@
         "supports-color": "3.2.3"
       },
       "dependencies": {
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
@@ -4378,12 +4615,6 @@
         "handlebars": "4.0.11"
       }
     },
-    "jest-docblock": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
-      "dev": true
-    },
     "jest-get-type": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
@@ -4400,49 +4631,12 @@
         "jest-get-type": "21.2.0",
         "leven": "2.1.0",
         "pretty-format": "21.2.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
       }
     },
     "js-base64": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
-      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.2.tgz",
+      "integrity": "sha512-lLkz3IRPTNeATsKQGeltbzRK/5+bWsXBHfpZrxJAi4N30RtCtNA+rJznp4uR2+4OgkBsoeeFwONVLr4gzIVErQ==",
       "dev": true
     },
     "js-tokens": {
@@ -4479,9 +4673,9 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -4491,6 +4685,22 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
+    },
+    "jspm-config": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/jspm-config/-/jspm-config-0.3.4.tgz",
+      "integrity": "sha1-RMJpAuSujs4jZs7cn/FrEKXzkcY=",
+      "requires": {
+        "any-promise": "1.3.0",
+        "graceful-fs": "4.1.11",
+        "make-error-cause": "1.2.2",
+        "object.pick": "1.3.0",
+        "parse-json": "2.2.0",
+        "strip-bom": "3.0.0",
+        "thenify": "3.3.0",
+        "throat": "3.2.0",
+        "xtend": "4.0.1"
+      }
     },
     "jszip": {
       "version": "3.1.5",
@@ -4533,6 +4743,12 @@
         }
       }
     },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -4542,20 +4758,12 @@
         "is-buffer": "1.1.6"
       }
     },
-    "klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
-    },
     "latest-version": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
-      "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "requires": {
-        "package-json": "2.4.0"
+        "package-json": "4.0.1"
       }
     },
     "lazy-cache": {
@@ -4564,11 +4772,6 @@
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true,
       "optional": true
-    },
-    "lazy-req": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
-      "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w="
     },
     "lcid": {
       "version": "1.0.0",
@@ -4611,7 +4814,7 @@
       "requires": {
         "app-root-path": "2.0.1",
         "chalk": "2.3.0",
-        "commander": "2.12.2",
+        "commander": "2.13.0",
         "cosmiconfig": "3.1.0",
         "debug": "3.1.0",
         "dedent": "0.7.0",
@@ -4621,7 +4824,7 @@
         "jest-validate": "21.2.1",
         "listr": "0.13.0",
         "lodash": "4.17.4",
-        "log-symbols": "2.1.0",
+        "log-symbols": "2.2.0",
         "minimatch": "3.0.4",
         "npm-which": "3.0.1",
         "p-map": "1.2.0",
@@ -4631,42 +4834,11 @@
         "stringify-object": "3.2.1"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
         "commander": {
-          "version": "2.12.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
           "dev": true
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
-          }
         },
         "debug": {
           "version": "3.1.0",
@@ -4676,33 +4848,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "execa": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
-          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
         },
         "is-extglob": {
           "version": "2.1.1",
@@ -4717,45 +4862,6 @@
           "dev": true,
           "requires": {
             "is-extglob": "2.1.1"
-          }
-        },
-        "log-symbols": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
-          "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.3.0"
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "2.0.1"
-          }
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-          "dev": true
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
           }
         }
       }
@@ -4790,11 +4896,30 @@
         "strip-ansi": "3.0.1"
       },
       "dependencies": {
-        "cli-spinners": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
-          "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
         },
         "figures": {
           "version": "1.7.0",
@@ -4806,17 +4931,29 @@
             "object-assign": "4.1.1"
           }
         },
-        "ora": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
-          "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "cli-cursor": "1.0.2",
-            "cli-spinners": "0.1.2",
-            "object-assign": "4.1.1"
+            "chalk": "1.1.3"
           }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
@@ -4842,6 +4979,31 @@
         "strip-ansi": "3.0.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
         "figures": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -4856,6 +5018,30 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
           "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
@@ -4872,6 +5058,40 @@
         "figures": "1.7.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
+        },
         "figures": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -4881,25 +5101,74 @@
             "escape-string-regexp": "1.0.5",
             "object-assign": "4.1.1"
           }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
     "livereload-js": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
-      "integrity": "sha1-bIclfmSKtHW8JOoldFftzB+NC8I=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
+      "integrity": "sha512-j1R0/FeGa64Y+NmqfZhyoVRzcFlOZ8sNlKzHjh4VvLULFACZhn68XrX5DFg2FhMvSMJmROuFxRSa560ECWKBMg==",
       "dev": true
     },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "parse-json": "2.2.0",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
         "strip-bom": "2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        }
       }
     },
     "loader-utils": {
@@ -4918,18 +5187,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
       "requires": {
         "p-locate": "2.0.0",
         "path-exists": "3.0.0"
-      },
-      "dependencies": {
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        }
       }
     },
     "lockfile": {
@@ -4942,107 +5202,22 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basetostring": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-      "dev": true
-    },
-    "lodash._basevalues": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
-    "lodash._reescape": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-      "dev": true
-    },
-    "lodash._reevaluate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-      "dev": true
-    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
-    "lodash._root": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
-    },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-    },
-    "lodash.escape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-      "dev": true,
-      "requires": {
-        "lodash._root": "3.0.1"
-      }
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
     },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
-    },
-    "lodash.restparam": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
     },
     "lodash.template": {
@@ -5071,11 +5246,12 @@
       "dev": true
     },
     "log-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "2.3.0"
       }
     },
     "log-update": {
@@ -5086,12 +5262,45 @@
       "requires": {
         "ansi-escapes": "1.4.0",
         "cli-cursor": "1.0.2"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
+        }
       }
     },
     "lolex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
+      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw==",
       "dev": true
     },
     "longest": {
@@ -5137,7 +5346,7 @@
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "requires": {
-        "es5-ext": "0.10.37"
+        "es5-ext": "0.10.38"
       }
     },
     "macaddress": {
@@ -5150,30 +5359,21 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
       "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
-      "dev": true,
       "requires": {
         "pify": "3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
       }
     },
     "make-error": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
-      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.2.tgz",
+      "integrity": "sha512-l9ra35l5VWLF24y75Tg8XgfGLX0ueRhph118WKM6H5denx4bB5QF59+4UAm9oJ2qsPQZas/CQUDdtDdfvYHBdQ=="
     },
     "make-error-cause": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
       "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
       "requires": {
-        "make-error": "1.3.0"
+        "make-error": "1.3.2"
       }
     },
     "map-obj": {
@@ -5183,9 +5383,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
-      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
       "dev": true
     },
     "math-expression-evaluator": {
@@ -5204,7 +5404,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
       "requires": {
         "mimic-fn": "1.1.0"
       }
@@ -5215,7 +5414,7 @@
       "integrity": "sha1-vemBdmPJ5A/bKk6hw2cpYIeujI8=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "es6-weak-map": "2.0.2",
         "event-emitter": "0.3.5",
         "is-promise": "2.1.0",
@@ -5309,8 +5508,7 @@
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
-      "dev": true
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -5341,9 +5539,9 @@
       }
     },
     "mockery": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
-      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
       "dev": true
     },
     "ms": {
@@ -5351,54 +5549,10 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "multipipe": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-      "dev": true,
-      "requires": {
-        "duplexer2": "0.0.2"
-      },
-      "dependencies": {
-        "duplexer2": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-          "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "1.1.14"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
     "mute-stream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-      "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
       "version": "2.8.0",
@@ -5430,10 +5584,41 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
-    "node-status-codes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
-      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
+    "nise": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
+      "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
+      "dev": true,
+      "requires": {
+        "formatio": "1.2.0",
+        "just-extend": "1.1.27",
+        "lolex": "1.6.0",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "lolex": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-uuid": {
       "version": "1.4.8",
@@ -5453,10 +5638,11 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -5488,17 +5674,20 @@
       }
     },
     "npm": {
-      "version": "3.10.10",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-3.10.10.tgz",
-      "integrity": "sha1-Wx1XfkyIadbIYDvInpzRY3MD5G4=",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-4.6.1.tgz",
+      "integrity": "sha1-+Osa0A3FilUUNjtBylNCgX8L1kY=",
       "requires": {
-        "abbrev": "1.0.9",
-        "ansi-regex": "2.0.0",
+        "JSONStream": "1.3.1",
+        "abbrev": "1.1.0",
+        "ansi-regex": "2.1.1",
         "ansicolors": "0.3.2",
         "ansistyles": "0.1.3",
-        "aproba": "1.0.4",
+        "aproba": "1.1.1",
         "archy": "1.0.0",
         "asap": "2.0.5",
+        "bluebird": "3.5.0",
+        "call-limit": "1.1.0",
         "chownr": "1.0.1",
         "cmd-shim": "2.0.2",
         "columnify": "1.5.4",
@@ -5506,21 +5695,22 @@
         "debuglog": "1.0.1",
         "dezalgo": "1.0.3",
         "editor": "1.0.0",
-        "fs-vacuum": "1.2.9",
-        "fs-write-stream-atomic": "1.0.8",
-        "fstream": "1.0.10",
+        "fs-vacuum": "1.2.10",
+        "fs-write-stream-atomic": "1.0.10",
+        "fstream": "1.0.11",
         "fstream-npm": "1.2.0",
-        "glob": "7.1.0",
-        "graceful-fs": "4.1.9",
+        "glob": "7.1.1",
+        "graceful-fs": "4.1.11",
         "has-unicode": "2.0.1",
-        "hosted-git-info": "2.1.5",
+        "hosted-git-info": "2.4.2",
         "iferr": "0.1.5",
         "imurmurhash": "0.1.4",
-        "inflight": "1.0.5",
+        "inflight": "1.0.6",
         "inherits": "2.0.3",
         "ini": "1.3.4",
-        "init-package-json": "1.9.4",
-        "lockfile": "1.0.2",
+        "init-package-json": "1.10.1",
+        "lazy-property": "1.0.0",
+        "lockfile": "1.0.3",
         "lodash._baseindexof": "3.1.0",
         "lodash._baseuniq": "4.6.0",
         "lodash._bindcallback": "3.0.1",
@@ -5532,36 +5722,39 @@
         "lodash.union": "4.6.0",
         "lodash.uniq": "4.5.0",
         "lodash.without": "4.4.0",
+        "mississippi": "1.3.0",
         "mkdirp": "0.5.1",
-        "node-gyp": "3.4.0",
-        "nopt": "3.0.6",
+        "move-concurrently": "1.0.1",
+        "node-gyp": "3.6.0",
+        "nopt": "4.0.1",
         "normalize-git-url": "3.0.2",
-        "normalize-package-data": "2.3.5",
+        "normalize-package-data": "2.3.8",
         "npm-cache-filename": "1.0.2",
         "npm-install-checks": "3.0.0",
-        "npm-package-arg": "4.2.0",
-        "npm-registry-client": "7.2.1",
+        "npm-package-arg": "4.2.1",
+        "npm-registry-client": "8.1.1",
         "npm-user-validate": "0.1.5",
-        "npmlog": "4.0.0",
+        "npmlog": "4.0.2",
         "once": "1.4.0",
-        "opener": "1.4.2",
-        "osenv": "0.1.3",
+        "opener": "1.4.3",
+        "osenv": "0.1.4",
         "path-is-inside": "1.0.2",
         "read": "1.0.7",
         "read-cmd-shim": "1.0.1",
         "read-installed": "4.0.3",
-        "read-package-json": "2.0.4",
+        "read-package-json": "2.0.5",
         "read-package-tree": "5.1.5",
-        "readable-stream": "2.1.5",
+        "readable-stream": "2.2.9",
         "readdir-scoped-modules": "1.0.2",
         "realize-package-specifier": "3.0.3",
-        "request": "2.75.0",
-        "retry": "0.10.0",
-        "rimraf": "2.5.4",
+        "request": "2.81.0",
+        "retry": "0.10.1",
+        "rimraf": "2.6.1",
         "semver": "5.3.0",
         "sha": "2.0.1",
         "slide": "1.1.6",
         "sorted-object": "2.0.1",
+        "sorted-union-stream": "2.1.3",
         "strip-ansi": "3.0.1",
         "tar": "2.2.1",
         "text-table": "0.2.0",
@@ -5569,19 +5762,39 @@
         "umask": "1.1.0",
         "unique-filename": "1.1.0",
         "unpipe": "1.0.0",
+        "update-notifier": "2.1.0",
+        "uuid": "3.0.1",
         "validate-npm-package-license": "3.0.1",
-        "validate-npm-package-name": "2.2.2",
-        "which": "1.2.11",
+        "validate-npm-package-name": "3.0.0",
+        "which": "1.2.14",
         "wrappy": "1.0.2",
-        "write-file-atomic": "1.2.0"
+        "write-file-atomic": "1.3.3"
       },
       "dependencies": {
+        "JSONStream": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "1.3.0",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            }
+          }
+        },
         "abbrev": {
-          "version": "1.0.9",
+          "version": "1.1.0",
           "bundled": true
         },
         "ansi-regex": {
-          "version": "2.0.0",
+          "version": "2.1.1",
           "bundled": true
         },
         "ansicolors": {
@@ -5593,7 +5806,7 @@
           "bundled": true
         },
         "aproba": {
-          "version": "1.0.4",
+          "version": "1.1.1",
           "bundled": true
         },
         "archy": {
@@ -5604,6 +5817,14 @@
           "version": "2.0.5",
           "bundled": true
         },
+        "bluebird": {
+          "version": "3.5.0",
+          "bundled": true
+        },
+        "call-limit": {
+          "version": "1.1.0",
+          "bundled": true
+        },
         "chownr": {
           "version": "1.0.1",
           "bundled": true
@@ -5612,7 +5833,7 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.9",
+            "graceful-fs": "4.1.11",
             "mkdirp": "0.5.1"
           }
         },
@@ -5679,32 +5900,32 @@
           "bundled": true
         },
         "fs-vacuum": {
-          "version": "1.2.9",
+          "version": "1.2.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.9",
+            "graceful-fs": "4.1.11",
             "path-is-inside": "1.0.2",
-            "rimraf": "2.5.4"
+            "rimraf": "2.6.1"
           }
         },
         "fs-write-stream-atomic": {
-          "version": "1.0.8",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.9",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "readable-stream": "2.1.5"
-          }
-        },
-        "fstream": {
           "version": "1.0.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.9",
+            "graceful-fs": "4.1.11",
+            "iferr": "0.1.5",
+            "imurmurhash": "0.1.4",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
             "inherits": "2.0.3",
             "mkdirp": "0.5.1",
-            "rimraf": "2.5.4"
+            "rimraf": "2.6.1"
           }
         },
         "fstream-npm": {
@@ -5719,7 +5940,7 @@
               "version": "1.0.5",
               "bundled": true,
               "requires": {
-                "fstream": "1.0.10",
+                "fstream": "1.0.11",
                 "inherits": "2.0.3",
                 "minimatch": "3.0.3"
               },
@@ -5756,11 +5977,11 @@
           }
         },
         "glob": {
-          "version": "7.1.0",
+          "version": "7.1.1",
           "bundled": true,
           "requires": {
             "fs.realpath": "1.0.0",
-            "inflight": "1.0.5",
+            "inflight": "1.0.6",
             "inherits": "2.0.3",
             "minimatch": "3.0.3",
             "once": "1.4.0",
@@ -5805,7 +6026,7 @@
           }
         },
         "graceful-fs": {
-          "version": "4.1.9",
+          "version": "4.1.11",
           "bundled": true
         },
         "has-unicode": {
@@ -5813,7 +6034,7 @@
           "bundled": true
         },
         "hosted-git-info": {
-          "version": "2.1.5",
+          "version": "2.4.2",
           "bundled": true
         },
         "iferr": {
@@ -5825,7 +6046,7 @@
           "bundled": true
         },
         "inflight": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true,
           "requires": {
             "once": "1.4.0",
@@ -5841,63 +6062,19 @@
           "bundled": true
         },
         "init-package-json": {
-          "version": "1.9.4",
+          "version": "1.10.1",
           "bundled": true,
           "requires": {
-            "glob": "6.0.4",
-            "npm-package-arg": "4.2.0",
+            "glob": "7.1.1",
+            "npm-package-arg": "4.2.1",
             "promzard": "0.3.0",
             "read": "1.0.7",
-            "read-package-json": "2.0.4",
+            "read-package-json": "2.0.5",
             "semver": "5.3.0",
             "validate-npm-package-license": "3.0.1",
-            "validate-npm-package-name": "2.2.2"
+            "validate-npm-package-name": "3.0.0"
           },
           "dependencies": {
-            "glob": {
-              "version": "6.0.4",
-              "bundled": true,
-              "requires": {
-                "inflight": "1.0.5",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.3",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.0"
-              },
-              "dependencies": {
-                "minimatch": {
-                  "version": "3.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "brace-expansion": "1.1.6"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.6",
-                      "bundled": true,
-                      "requires": {
-                        "balanced-match": "0.4.2",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.4.2",
-                          "bundled": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
             "promzard": {
               "version": "0.3.0",
               "bundled": true,
@@ -5907,8 +6084,12 @@
             }
           }
         },
+        "lazy-property": {
+          "version": "1.0.0",
+          "bundled": true
+        },
         "lockfile": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "bundled": true
         },
         "lodash._baseindexof": {
@@ -5972,6 +6153,163 @@
           "version": "4.4.0",
           "bundled": true
         },
+        "mississippi": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "concat-stream": "1.6.0",
+            "duplexify": "3.5.0",
+            "end-of-stream": "1.1.0",
+            "flush-write-stream": "1.0.2",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "1.0.2",
+            "pumpify": "1.3.5",
+            "stream-each": "1.2.0",
+            "through2": "2.0.3"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.6.0",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.2.9",
+                "typedarray": "0.0.6"
+              },
+              "dependencies": {
+                "typedarray": {
+                  "version": "0.0.6",
+                  "bundled": true
+                }
+              }
+            },
+            "duplexify": {
+              "version": "3.5.0",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.2.9",
+                "stream-shift": "1.0.0"
+              },
+              "dependencies": {
+                "end-of-stream": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "once": "1.3.3"
+                  },
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.3",
+                      "bundled": true,
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      }
+                    }
+                  }
+                },
+                "stream-shift": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "end-of-stream": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "once": "1.3.3"
+              },
+              "dependencies": {
+                "once": {
+                  "version": "1.3.3",
+                  "bundled": true,
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  }
+                }
+              }
+            },
+            "flush-write-stream": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.2.9"
+              }
+            },
+            "from2": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.2.9"
+              }
+            },
+            "parallel-transform": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.2.9"
+              },
+              "dependencies": {
+                "cyclist": {
+                  "version": "0.2.2",
+                  "bundled": true
+                }
+              }
+            },
+            "pump": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.1.0",
+                "once": "1.4.0"
+              }
+            },
+            "pumpify": {
+              "version": "1.3.5",
+              "bundled": true,
+              "requires": {
+                "duplexify": "3.5.0",
+                "inherits": "2.0.3",
+                "pump": "1.0.2"
+              }
+            },
+            "stream-each": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "1.1.0",
+                "stream-shift": "1.0.0"
+              },
+              "dependencies": {
+                "stream-shift": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "through2": {
+              "version": "2.0.3",
+              "bundled": true,
+              "requires": {
+                "readable-stream": "2.2.9",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "xtend": {
+                  "version": "4.0.1",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
@@ -5985,24 +6323,56 @@
             }
           }
         },
-        "node-gyp": {
-          "version": "3.4.0",
+        "move-concurrently": {
+          "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "fstream": "1.0.10",
-            "glob": "7.1.0",
-            "graceful-fs": "4.1.9",
+            "aproba": "1.1.1",
+            "copy-concurrently": "1.0.3",
+            "fs-write-stream-atomic": "1.0.10",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1",
+            "run-queue": "1.0.3"
+          },
+          "dependencies": {
+            "copy-concurrently": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "aproba": "1.1.1",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1",
+                "run-queue": "1.0.3"
+              }
+            },
+            "run-queue": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "aproba": "1.1.1"
+              }
+            }
+          }
+        },
+        "node-gyp": {
+          "version": "3.6.0",
+          "bundled": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "glob": "7.1.1",
+            "graceful-fs": "4.1.11",
             "minimatch": "3.0.3",
             "mkdirp": "0.5.1",
             "nopt": "3.0.6",
-            "npmlog": "3.1.2",
-            "osenv": "0.1.3",
-            "path-array": "1.0.1",
-            "request": "2.75.0",
-            "rimraf": "2.5.4",
+            "npmlog": "4.0.2",
+            "osenv": "0.1.4",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
             "semver": "5.3.0",
             "tar": "2.2.1",
-            "which": "1.2.11"
+            "which": "1.2.14"
           },
           "dependencies": {
             "minimatch": {
@@ -6032,188 +6402,41 @@
                 }
               }
             },
-            "npmlog": {
-              "version": "3.1.2",
+            "nopt": {
+              "version": "3.0.6",
               "bundled": true,
               "requires": {
-                "are-we-there-yet": "1.1.2",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.6.0",
-                "set-blocking": "2.0.0"
-              },
-              "dependencies": {
-                "are-we-there-yet": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "delegates": "1.0.0",
-                    "readable-stream": "2.1.5"
-                  },
-                  "dependencies": {
-                    "delegates": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "console-control-strings": {
-                  "version": "1.1.0",
-                  "bundled": true
-                },
-                "gauge": {
-                  "version": "2.6.0",
-                  "bundled": true,
-                  "requires": {
-                    "aproba": "1.0.4",
-                    "console-control-strings": "1.1.0",
-                    "has-color": "0.1.7",
-                    "has-unicode": "2.0.1",
-                    "object-assign": "4.1.0",
-                    "signal-exit": "3.0.0",
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1",
-                    "wide-align": "1.1.0"
-                  },
-                  "dependencies": {
-                    "has-color": {
-                      "version": "0.1.7",
-                      "bundled": true
-                    },
-                    "object-assign": {
-                      "version": "4.1.0",
-                      "bundled": true
-                    },
-                    "signal-exit": {
-                      "version": "3.0.0",
-                      "bundled": true
-                    },
-                    "string-width": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "code-point-at": "1.0.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      },
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "number-is-nan": "1.0.0"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "number-is-nan": "1.0.0"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "wide-align": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "string-width": "1.0.2"
-                      }
-                    }
-                  }
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "path-array": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "array-index": "1.0.0"
-              },
-              "dependencies": {
-                "array-index": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "debug": "2.2.0",
-                    "es6-symbol": "3.1.0"
-                  },
-                  "dependencies": {
-                    "debug": {
-                      "version": "2.2.0",
-                      "bundled": true,
-                      "requires": {
-                        "ms": "0.7.1"
-                      },
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.1",
-                          "bundled": true
-                        }
-                      }
-                    },
-                    "es6-symbol": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "d": "0.1.1",
-                        "es5-ext": "0.10.12"
-                      },
-                      "dependencies": {
-                        "d": {
-                          "version": "0.1.1",
-                          "bundled": true,
-                          "requires": {
-                            "es5-ext": "0.10.12"
-                          }
-                        },
-                        "es5-ext": {
-                          "version": "0.10.12",
-                          "bundled": true,
-                          "requires": {
-                            "es6-iterator": "2.0.0",
-                            "es6-symbol": "3.1.0"
-                          },
-                          "dependencies": {
-                            "es6-iterator": {
-                              "version": "2.0.0",
-                              "bundled": true,
-                              "requires": {
-                                "d": "0.1.1",
-                                "es5-ext": "0.10.12",
-                                "es6-symbol": "3.1.0"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
+                "abbrev": "1.1.0"
               }
             }
           }
         },
         "nopt": {
-          "version": "3.0.6",
+          "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          },
+          "dependencies": {
+            "osenv": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+              },
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "bundled": true
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "bundled": true
+                }
+              }
+            }
           }
         },
         "normalize-git-url": {
@@ -6221,10 +6444,10 @@
           "bundled": true
         },
         "normalize-package-data": {
-          "version": "2.3.5",
+          "version": "2.3.8",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.1.5",
+            "hosted-git-info": "2.4.2",
             "is-builtin-module": "1.0.0",
             "semver": "5.3.0",
             "validate-npm-package-license": "3.0.1"
@@ -6257,197 +6480,43 @@
           }
         },
         "npm-package-arg": {
-          "version": "4.2.0",
+          "version": "4.2.1",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.1.5",
+            "hosted-git-info": "2.4.2",
             "semver": "5.3.0"
           }
         },
         "npm-registry-client": {
-          "version": "7.2.1",
+          "version": "8.1.1",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.5.2",
-            "graceful-fs": "4.1.9",
-            "normalize-package-data": "2.3.5",
-            "npm-package-arg": "4.2.0",
-            "npmlog": "3.1.2",
+            "concat-stream": "1.6.0",
+            "graceful-fs": "4.1.11",
+            "normalize-package-data": "2.3.8",
+            "npm-package-arg": "4.2.1",
+            "npmlog": "4.0.2",
             "once": "1.4.0",
-            "request": "2.75.0",
-            "retry": "0.10.0",
+            "request": "2.81.0",
+            "retry": "0.10.1",
             "semver": "5.3.0",
             "slide": "1.1.6"
           },
           "dependencies": {
             "concat-stream": {
-              "version": "1.5.2",
+              "version": "1.6.0",
               "bundled": true,
               "requires": {
                 "inherits": "2.0.3",
-                "readable-stream": "2.0.6",
+                "readable-stream": "2.2.9",
                 "typedarray": "0.0.6"
               },
               "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "bundled": true,
-                  "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "1.0.0",
-                    "process-nextick-args": "1.0.7",
-                    "string_decoder": "0.10.31",
-                    "util-deprecate": "1.0.2"
-                  },
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "bundled": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "bundled": true
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    }
-                  }
-                },
                 "typedarray": {
                   "version": "0.0.6",
                   "bundled": true
                 }
               }
-            },
-            "npmlog": {
-              "version": "3.1.2",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "are-we-there-yet": "1.1.2",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.6.0",
-                "set-blocking": "2.0.0"
-              },
-              "dependencies": {
-                "are-we-there-yet": {
-                  "version": "1.1.2",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "delegates": "1.0.0",
-                    "readable-stream": "2.1.5"
-                  },
-                  "dependencies": {
-                    "delegates": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "optional": true
-                    }
-                  }
-                },
-                "console-control-strings": {
-                  "version": "1.1.0",
-                  "bundled": true
-                },
-                "gauge": {
-                  "version": "2.6.0",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "aproba": "1.0.4",
-                    "console-control-strings": "1.1.0",
-                    "has-color": "0.1.7",
-                    "has-unicode": "2.0.1",
-                    "object-assign": "4.1.0",
-                    "signal-exit": "3.0.0",
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1",
-                    "wide-align": "1.1.0"
-                  },
-                  "dependencies": {
-                    "has-color": {
-                      "version": "0.1.7",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "object-assign": {
-                      "version": "4.1.0",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "signal-exit": {
-                      "version": "3.0.0",
-                      "bundled": true,
-                      "optional": true
-                    },
-                    "string-width": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "code-point-at": "1.0.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      },
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "number-is-nan": "1.0.0"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "number-is-nan": "1.0.0"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "wide-align": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "optional": true,
-                      "requires": {
-                        "string-width": "1.0.2"
-                      }
-                    }
-                  }
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "retry": {
-              "version": "0.10.0",
-              "bundled": true
             }
           }
         },
@@ -6456,21 +6525,21 @@
           "bundled": true
         },
         "npmlog": {
-          "version": "4.0.0",
+          "version": "4.0.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "1.1.2",
+            "are-we-there-yet": "1.1.4",
             "console-control-strings": "1.1.0",
-            "gauge": "2.6.0",
+            "gauge": "2.7.4",
             "set-blocking": "2.0.0"
           },
           "dependencies": {
             "are-we-there-yet": {
-              "version": "1.1.2",
+              "version": "1.1.4",
               "bundled": true,
               "requires": {
                 "delegates": "1.0.0",
-                "readable-stream": "2.1.5"
+                "readable-stream": "2.2.9"
               },
               "dependencies": {
                 "delegates": {
@@ -6484,63 +6553,49 @@
               "bundled": true
             },
             "gauge": {
-              "version": "2.6.0",
+              "version": "2.7.4",
               "bundled": true,
               "requires": {
-                "aproba": "1.0.4",
+                "aproba": "1.1.1",
                 "console-control-strings": "1.1.0",
-                "has-color": "0.1.7",
                 "has-unicode": "2.0.1",
-                "object-assign": "4.1.0",
-                "signal-exit": "3.0.0",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
                 "string-width": "1.0.2",
                 "strip-ansi": "3.0.1",
                 "wide-align": "1.1.0"
               },
               "dependencies": {
-                "has-color": {
-                  "version": "0.1.7",
-                  "bundled": true
-                },
                 "object-assign": {
-                  "version": "4.1.0",
+                  "version": "4.1.1",
                   "bundled": true
                 },
                 "signal-exit": {
-                  "version": "3.0.0",
+                  "version": "3.0.2",
                   "bundled": true
                 },
                 "string-width": {
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "code-point-at": "1.0.0",
+                    "code-point-at": "1.1.0",
                     "is-fullwidth-code-point": "1.0.0",
                     "strip-ansi": "3.0.1"
                   },
                   "dependencies": {
                     "code-point-at": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "number-is-nan": "1.0.0"
-                      },
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
+                      "version": "1.1.0",
+                      "bundled": true
                     },
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "number-is-nan": "1.0.0"
+                        "number-is-nan": "1.0.1"
                       },
                       "dependencies": {
                         "number-is-nan": {
-                          "version": "1.0.0",
+                          "version": "1.0.1",
                           "bundled": true
                         }
                       }
@@ -6570,23 +6625,23 @@
           }
         },
         "opener": {
-          "version": "1.4.2",
+          "version": "1.4.3",
           "bundled": true
         },
         "osenv": {
-          "version": "0.1.3",
+          "version": "0.1.4",
           "bundled": true,
           "requires": {
-            "os-homedir": "1.0.1",
-            "os-tmpdir": "1.0.1"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           },
           "dependencies": {
             "os-homedir": {
-              "version": "1.0.1",
+              "version": "1.0.2",
               "bundled": true
             },
             "os-tmpdir": {
-              "version": "1.0.1",
+              "version": "1.0.2",
               "bundled": true
             }
           }
@@ -6612,7 +6667,7 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.9"
+            "graceful-fs": "4.1.11"
           }
         },
         "read-installed": {
@@ -6620,8 +6675,8 @@
           "bundled": true,
           "requires": {
             "debuglog": "1.0.1",
-            "graceful-fs": "4.1.9",
-            "read-package-json": "2.0.4",
+            "graceful-fs": "4.1.11",
+            "read-package-json": "2.0.5",
             "readdir-scoped-modules": "1.0.2",
             "semver": "5.3.0",
             "slide": "1.1.6",
@@ -6635,59 +6690,15 @@
           }
         },
         "read-package-json": {
-          "version": "2.0.4",
+          "version": "2.0.5",
           "bundled": true,
           "requires": {
-            "glob": "6.0.4",
-            "graceful-fs": "4.1.9",
+            "glob": "7.1.1",
+            "graceful-fs": "4.1.11",
             "json-parse-helpfulerror": "1.0.3",
-            "normalize-package-data": "2.3.5"
+            "normalize-package-data": "2.3.8"
           },
           "dependencies": {
-            "glob": {
-              "version": "6.0.4",
-              "bundled": true,
-              "requires": {
-                "inflight": "1.0.5",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.3",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.0"
-              },
-              "dependencies": {
-                "minimatch": {
-                  "version": "3.0.3",
-                  "bundled": true,
-                  "requires": {
-                    "brace-expansion": "1.1.6"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.6",
-                      "bundled": true,
-                      "requires": {
-                        "balanced-match": "0.4.2",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.4.2",
-                          "bundled": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
             "json-parse-helpfulerror": {
               "version": "1.0.3",
               "bundled": true,
@@ -6710,12 +6721,12 @@
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
             "once": "1.4.0",
-            "read-package-json": "2.0.4",
+            "read-package-json": "2.0.5",
             "readdir-scoped-modules": "1.0.2"
           }
         },
         "readable-stream": {
-          "version": "2.1.5",
+          "version": "2.2.9",
           "bundled": true,
           "requires": {
             "buffer-shims": "1.0.0",
@@ -6723,7 +6734,7 @@
             "inherits": "2.0.3",
             "isarray": "1.0.0",
             "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
+            "string_decoder": "1.0.0",
             "util-deprecate": "1.0.2"
           },
           "dependencies": {
@@ -6744,8 +6755,11 @@
               "bundled": true
             },
             "string_decoder": {
-              "version": "0.10.31",
-              "bundled": true
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "buffer-shims": "1.0.0"
+              }
             },
             "util-deprecate": {
               "version": "1.0.2",
@@ -6759,7 +6773,7 @@
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
-            "graceful-fs": "4.1.9",
+            "graceful-fs": "4.1.11",
             "once": "1.4.0"
           }
         },
@@ -6768,34 +6782,35 @@
           "bundled": true,
           "requires": {
             "dezalgo": "1.0.3",
-            "npm-package-arg": "4.2.0"
+            "npm-package-arg": "4.2.1"
           }
         },
         "request": {
-          "version": "2.75.0",
+          "version": "2.81.0",
           "bundled": true,
           "requires": {
             "aws-sign2": "0.6.0",
-            "aws4": "1.4.1",
-            "bl": "1.1.2",
-            "caseless": "0.11.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
             "combined-stream": "1.0.5",
             "extend": "3.0.0",
             "forever-agent": "0.6.1",
-            "form-data": "2.0.0",
-            "har-validator": "2.0.6",
+            "form-data": "2.1.2",
+            "har-validator": "4.2.1",
             "hawk": "3.1.3",
             "http-signature": "1.1.1",
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.12",
-            "node-uuid": "1.4.7",
+            "mime-types": "2.1.14",
             "oauth-sign": "0.8.2",
-            "qs": "6.2.1",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
             "stringstream": "0.0.5",
-            "tough-cookie": "2.3.1",
-            "tunnel-agent": "0.4.3"
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
           },
           "dependencies": {
             "aws-sign2": {
@@ -6803,54 +6818,11 @@
               "bundled": true
             },
             "aws4": {
-              "version": "1.4.1",
+              "version": "1.6.0",
               "bundled": true
             },
-            "bl": {
-              "version": "1.1.2",
-              "bundled": true,
-              "requires": {
-                "readable-stream": "2.0.6"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "bundled": true,
-                  "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "1.0.0",
-                    "process-nextick-args": "1.0.7",
-                    "string_decoder": "0.10.31",
-                    "util-deprecate": "1.0.2"
-                  },
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "bundled": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "bundled": true
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
             "caseless": {
-              "version": "0.11.0",
+              "version": "0.12.0",
               "bundled": true
             },
             "combined-stream": {
@@ -6875,12 +6847,12 @@
               "bundled": true
             },
             "form-data": {
-              "version": "2.0.0",
+              "version": "2.1.2",
               "bundled": true,
               "requires": {
                 "asynckit": "0.4.0",
                 "combined-stream": "1.0.5",
-                "mime-types": "2.1.12"
+                "mime-types": "2.1.14"
               },
               "dependencies": {
                 "asynckit": {
@@ -6890,109 +6862,43 @@
               }
             },
             "har-validator": {
-              "version": "2.0.6",
+              "version": "4.2.1",
               "bundled": true,
               "requires": {
-                "chalk": "1.1.3",
-                "commander": "2.9.0",
-                "is-my-json-valid": "2.15.0",
-                "pinkie-promise": "2.0.1"
+                "ajv": "4.11.4",
+                "har-schema": "1.0.5"
               },
               "dependencies": {
-                "chalk": {
-                  "version": "1.1.3",
+                "ajv": {
+                  "version": "4.11.4",
                   "bundled": true,
                   "requires": {
-                    "ansi-styles": "2.2.1",
-                    "escape-string-regexp": "1.0.5",
-                    "has-ansi": "2.0.0",
-                    "strip-ansi": "3.0.1",
-                    "supports-color": "2.0.0"
+                    "co": "4.6.0",
+                    "json-stable-stringify": "1.0.1"
                   },
                   "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.2.1",
+                    "co": {
+                      "version": "4.6.0",
                       "bundled": true
                     },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "bundled": true
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "requires": {
-                        "ansi-regex": "2.0.0"
-                      }
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "commander": {
-                  "version": "2.9.0",
-                  "bundled": true,
-                  "requires": {
-                    "graceful-readlink": "1.0.1"
-                  },
-                  "dependencies": {
-                    "graceful-readlink": {
+                    "json-stable-stringify": {
                       "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "is-my-json-valid": {
-                  "version": "2.15.0",
-                  "bundled": true,
-                  "requires": {
-                    "generate-function": "2.0.0",
-                    "generate-object-property": "1.2.0",
-                    "jsonpointer": "4.0.0",
-                    "xtend": "4.0.1"
-                  },
-                  "dependencies": {
-                    "generate-function": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    },
-                    "generate-object-property": {
-                      "version": "1.2.0",
                       "bundled": true,
                       "requires": {
-                        "is-property": "1.0.2"
+                        "jsonify": "0.0.0"
                       },
                       "dependencies": {
-                        "is-property": {
-                          "version": "1.0.2",
+                        "jsonify": {
+                          "version": "0.0.0",
                           "bundled": true
                         }
                       }
-                    },
-                    "jsonpointer": {
-                      "version": "4.0.0",
-                      "bundled": true
-                    },
-                    "xtend": {
-                      "version": "4.0.1",
-                      "bundled": true
                     }
                   }
                 },
-                "pinkie-promise": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "requires": {
-                    "pinkie": "2.0.4"
-                  },
-                  "dependencies": {
-                    "pinkie": {
-                      "version": "2.0.4",
-                      "bundled": true
-                    }
-                  }
+                "har-schema": {
+                  "version": "1.0.5",
+                  "bundled": true
                 }
               }
             },
@@ -7039,7 +6945,7 @@
               "requires": {
                 "assert-plus": "0.2.0",
                 "jsprim": "1.3.1",
-                "sshpk": "1.10.1"
+                "sshpk": "1.11.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -7073,18 +6979,18 @@
                   }
                 },
                 "sshpk": {
-                  "version": "1.10.1",
+                  "version": "1.11.0",
                   "bundled": true,
                   "requires": {
                     "asn1": "0.2.3",
                     "assert-plus": "1.0.0",
-                    "bcrypt-pbkdf": "1.0.0",
-                    "dashdash": "1.14.0",
+                    "bcrypt-pbkdf": "1.0.1",
+                    "dashdash": "1.14.1",
                     "ecc-jsbn": "0.1.1",
                     "getpass": "0.1.6",
                     "jodid25519": "1.0.2",
-                    "jsbn": "0.1.0",
-                    "tweetnacl": "0.14.3"
+                    "jsbn": "0.1.1",
+                    "tweetnacl": "0.14.5"
                   },
                   "dependencies": {
                     "asn1": {
@@ -7096,15 +7002,15 @@
                       "bundled": true
                     },
                     "bcrypt-pbkdf": {
-                      "version": "1.0.0",
+                      "version": "1.0.1",
                       "bundled": true,
                       "optional": true,
                       "requires": {
-                        "tweetnacl": "0.14.3"
+                        "tweetnacl": "0.14.5"
                       }
                     },
                     "dashdash": {
-                      "version": "1.14.0",
+                      "version": "1.14.1",
                       "bundled": true,
                       "requires": {
                         "assert-plus": "1.0.0"
@@ -7115,7 +7021,7 @@
                       "bundled": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "0.1.0"
+                        "jsbn": "0.1.1"
                       }
                     },
                     "getpass": {
@@ -7130,16 +7036,16 @@
                       "bundled": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "0.1.0"
+                        "jsbn": "0.1.1"
                       }
                     },
                     "jsbn": {
-                      "version": "0.1.0",
+                      "version": "0.1.1",
                       "bundled": true,
                       "optional": true
                     },
                     "tweetnacl": {
-                      "version": "0.14.3",
+                      "version": "0.14.5",
                       "bundled": true,
                       "optional": true
                     }
@@ -7160,28 +7066,32 @@
               "bundled": true
             },
             "mime-types": {
-              "version": "2.1.12",
+              "version": "2.1.14",
               "bundled": true,
               "requires": {
-                "mime-db": "1.24.0"
+                "mime-db": "1.26.0"
               },
               "dependencies": {
                 "mime-db": {
-                  "version": "1.24.0",
+                  "version": "1.26.0",
                   "bundled": true
                 }
               }
-            },
-            "node-uuid": {
-              "version": "1.4.7",
-              "bundled": true
             },
             "oauth-sign": {
               "version": "0.8.2",
               "bundled": true
             },
+            "performance-now": {
+              "version": "0.2.0",
+              "bundled": true
+            },
             "qs": {
-              "version": "6.2.1",
+              "version": "6.4.0",
+              "bundled": true
+            },
+            "safe-buffer": {
+              "version": "5.0.1",
               "bundled": true
             },
             "stringstream": {
@@ -7189,24 +7099,36 @@
               "bundled": true
             },
             "tough-cookie": {
-              "version": "2.3.1",
-              "bundled": true
+              "version": "2.3.2",
+              "bundled": true,
+              "requires": {
+                "punycode": "1.4.1"
+              },
+              "dependencies": {
+                "punycode": {
+                  "version": "1.4.1",
+                  "bundled": true
+                }
+              }
             },
             "tunnel-agent": {
-              "version": "0.4.3",
-              "bundled": true
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.0.1"
+              }
             }
           }
         },
         "retry": {
-          "version": "0.10.0",
+          "version": "0.10.1",
           "bundled": true
         },
         "rimraf": {
-          "version": "2.5.4",
+          "version": "2.6.1",
           "bundled": true,
           "requires": {
-            "glob": "7.1.0"
+            "glob": "7.1.1"
           }
         },
         "semver": {
@@ -7217,8 +7139,8 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.9",
-            "readable-stream": "2.1.5"
+            "graceful-fs": "4.1.11",
+            "readable-stream": "2.2.9"
           }
         },
         "slide": {
@@ -7229,11 +7151,59 @@
           "version": "2.0.1",
           "bundled": true
         },
+        "sorted-union-stream": {
+          "version": "2.1.3",
+          "bundled": true,
+          "requires": {
+            "from2": "1.3.0",
+            "stream-iterate": "1.1.1"
+          },
+          "dependencies": {
+            "from2": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "1.1.14"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.14",
+                  "bundled": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "bundled": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "stream-iterate": {
+              "version": "1.1.1",
+              "bundled": true
+            }
+          }
+        },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "tar": {
@@ -7241,7 +7211,7 @@
           "bundled": true,
           "requires": {
             "block-stream": "0.0.8",
-            "fstream": "1.0.10",
+            "fstream": "1.0.11",
             "inherits": "2.0.3"
           },
           "dependencies": {
@@ -7286,6 +7256,470 @@
           "version": "1.0.0",
           "bundled": true
         },
+        "update-notifier": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "boxen": "1.0.0",
+            "chalk": "1.1.3",
+            "configstore": "3.0.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.0.0",
+            "lazy-req": "2.0.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
+          },
+          "dependencies": {
+            "boxen": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-align": "1.1.0",
+                "camelcase": "4.0.0",
+                "chalk": "1.1.3",
+                "cli-boxes": "1.0.0",
+                "string-width": "2.0.0",
+                "term-size": "0.1.1",
+                "widest-line": "1.0.0"
+              },
+              "dependencies": {
+                "ansi-align": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  },
+                  "dependencies": {
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "camelcase": {
+                  "version": "4.0.0",
+                  "bundled": true
+                },
+                "cli-boxes": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "string-width": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-fullwidth-code-point": "2.0.0",
+                    "strip-ansi": "3.0.1"
+                  },
+                  "dependencies": {
+                    "is-fullwidth-code-point": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "term-size": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "execa": "0.4.0"
+                  },
+                  "dependencies": {
+                    "execa": {
+                      "version": "0.4.0",
+                      "bundled": true,
+                      "requires": {
+                        "cross-spawn-async": "2.2.5",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "1.0.0",
+                        "object-assign": "4.1.1",
+                        "path-key": "1.0.0",
+                        "strip-eof": "1.0.0"
+                      },
+                      "dependencies": {
+                        "cross-spawn-async": {
+                          "version": "2.2.5",
+                          "bundled": true,
+                          "requires": {
+                            "lru-cache": "4.0.2",
+                            "which": "1.2.14"
+                          },
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "4.0.2",
+                              "bundled": true,
+                              "requires": {
+                                "pseudomap": "1.0.2",
+                                "yallist": "2.0.0"
+                              },
+                              "dependencies": {
+                                "pseudomap": {
+                                  "version": "1.0.2",
+                                  "bundled": true
+                                },
+                                "yallist": {
+                                  "version": "2.0.0",
+                                  "bundled": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "npm-run-path": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "path-key": "1.0.0"
+                          }
+                        },
+                        "object-assign": {
+                          "version": "4.1.1",
+                          "bundled": true
+                        },
+                        "path-key": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "strip-eof": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "widest-line": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  },
+                  "dependencies": {
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "bundled": true
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "bundled": true
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "configstore": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "dot-prop": "4.1.1",
+                "graceful-fs": "4.1.11",
+                "mkdirp": "0.5.1",
+                "unique-string": "1.0.0",
+                "write-file-atomic": "1.3.3",
+                "xdg-basedir": "3.0.0"
+              },
+              "dependencies": {
+                "dot-prop": {
+                  "version": "4.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-obj": "1.0.1"
+                  },
+                  "dependencies": {
+                    "is-obj": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "unique-string": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "crypto-random-string": "1.0.0"
+                  },
+                  "dependencies": {
+                    "crypto-random-string": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "is-npm": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "latest-version": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "package-json": "3.1.0"
+              },
+              "dependencies": {
+                "package-json": {
+                  "version": "3.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "got": "6.7.1",
+                    "registry-auth-token": "3.1.0",
+                    "registry-url": "3.1.0",
+                    "semver": "5.3.0"
+                  },
+                  "dependencies": {
+                    "got": {
+                      "version": "6.7.1",
+                      "bundled": true,
+                      "requires": {
+                        "create-error-class": "3.0.2",
+                        "duplexer3": "0.1.4",
+                        "get-stream": "3.0.0",
+                        "is-redirect": "1.0.0",
+                        "is-retry-allowed": "1.1.0",
+                        "is-stream": "1.1.0",
+                        "lowercase-keys": "1.0.0",
+                        "safe-buffer": "5.0.1",
+                        "timed-out": "4.0.1",
+                        "unzip-response": "2.0.1",
+                        "url-parse-lax": "1.0.0"
+                      },
+                      "dependencies": {
+                        "create-error-class": {
+                          "version": "3.0.2",
+                          "bundled": true,
+                          "requires": {
+                            "capture-stack-trace": "1.0.0"
+                          },
+                          "dependencies": {
+                            "capture-stack-trace": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "duplexer3": {
+                          "version": "0.1.4",
+                          "bundled": true
+                        },
+                        "get-stream": {
+                          "version": "3.0.0",
+                          "bundled": true
+                        },
+                        "is-redirect": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "is-retry-allowed": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "lowercase-keys": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "safe-buffer": {
+                          "version": "5.0.1",
+                          "bundled": true
+                        },
+                        "timed-out": {
+                          "version": "4.0.1",
+                          "bundled": true
+                        },
+                        "unzip-response": {
+                          "version": "2.0.1",
+                          "bundled": true
+                        },
+                        "url-parse-lax": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "prepend-http": "1.0.4"
+                          },
+                          "dependencies": {
+                            "prepend-http": {
+                              "version": "1.0.4",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry-auth-token": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "rc": "1.1.7"
+                      },
+                      "dependencies": {
+                        "rc": {
+                          "version": "1.1.7",
+                          "bundled": true,
+                          "requires": {
+                            "deep-extend": "0.4.1",
+                            "ini": "1.3.4",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
+                          },
+                          "dependencies": {
+                            "deep-extend": {
+                              "version": "0.4.1",
+                              "bundled": true
+                            },
+                            "minimist": {
+                              "version": "1.2.0",
+                              "bundled": true
+                            },
+                            "strip-json-comments": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry-url": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "rc": "1.1.7"
+                      },
+                      "dependencies": {
+                        "rc": {
+                          "version": "1.1.7",
+                          "bundled": true,
+                          "requires": {
+                            "deep-extend": "0.4.1",
+                            "ini": "1.3.4",
+                            "minimist": "1.2.0",
+                            "strip-json-comments": "2.0.1"
+                          },
+                          "dependencies": {
+                            "deep-extend": {
+                              "version": "0.4.1",
+                              "bundled": true
+                            },
+                            "minimist": {
+                              "version": "1.2.0",
+                              "bundled": true
+                            },
+                            "strip-json-comments": {
+                              "version": "2.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lazy-req": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "semver-diff": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "semver": "5.3.0"
+              }
+            },
+            "xdg-basedir": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true
+        },
         "validate-npm-package-license": {
           "version": "3.0.1",
           "bundled": true,
@@ -7328,27 +7762,27 @@
           }
         },
         "validate-npm-package-name": {
-          "version": "2.2.2",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "builtins": "0.0.7"
+            "builtins": "1.0.3"
           },
           "dependencies": {
             "builtins": {
-              "version": "0.0.7",
+              "version": "1.0.3",
               "bundled": true
             }
           }
         },
         "which": {
-          "version": "1.2.11",
+          "version": "1.2.14",
           "bundled": true,
           "requires": {
-            "isexe": "1.1.2"
+            "isexe": "2.0.0"
           },
           "dependencies": {
             "isexe": {
-              "version": "1.1.2",
+              "version": "2.0.0",
               "bundled": true
             }
           }
@@ -7358,10 +7792,10 @@
           "bundled": true
         },
         "write-file-atomic": {
-          "version": "1.2.0",
+          "version": "1.3.3",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.9",
+            "graceful-fs": "4.1.11",
             "imurmurhash": "0.1.4",
             "slide": "1.1.6"
           }
@@ -7369,21 +7803,20 @@
       }
     },
     "npm-path": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
-      "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
+      "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
       "dev": true,
       "requires": {
         "which": "1.3.0"
       }
     },
     "npm-run-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-      "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-      "dev": true,
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "1.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npm-which": {
@@ -7392,15 +7825,15 @@
       "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
       "dev": true,
       "requires": {
-        "commander": "2.12.2",
-        "npm-path": "2.0.3",
+        "commander": "2.13.0",
+        "npm-path": "2.0.4",
         "which": "1.3.0"
       },
       "dependencies": {
         "commander": {
-          "version": "2.12.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
           "dev": true
         }
       }
@@ -7470,9 +7903,12 @@
       "dev": true
     },
     "onetime": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
     },
     "optimist": {
       "version": "0.6.1",
@@ -7515,33 +7951,115 @@
       }
     },
     "ora": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-0.3.0.tgz",
-      "integrity": "sha1-NnoHitJc+wltpQERXrW0AeB9dJU=",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+      "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "cli-cursor": "1.0.2",
-        "cli-spinners": "0.2.0",
-        "log-symbols": "1.0.2"
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "requires": {
-        "lcid": "1.0.0"
+        "execa": "0.7.0",
+        "lcid": "1.0.0",
+        "mem": "1.1.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        }
       }
-    },
-    "os-shim": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc="
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -7552,6 +8070,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "dev": true,
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
@@ -7560,22 +8079,22 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "requires": {
+        "p-try": "1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "1.2.0"
       }
     },
     "p-map": {
@@ -7584,15 +8103,20 @@
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
     },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+    },
     "package-json": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
-      "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "requires": {
-        "got": "5.7.1",
+        "got": "6.7.1",
         "registry-auth-token": "3.3.1",
         "registry-url": "3.1.0",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "pako": {
@@ -7657,12 +8181,9 @@
       "dev": true
     },
     "path-exists": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "requires": {
-        "pinkie-promise": "2.0.1"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -7672,14 +8193,12 @@
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
     "path-key": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-      "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.5",
@@ -7697,10 +8216,19 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "pathval": {
@@ -7721,9 +8249,9 @@
       "integrity": "sha1-FggOlwqud5kTdWwtrviOqnSG30E="
     },
     "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -7750,17 +8278,17 @@
       }
     },
     "pkg-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "2.1.0"
       }
     },
     "platform": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.4.tgz",
-      "integrity": "sha1-bw+xftqqSPIUQrOpdcBjEw8cPr0=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
       "dev": true
     },
     "pleeease-filters": {
@@ -7773,19 +8301,55 @@
         "postcss": "5.2.18"
       }
     },
-    "popsicle": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-8.2.0.tgz",
-      "integrity": "sha1-/0QBAFyrQ6lBipFBBhHAAZdxLSE=",
+    "plugin-error": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+      "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+      "dev": true,
       "requires": {
-        "any-promise": "1.3.0",
-        "arrify": "1.0.1",
+        "ansi-cyan": "0.1.1",
+        "ansi-red": "0.1.1",
+        "arr-diff": "1.1.0",
+        "arr-union": "2.1.0",
+        "extend-shallow": "1.1.4"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
+          }
+        },
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "dev": true,
+          "requires": {
+            "kind-of": "1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
+        }
+      }
+    },
+    "popsicle": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-9.2.0.tgz",
+      "integrity": "sha512-petRj39w05GvH1WKuGFmzxR9+k+R9E7zX5XWTFee7P/qf88hMuLT7aAO/RsmldpQMtJsWQISkTQlfMRECKlxhw==",
+      "requires": {
         "concat-stream": "1.6.0",
         "form-data": "2.3.1",
         "make-error-cause": "1.2.2",
-        "throwback": "1.1.1",
-        "tough-cookie": "2.3.3",
-        "xtend": "4.0.1"
+        "tough-cookie": "2.3.3"
       }
     },
     "popsicle-proxy-agent": {
@@ -7823,11 +8387,59 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "js-base64": "2.4.0",
+        "js-base64": "2.4.2",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
@@ -8043,6 +8655,48 @@
         "postcss-replace-overflow-wrap": "1.0.0",
         "postcss-selector-matches": "2.0.5",
         "postcss-selector-not": "2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "postcss-custom-media": {
@@ -8173,45 +8827,19 @@
       "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14",
+        "postcss": "6.0.16",
         "postcss-media-query-parser": "0.2.3"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -8221,9 +8849,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -8372,44 +9000,18 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14"
+        "postcss": "6.0.16"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -8419,9 +9021,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -8436,44 +9038,18 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.16"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -8483,9 +9059,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -8500,44 +9076,18 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.16"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -8547,9 +9097,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -8564,44 +9114,18 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.16"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -8611,9 +9135,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -8850,23 +9374,6 @@
       "requires": {
         "ansi-regex": "3.0.0",
         "ansi-styles": "3.2.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        }
       }
     },
     "process-nextick-args": {
@@ -8898,12 +9405,9 @@
       }
     },
     "promise-finally": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/promise-finally/-/promise-finally-2.2.1.tgz",
-      "integrity": "sha1-ImFsS6kCkW6Yi9RsVNfKoIkQzXc=",
-      "requires": {
-        "any-promise": "1.3.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/promise-finally/-/promise-finally-3.0.0.tgz",
+      "integrity": "sha1-3dXQ+JVDKxIGzrjaEnUGTRjnqiM="
     },
     "proxy-addr": {
       "version": "1.1.5",
@@ -9020,23 +9524,14 @@
       }
     },
     "rc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.4.tgz",
+      "integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
       "requires": {
         "deep-extend": "0.4.2",
         "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
-      }
-    },
-    "read-all-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
-      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-      "requires": {
-        "pinkie-promise": "2.0.1",
-        "readable-stream": "2.3.3"
       }
     },
     "read-cache": {
@@ -9046,12 +9541,21 @@
       "dev": true,
       "requires": {
         "pify": "2.3.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
       "requires": {
         "load-json-file": "1.1.0",
         "normalize-package-data": "2.4.0",
@@ -9062,9 +9566,31 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
       "requires": {
         "find-up": "1.1.2",
         "read-pkg": "1.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        }
       }
     },
     "readable-stream": {
@@ -9196,9 +9722,9 @@
       "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "regex-cache": {
@@ -9226,7 +9752,7 @@
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "requires": {
-        "rc": "1.2.2",
+        "rc": "1.2.4",
         "safe-buffer": "5.1.1"
       }
     },
@@ -9235,7 +9761,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "requires": {
-        "rc": "1.2.2"
+        "rc": "1.2.4"
       }
     },
     "regjsgen": {
@@ -9262,17 +9788,25 @@
       }
     },
     "remap-istanbul": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.9.5.tgz",
-      "integrity": "sha1-oYYXsfMe7Fp9vud1OCmLd1YGqqg=",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.10.1.tgz",
+      "integrity": "sha512-gsNQXs5kJLhErICSyYhzVZ++C8LBW8dgwr874Y2QvzAUS75zBlD/juZgXs39nbYJ09fZDlX2AVLVJAY2jbFJoQ==",
       "dev": true,
       "requires": {
         "amdefine": "1.0.1",
-        "gulp-util": "3.0.7",
         "istanbul": "0.4.5",
         "minimatch": "3.0.4",
-        "source-map": "0.5.7",
+        "plugin-error": "0.1.2",
+        "source-map": "0.6.1",
         "through2": "2.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "remove-trailing-separator": {
@@ -9297,15 +9831,10 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
       "requires": {
         "is-finite": "1.0.2"
       }
-    },
-    "replace-ext": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-      "dev": true
     },
     "request": {
       "version": "2.42.0",
@@ -9403,12 +9932,12 @@
       "dev": true
     },
     "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "resumer": {
@@ -9458,10 +9987,18 @@
         "is-promise": "2.1.0"
       }
     },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
     },
     "rxjs": {
       "version": "5.5.6",
@@ -9486,9 +10023,9 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "samsam": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
     "sax": {
@@ -9507,16 +10044,16 @@
       }
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "semver-diff": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "send": {
@@ -9526,9 +10063,9 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
         "fresh": "0.5.2",
@@ -9550,6 +10087,14 @@
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
             "statuses": "1.3.1"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+              "dev": true
+            }
           }
         },
         "mime": {
@@ -9572,7 +10117,7 @@
       "integrity": "sha1-uXN3P2NEmTTaVOW+ul4x2fQhFXc=",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
         "send": "0.15.6"
@@ -9599,7 +10144,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "1.0.0"
       }
@@ -9607,8 +10151,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shell-quote": {
       "version": "1.6.1",
@@ -9642,19 +10185,38 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
-      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.2.1.tgz",
+      "integrity": "sha512-lx9ZCoScNhvs6+n3ku78CqIpQNIiY9gLfvuIdhZjnKOkcVL6FfWfA1jkOrcO+n3mX4BIg2XwQnyCS/Ive21QMw==",
       "dev": true,
       "requires": {
-        "formatio": "1.1.1",
-        "lolex": "1.3.2",
-        "samsam": "1.1.2",
-        "util": "0.10.3"
+        "diff": "3.4.0",
+        "formatio": "1.2.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.1",
+        "nise": "1.2.0",
+        "supports-color": "5.1.0",
+        "type-detect": "4.0.7"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "sinon-as-promised": {
@@ -9676,7 +10238,8 @@
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
     },
     "sntp": {
       "version": "0.2.4",
@@ -9702,25 +10265,11 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
-    "sparkles": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
-      "dev": true
-    },
-    "spawn-sync": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-      "requires": {
-        "concat-stream": "1.6.0",
-        "os-shim": "0.1.3"
-      }
-    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "dev": true,
       "requires": {
         "spdx-license-ids": "1.2.2"
       }
@@ -9728,12 +10277,14 @@
     "spdx-expression-parse": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+      "dev": true
     },
     "spdx-license-ids": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
     },
     "split": {
       "version": "0.2.10",
@@ -9798,13 +10349,12 @@
       "integrity": "sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y="
     },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       }
     },
     "string_decoder": {
@@ -9834,20 +10384,17 @@
       "optional": true
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "3.0.0"
       }
     },
     "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "requires": {
-        "is-utf8": "0.2.1"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-dirs": {
       "version": "2.1.0",
@@ -9861,8 +10408,7 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-indent": {
       "version": "1.0.1",
@@ -9879,9 +10425,12 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+      "requires": {
+        "has-flag": "2.0.0"
+      }
     },
     "svgo": {
       "version": "0.7.2",
@@ -9945,7 +10494,7 @@
       "dev": true,
       "requires": {
         "bl": "1.2.1",
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "readable-stream": "2.3.3",
         "xtend": "4.0.1"
       },
@@ -9965,27 +10514,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "dev": true,
       "requires": {
         "execa": "0.7.0"
       },
       "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
-          }
-        },
         "execa": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "dev": true,
           "requires": {
             "cross-spawn": "5.1.0",
             "get-stream": "3.0.0",
@@ -9995,29 +10531,14 @@
             "signal-exit": "3.0.2",
             "strip-eof": "1.0.0"
           }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "2.0.1"
-          }
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-          "dev": true
         }
       }
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "thenify": {
       "version": "3.3.0",
@@ -10073,27 +10594,22 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/throwback/-/throwback-1.1.1.tgz",
       "integrity": "sha1-8AfnwXYEptFtegfEGqDo/txhhKQ=",
+      "dev": true,
       "requires": {
         "any-promise": "1.3.0"
       }
     },
-    "time-stamp": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-      "dev": true
-    },
     "timed-out": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
-      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "timers-ext": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
       "integrity": "sha1-YcxHp2wavTGV8UUn+XjViulMUgQ=",
       "requires": {
-        "es5-ext": "0.10.37",
+        "es5-ext": "0.10.38",
         "next-tick": "1.0.0"
       }
     },
@@ -10106,7 +10622,7 @@
         "body-parser": "1.14.2",
         "debug": "2.2.0",
         "faye-websocket": "0.10.0",
-        "livereload-js": "2.2.2",
+        "livereload-js": "2.3.0",
         "parseurl": "1.3.2",
         "qs": "5.1.0"
       },
@@ -10135,9 +10651,9 @@
       }
     },
     "tmp": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-      "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
         "os-tmpdir": "1.0.2"
       }
@@ -10177,9 +10693,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-      "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg=="
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
     },
     "tslint": {
       "version": "5.2.0",
@@ -10194,8 +10710,8 @@
         "glob": "7.1.2",
         "optimist": "0.6.1",
         "resolve": "1.5.0",
-        "semver": "5.4.1",
-        "tslib": "1.8.0",
+        "semver": "5.5.0",
+        "tslib": "1.8.1",
         "tsutils": "1.9.1"
       },
       "dependencies": {
@@ -10222,16 +10738,6 @@
         }
       }
     },
-    "tslint-plugin-prettier": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
-      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
-      "dev": true,
-      "requires": {
-        "eslint-plugin-prettier": "2.4.0",
-        "tslib": "1.8.0"
-      }
-    },
     "tsutils": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-1.9.1.tgz",
@@ -10254,9 +10760,9 @@
       }
     },
     "type-detect": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.7.tgz",
+      "integrity": "sha512-4Rh17pAMVdMWzktddFhISRnUnFIStObtUMNGzDwlA6w/77bmGv3aBbRdCmQR6IjzfkTo9otnW+2K/cDRhKSxDA==",
       "dev": true
     },
     "type-is": {
@@ -10286,42 +10792,16 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
         },
         "async-each": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
           "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
           "dev": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
         },
         "chokidar": {
           "version": "1.7.0",
@@ -10340,39 +10820,28 @@
             "readdirp": "2.1.0"
           }
         },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
-          }
-        },
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
           }
         },
         "fsevents": {
@@ -11279,12 +11748,6 @@
             }
           }
         },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
         "glob-parent": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
@@ -11294,17 +11757,14 @@
             "is-glob": "2.0.1"
           }
         },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "is-glob": {
           "version": "2.0.1",
@@ -11327,32 +11787,6 @@
             "strip-bom": "3.0.0"
           }
         },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "2.0.1"
-          }
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
-          }
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-          "dev": true
-        },
         "path-type": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
@@ -11361,6 +11795,12 @@
           "requires": {
             "pify": "2.3.0"
           }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
         },
         "read-pkg": {
           "version": "2.0.0",
@@ -11395,45 +11835,14 @@
             "set-immediate-shim": "1.0.1"
           }
         },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "2.1.1"
           }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
         },
         "yargs": {
           "version": "8.0.2",
@@ -11481,7 +11890,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.87",
+        "@types/lodash": "4.14.96",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",
@@ -11489,7 +11898,7 @@
         "handlebars": "4.0.5",
         "highlight.js": "9.12.0",
         "lodash": "4.17.4",
-        "marked": "0.3.7",
+        "marked": "0.3.12",
         "minimatch": "3.0.4",
         "progress": "1.1.8",
         "shelljs": "0.7.8",
@@ -11503,7 +11912,7 @@
           "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
           "dev": true,
           "requires": {
-            "@types/node": "6.0.92"
+            "@types/node": "8.5.9"
           }
         },
         "@types/minimatch": {
@@ -11540,6 +11949,15 @@
             "uglify-js": "2.8.29"
           }
         },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
@@ -11569,52 +11987,42 @@
       "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
     },
     "typings-core": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/typings-core/-/typings-core-1.6.1.tgz",
-      "integrity": "sha1-zkspMeovGbuPPay+xpmDrE6WSjc=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/typings-core/-/typings-core-2.3.3.tgz",
+      "integrity": "sha1-CexUzVsR3V8e8vwKsx03ACyita0=",
       "requires": {
-        "any-promise": "1.3.0",
         "array-uniq": "1.0.3",
-        "configstore": "2.1.0",
+        "configstore": "3.1.1",
         "debug": "2.6.9",
-        "detect-indent": "4.0.0",
+        "detect-indent": "5.0.0",
         "graceful-fs": "4.1.11",
         "has": "1.0.1",
         "invariant": "2.2.2",
         "is-absolute": "0.2.6",
+        "jspm-config": "0.3.4",
         "listify": "1.0.0",
         "lockfile": "1.0.3",
         "make-error-cause": "1.2.2",
         "mkdirp": "0.5.1",
         "object.pick": "1.3.0",
         "parse-json": "2.2.0",
-        "popsicle": "8.2.0",
+        "popsicle": "9.2.0",
         "popsicle-proxy-agent": "3.0.0",
         "popsicle-retry": "3.2.1",
         "popsicle-rewrite": "1.0.0",
         "popsicle-status": "2.0.1",
-        "promise-finally": "2.2.1",
-        "rc": "1.2.2",
+        "promise-finally": "3.0.0",
+        "rc": "1.2.4",
         "rimraf": "2.6.2",
         "sort-keys": "1.1.2",
         "string-template": "1.0.0",
-        "strip-bom": "2.0.0",
+        "strip-bom": "3.0.0",
         "thenify": "3.3.0",
         "throat": "3.2.0",
         "touch": "1.0.0",
         "typescript": "2.6.2",
         "xtend": "4.0.1",
         "zip-object": "0.1.0"
-      },
-      "dependencies": {
-        "detect-indent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-          "requires": {
-            "repeating": "2.0.1"
-          }
-        }
       }
     },
     "uglify-js": {
@@ -11647,13 +12055,6 @@
             "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           }
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-          "dev": true,
-          "optional": true
         },
         "wordwrap": {
           "version": "0.0.2",
@@ -11754,7 +12155,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "dev": true,
       "requires": {
         "crypto-random-string": "1.0.0"
       }
@@ -11769,6 +12169,11 @@
         "viewport-dimensions": "0.2.0"
       }
     },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -11776,23 +12181,24 @@
       "dev": true
     },
     "unzip-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
     },
     "update-notifier": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
-      "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
+      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
       "requires": {
-        "boxen": "0.6.0",
-        "chalk": "1.1.3",
-        "configstore": "2.1.0",
+        "boxen": "1.3.0",
+        "chalk": "2.3.0",
+        "configstore": "3.1.1",
+        "import-lazy": "2.1.0",
+        "is-installed-globally": "0.1.0",
         "is-npm": "1.0.0",
-        "latest-version": "2.0.0",
-        "lazy-req": "1.1.0",
+        "latest-version": "3.1.0",
         "semver-diff": "2.1.0",
-        "xdg-basedir": "2.0.0"
+        "xdg-basedir": "3.0.0"
       }
     },
     "url-parse-lax": {
@@ -11812,23 +12218,6 @@
         "tape": "2.3.0"
       }
     },
-    "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
-        }
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -11843,12 +12232,14 @@
     "uuid": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "dev": true,
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
@@ -11871,17 +12262,6 @@
       "resolved": "https://registry.npmjs.org/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz",
       "integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w=",
       "dev": true
-    },
-    "vinyl": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-      "dev": true,
-      "requires": {
-        "clone": "1.0.3",
-        "clone-stats": "0.0.1",
-        "replace-ext": "0.0.1"
-      }
     },
     "websocket-driver": {
       "version": "0.7.0",
@@ -11914,22 +12294,24 @@
       }
     },
     "which-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "widest-line": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
-      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "2.1.1"
       }
     },
     "window-size": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
     },
     "wordwrap": {
       "version": "0.0.3",
@@ -11944,6 +12326,39 @@
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        }
       }
     },
     "wrappy": {
@@ -11952,13 +12367,13 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "requires": {
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
+        "signal-exit": "3.0.2"
       }
     },
     "ws": {
@@ -11980,12 +12395,9 @@
       }
     },
     "xdg-basedir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-      "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
     },
     "xml2js": {
       "version": "0.4.19",
@@ -12019,40 +12431,30 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz",
-      "integrity": "sha1-M1UUSXfQV1fbuG1uOOwFYSOzpm4=",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+      "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
       "requires": {
-        "cliui": "3.2.0",
+        "cliui": "4.0.0",
         "decamelize": "1.2.0",
+        "find-up": "2.1.0",
         "get-caller-file": "1.0.2",
-        "lodash.assign": "4.2.0",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
+        "os-locale": "2.1.0",
         "require-directory": "2.1.1",
         "require-main-filename": "1.0.1",
         "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "window-size": "0.2.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
         "y18n": "3.2.1",
-        "yargs-parser": "3.2.0"
+        "yargs-parser": "8.1.0"
       }
     },
     "yargs-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz",
-      "integrity": "sha1-UIE1XRnZ0MjF2BrakIy05tGGZk8=",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+      "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
       "requires": {
-        "camelcase": "3.0.0",
-        "lodash.assign": "4.2.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-        }
+        "camelcase": "4.1.0"
       }
     },
     "yauzl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1740,16 +1740,6 @@
         "capture-stack-trace": "1.0.0"
       }
     },
-    "create-thenable": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/create-thenable/-/create-thenable-1.0.2.tgz",
-      "integrity": "sha1-4gMXIMzJV12M+jH1wUbnYqgMBTQ=",
-      "dev": true,
-      "requires": {
-        "object.omit": "2.0.1",
-        "unique-concat": "0.2.2"
-      }
-    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -5560,12 +5550,6 @@
       "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
       "dev": true,
       "optional": true
-    },
-    "native-promise-only": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
-      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
-      "dev": true
     },
     "ncp": {
       "version": "0.5.1",
@@ -10219,16 +10203,6 @@
         }
       }
     },
-    "sinon-as-promised": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/sinon-as-promised/-/sinon-as-promised-4.0.3.tgz",
-      "integrity": "sha1-wFRbFoX9gTWIpO1pcBJIftEdFRs=",
-      "dev": true,
-      "requires": {
-        "create-thenable": "1.0.2",
-        "native-promise-only": "0.8.1"
-      }
-    },
     "slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
@@ -12143,12 +12117,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
-      "dev": true
-    },
-    "unique-concat": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/unique-concat/-/unique-concat-0.2.2.tgz",
-      "integrity": "sha1-khD5vcqsxeHjkpSQ18AZ35bxhxI=",
       "dev": true
     },
     "unique-string": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,37 +1,39 @@
 {
   "name": "@dojo/cli",
-  "version": "0.5.1-pre",
+  "version": "0.4.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@dojo/core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@dojo/core/-/core-0.3.1.tgz",
-      "integrity": "sha512-PEwqxpsuTTG0b2wwy0TLHEFf/R6ZBE4zizo4EXzGUVRc5O44w5Hbn+NN48v/o8hwQRKxmX3ywLI0Z1CMZ6NM6w==",
+    "@dojo/cli-create-app": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@dojo/cli-create-app/-/cli-create-app-0.3.0.tgz",
+      "integrity": "sha512-XHxFjZcAVH3eVSJIuaIhOolHWJer8XI7cZiy4/sORAYq0/rdqPPmskttPWAIVK9EJbJ62rzRRDP5268KtBSnkQ==",
       "requires": {
-        "tslib": "1.8.1"
+        "chalk": "1.1.3",
+        "cross-spawn": "4.0.2",
+        "ejs": "2.5.7",
+        "fs-extra": "0.30.0",
+        "ora": "0.3.0",
+        "pkg-dir": "1.0.0"
       }
     },
+    "@dojo/core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@dojo/core/-/core-0.3.0.tgz",
+      "integrity": "sha512-SnmiQcbPUqtjzy1sOmkLvg3C6UFUaXDNUNqHzGaF2QM1Ebp1Lw+j+BE+E6uJgxISlgckjAZ6myjwFI+obZ316w=="
+    },
     "@dojo/has": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@dojo/has/-/has-0.1.2.tgz",
-      "integrity": "sha512-122xXU9xHjG/EayITIAiIdKVphZTZ2wM9IEBArarkBQzXZP1shGAbTJq7NHWUoTemw48tvTxr+OOi7wVCm7IXg=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@dojo/has/-/has-0.1.1.tgz",
+      "integrity": "sha512-McwwBLpM0R0zsIy0+1WkHFXYYNalMOPJydqW3dd089K+AaOCto4AtFKA6+GDEuXDgJE9cMG5tX48hFwIL3dtxQ=="
     },
     "@dojo/interfaces": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.1.tgz",
-      "integrity": "sha512-/bIJJb9q02MxSlfA9G3n6AMTlD80fDx7qDRss/8HxeJ26ix/F/tCnX521c3XrWm/HOBEWp7GiRX5E0hQdIuCNw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.0.tgz",
+      "integrity": "sha512-sgqHsKraTjKDoLfWece/E/ip29CsV3z+vEDSIzuBSWtXDEau6/pDRhbhuSnxjBB1bvvB8Drn93xWkO+PqqQ0Dg==",
       "dev": true,
       "requires": {
-        "@types/yargs": "8.0.3"
-      },
-      "dependencies": {
-        "@types/yargs": {
-          "version": "8.0.3",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.3.tgz",
-          "integrity": "sha512-YdxO7zGQf2qJeMgR0fNO8QTlj88L2zCP5GOddovoTyetgLiNDOUXcWzhWKb4EdZZlOjLQUA0JM8lW7VcKQL+9w==",
-          "dev": true
-        }
+        "@types/yargs": "8.0.2"
       }
     },
     "@dojo/loader": {
@@ -41,13 +43,13 @@
       "dev": true
     },
     "@dojo/shim": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.5.tgz",
-      "integrity": "sha512-RhUPwaMmxWRTTKA3rO5gwRwRvoyVZNRsZMsQof852AwZq2bReUOYy4K9Ed6wF5SKQrJngVxNxiaGFddaZLLwSg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.3.tgz",
+      "integrity": "sha512-DzpD1D90D1vsHuqPqGb78JFfykf0Nvbel+iAupYVPEwq+LVxAZPDC8nGZRsAaVfWSsFLuKPcbRRIInf+emCFAw==",
       "requires": {
         "intersection-observer": "0.4.3",
         "pepjs": "0.4.3",
-        "tslib": "1.8.1"
+        "tslib": "1.8.0"
       }
     },
     "@theintern/digdug": {
@@ -56,21 +58,13 @@
       "integrity": "sha512-BTcYNMxOnGlTEaOYqab9WygE2sLz9ZRWRsuTwUttceewzEDn/Ok/4lWdIgwwX+bb3MybvFPU1wBkq8Co+Bfqyw==",
       "dev": true,
       "requires": {
-        "@dojo/core": "0.3.1",
-        "@dojo/has": "0.1.2",
-        "@dojo/interfaces": "0.2.1",
-        "@dojo/shim": "0.2.5",
+        "@dojo/core": "0.3.0",
+        "@dojo/has": "0.1.1",
+        "@dojo/interfaces": "0.2.0",
+        "@dojo/shim": "0.2.3",
         "decompress": "4.2.0",
         "semver": "5.4.1",
-        "tslib": "1.8.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
-        }
+        "tslib": "1.8.0"
       }
     },
     "@theintern/leadfoot": {
@@ -79,19 +73,19 @@
       "integrity": "sha512-J9wLAMjAU+Wyv5jGmHdVN4xnuyaD24kK7mAoLUPBLRNxflkJoTo9Ph5g4BKUHp+xpKd/IMU00ulgMMf++Xqm4A==",
       "dev": true,
       "requires": {
-        "@dojo/core": "0.3.1",
-        "@dojo/has": "0.1.2",
-        "@dojo/interfaces": "0.2.1",
-        "@dojo/shim": "0.2.5",
+        "@dojo/core": "0.3.0",
+        "@dojo/has": "0.1.1",
+        "@dojo/interfaces": "0.2.0",
+        "@dojo/shim": "0.2.3",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.5",
-        "tslib": "1.8.1"
+        "tslib": "1.8.0"
       }
     },
     "@types/babel-types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.0.tgz",
-      "integrity": "sha512-PyWcbX0W4r4GcgXLI0Vu4jyJ/Erueo3PwjgvQcOmWAOBW0ObhzBBciEX+sHvjkNE0umI6nqD192FDKvYZTL91A==",
+      "version": "6.25.2",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
+      "integrity": "sha512-+3bMuktcY4a70a0KZc8aPJlEOArPuAKQYHU5ErjkOqGJdx8xuEEVK6nWogqigBOJ8nKPxRpyCUDTCPmZ3bUxGA==",
       "dev": true
     },
     "@types/benchmark": {
@@ -107,13 +101,19 @@
       "dev": true,
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "8.5.9"
+        "@types/node": "6.0.92"
       }
     },
     "@types/chai": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.10.tgz",
-      "integrity": "sha512-Ejh1AXTY8lm+x91X/yar3G2z4x9RyKwdTVdyyu7Xj3dNB35fMNCnEWqTO9FgS3zjzlRNqk1MruYhgb8yhRN9rA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
+      "integrity": "sha512-m812CONwdZn/dMzkIJEY0yAs4apyTkTORgfB2UsMOxgkUbC205AHnm4T8I0I5gPg9MHrFc1dJ35iS75c0CJkjg==",
+      "dev": true
+    },
+    "@types/chalk": {
+      "version": "0.4.31",
+      "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
+      "integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk=",
       "dev": true
     },
     "@types/charm": {
@@ -122,14 +122,8 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.9"
+        "@types/node": "6.0.92"
       }
-    },
-    "@types/configstore": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-2.1.1.tgz",
-      "integrity": "sha1-zR6FU2M60xhcPy8jns/10mQ+krY=",
-      "dev": true
     },
     "@types/detect-indent": {
       "version": "5.0.0",
@@ -143,27 +137,6 @@
       "integrity": "sha512-q3zfJvaTroV5BjAAR+peTHEGAAhGrPX0z2EzCzpt2mwFA+qzUn2nigJLqSekXRtdULKmT8am7zjvTMZSapIgHw==",
       "dev": true
     },
-    "@types/ejs": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-2.5.0.tgz",
-      "integrity": "sha512-mm6fwe7oF2ltOovvKf4ulneGAERJJOo4BFgp5cKDG194byeFOdTpB8Tsuqa9MGJeNydd/D5eh4vmYFOYylR8Rw==",
-      "dev": true
-    },
-    "@types/events": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
-      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
-      "dev": true
-    },
-    "@types/execa": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@types/execa/-/execa-0.8.1.tgz",
-      "integrity": "sha512-7dsoPp7r33mdPcxukSrs9WVQgI96fiqffC7K4XvXJnSrTtJov3x1CJUgid7msJ8yCbfkmXJoKJ3HXyQIwZD0NQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "8.5.9"
-      }
-    },
     "@types/express": {
       "version": "4.0.39",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.39.tgz",
@@ -171,37 +144,36 @@
       "dev": true,
       "requires": {
         "@types/body-parser": "1.16.8",
-        "@types/express-serve-static-core": "4.11.0",
+        "@types/express-serve-static-core": "4.0.57",
         "@types/serve-static": "1.13.1"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.0.tgz",
-      "integrity": "sha512-hOi1QNb+4G+UjDt6CEJ6MjXHy+XceY7AxIa28U9HgJ80C+3gIbj7h5dJNxOI7PU3DO1LIhGP5Bs47Dbf5l8+MA==",
+      "version": "4.0.57",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.57.tgz",
+      "integrity": "sha512-QLAHjdLwEICm3thVbXSKRoisjfgMVI4xJH/HU8F385BR2HI7PmM6ax4ELXf8Du6sLmSpySXMYaI+xc//oQ/IFw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.9"
+        "@types/node": "6.0.92"
       }
     },
     "@types/fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-qtxDULQKUenuaDLW003CgC+0T0eiAfH3BrH+vSt87GLzbz5EZ6Ox6mv9rMttvhDOatbb9nYh0E1m7ydoYwUrAg==",
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-0.0.34.tgz",
+      "integrity": "sha1-Tv8v9bBqWjv8VErdOm7TTN+JIzU=",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.9"
+        "@types/node": "6.0.92"
       }
     },
     "@types/glob": {
-      "version": "5.0.34",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.34.tgz",
-      "integrity": "sha512-sUvpieq+HsWTLdkeOI8Mi8u22Ag3AoGuM3sv+XMP1bKtbaIAHpEA2f52K2mz6vK5PVhTa3bFyRZLZMqTxOo2Cw==",
+      "version": "5.0.33",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
+      "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
       "dev": true,
       "requires": {
-        "@types/events": "1.1.0",
-        "@types/minimatch": "3.0.3",
-        "@types/node": "8.5.9"
+        "@types/minimatch": "3.0.1",
+        "@types/node": "6.0.92"
       }
     },
     "@types/globby": {
@@ -210,7 +182,7 @@
       "integrity": "sha512-EZellBZNOrvIre0bkGJdx+uDohIU8ICMsz8DCtxxJOPhP+R4uOREmHk9rbKlKaVGM/ol552yzZYKvzLEhz148g==",
       "dev": true,
       "requires": {
-        "@types/glob": "5.0.34"
+        "@types/glob": "5.0.33"
       }
     },
     "@types/grunt": {
@@ -219,7 +191,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.9"
+        "@types/node": "6.0.92"
       }
     },
     "@types/handlebars": {
@@ -241,9 +213,9 @@
       "dev": true
     },
     "@types/inquirer": {
-      "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.36.tgz",
-      "integrity": "sha512-fbqtdP4EOpbWaN+MtGArjo6CSVbPOzNtu8g6wporjg3pdk7cAq8opK4yKfP0gWLoVkbCIT1e/rSVbpYlV8FNrg==",
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.32.tgz",
+      "integrity": "sha1-pKCOg3QcUAp8PI53dgFPf4plhw0=",
       "dev": true,
       "requires": {
         "@types/rx": "4.1.1",
@@ -263,22 +235,14 @@
       "dev": true
     },
     "@types/istanbul-lib-instrument": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz",
-      "integrity": "sha512-Ll2qAzv7NItqVliZZ8OMAgAvGstddK2995/7X5YPU84lD3CFnqDfP4sTu5Q1GKReh5Ttw3shKR2e3Fe6Xo0C7A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.0.tgz",
+      "integrity": "sha512-BWj7zRtwVU5KzuYL/zNuVoSvYWIpT02smNMpQwQbJjwEyITEGSKsxVIT4b2bzXCWFMq76ss0sdY/5yw3NwTlIA==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "7.0.0",
+        "@types/babel-types": "6.25.2",
         "@types/istanbul-lib-coverage": "1.1.0",
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
+        "@types/source-map": "0.1.29"
       }
     },
     "@types/istanbul-lib-report": {
@@ -291,21 +255,13 @@
       }
     },
     "@types/istanbul-lib-source-maps": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
-      "integrity": "sha512-K0IvmTFbI2GjLG0O4AOLPV2hFItE5Bg/TY41IBZIThhLhYthJc3VjpZpM8/sIaIVtnQcX8b2k3muPDvsvhk+Fg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.0.tgz",
+      "integrity": "sha512-GxjyOSIZC/HETEo61MOjM72qdZH0F9UwfuXCKhmgqhVC7PSjE61BU2I/2eZwQ43+kSdkxKvnOBqqNZi1HHHNEA==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "1.1.0",
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
+        "@types/source-map": "0.1.29"
       }
     },
     "@types/istanbul-reports": {
@@ -325,9 +281,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.93",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.93.tgz",
-      "integrity": "sha512-xI9Il9Fqxse5hSh6bVwowEC5RXyEVJ2hssRJXANU70H/+NlirvsNi87JjvGMxtn6yTemyUPkkzSl9SCKFW4U3g==",
+      "version": "4.14.87",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz",
+      "integrity": "sha512-AqRC+aEF4N0LuNHtcjKtvF9OTfqZI0iaBoe3dA6m/W+/YZJBZjBmW/QIZ8fBeXC6cnytSY9tBoFBqZ9uSCeVsw==",
       "dev": true
     },
     "@types/marked": {
@@ -349,9 +305,9 @@
       "dev": true
     },
     "@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
+      "integrity": "sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==",
       "dev": true
     },
     "@types/mockery": {
@@ -361,9 +317,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.9.tgz",
-      "integrity": "sha512-s+c3AjymyAccTI4hcgNFK4mToH8l+hyPDhu4LIkn71lRy56FLijGu00fyLgldjM/846Pmk9N4KFUs2P8GDs0pA==",
+      "version": "6.0.92",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.92.tgz",
+      "integrity": "sha512-awEYSSTn7dauwVCYSx2CJaPTu0Z1Ht2oR1b2AD3CYao6ZRb+opb6EL43fzmD7eMFgMHzTBWSUzlWSD+S8xN0Nw==",
       "dev": true
     },
     "@types/platform": {
@@ -378,7 +334,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.9"
+        "@types/node": "6.0.92"
       }
     },
     "@types/rx": {
@@ -513,7 +469,7 @@
       "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.11.0",
+        "@types/express-serve-static-core": "4.0.57",
         "@types/mime": "2.0.0"
       }
     },
@@ -529,14 +485,23 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.9"
+        "@types/node": "6.0.92"
       }
     },
     "@types/sinon": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.1.3.tgz",
-      "integrity": "sha512-Xxn32Q3mAJHOMU20bxcT6HiPksUJEkZA+nyZS4NhLo8kKb8hLhkBgp5OeW/BI3+9QmdrvDRk3caYNqtYb+TEbA==",
+      "version": "1.16.36",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-1.16.36.tgz",
+      "integrity": "sha1-dLtu15KFl8Gz+xsAkAXpTcbq41c=",
       "dev": true
+    },
+    "@types/sinon-as-promised": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/sinon-as-promised/-/sinon-as-promised-4.0.7.tgz",
+      "integrity": "sha512-aGLbqBL0CZkL+doP850EyaDCCi0zy4+TQvkOQhDbZT6bwWATw11kX4FnntCoNpe2I73/j9CEmjRasd6Ir0thRw==",
+      "dev": true,
+      "requires": {
+        "@types/sinon": "1.16.36"
+      }
     },
     "@types/source-map": {
       "version": "0.1.29",
@@ -556,13 +521,13 @@
       "integrity": "sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.9"
+        "@types/node": "6.0.92"
       }
     },
     "@types/update-notifier": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/update-notifier/-/update-notifier-1.0.3.tgz",
-      "integrity": "sha512-BLStNhP2DFF7funARwTcoD6tetRte8NK3Sc59mn7GNALCN975jOlKX3dGvsFxXr/HwQMxxCuRn9IWB3WQ7odHQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/update-notifier/-/update-notifier-1.0.2.tgz",
+      "integrity": "sha512-NwfqJ7OT7MgzgV+SiWJr7jMdBezFIWuBSmCOmScvesL/SV8A17SUQR0sCI+shxo+4THHPNGgzaLzfbjQMYLHFA==",
       "dev": true
     },
     "@types/ws": {
@@ -571,13 +536,13 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.9"
+        "@types/node": "6.0.92"
       }
     },
     "@types/yargs": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-10.0.1.tgz",
-      "integrity": "sha512-EvK+v8864qaRCjtqcJa7iUKWYTIvbdSZ4MJd99QTcBpq2FbVllwW7ldRBesBYINgj2Mn0yMQ2yZZJPej1DcJFA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.2.tgz",
+      "integrity": "sha512-Upj9YsBZRgjEVPvsaeGru48d2JiyzBNZkmkebHyoaQ+UM9wqj/rp5mkilRjSq/Ga45yfd/zwrNuML9f2gGfVpw==",
       "dev": true
     },
     "abbrev": {
@@ -635,53 +600,32 @@
       "dev": true
     },
     "ansi-align": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
+      "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
       "requires": {
-        "string-width": "2.1.1"
-      }
-    },
-    "ansi-cyan": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
-      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
-      "dev": true,
-      "requires": {
-        "ansi-wrap": "0.1.0"
+        "string-width": "1.0.2"
       }
     },
     "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
-    },
-    "ansi-red": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
-      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
-      "dev": true,
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
     },
     "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-      "requires": {
-        "color-convert": "1.9.1"
-      }
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
-    "ansi-wrap": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+    "any-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
+      "integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
       "dev": true
     },
     "any-promise": {
@@ -698,6 +642,12 @@
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
       }
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+      "dev": true
     },
     "append-transform": {
       "version": "0.4.0",
@@ -732,10 +682,10 @@
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
-    "arr-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
-      "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+    "array-differ": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true
     },
     "array-filter": {
@@ -768,12 +718,6 @@
       "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
       "dev": true
     },
-    "array-slice": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-      "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
-      "dev": true
-    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -796,8 +740,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asn1": {
       "version": "0.1.11",
@@ -814,9 +757,9 @@
       "optional": true
     },
     "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
     },
     "async": {
@@ -845,7 +788,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000793",
+        "caniuse-db": "1.0.30000778",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -868,48 +811,6 @@
         "chalk": "1.1.3",
         "esutils": "2.0.2",
         "js-tokens": "3.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "babel-generator": {
@@ -954,14 +855,14 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
           "dev": true
         }
       }
@@ -1023,6 +924,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
       "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
+      "dev": true
+    },
+    "beeper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
       "dev": true
     },
     "benchmark": {
@@ -1097,7 +1004,7 @@
         "bytes": "2.2.0",
         "content-type": "1.0.4",
         "debug": "2.2.0",
-        "depd": "1.1.2",
+        "depd": "1.1.1",
         "http-errors": "1.3.1",
         "iconv-lite": "0.4.13",
         "on-finished": "2.3.0",
@@ -1145,17 +1052,19 @@
       }
     },
     "boxen": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
+      "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
       "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "2.3.0",
+        "ansi-align": "1.1.0",
+        "camelcase": "2.1.1",
+        "chalk": "1.1.3",
         "cli-boxes": "1.0.0",
-        "string-width": "2.1.1",
-        "term-size": "1.2.0",
-        "widest-line": "2.0.0"
+        "filled-array": "1.1.0",
+        "object-assign": "4.1.1",
+        "repeating": "2.0.1",
+        "string-width": "1.0.2",
+        "widest-line": "1.0.0"
       }
     },
     "brace-expansion": {
@@ -1184,8 +1093,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000793",
-        "electron-to-chromium": "1.3.31"
+        "caniuse-db": "1.0.30000778",
+        "electron-to-chromium": "1.3.28"
       }
     },
     "buffer": {
@@ -1208,8 +1117,7 @@
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
     },
     "bytes": {
       "version": "2.2.0",
@@ -1218,9 +1126,9 @@
       "dev": true
     },
     "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
     },
     "camelcase-keys": {
       "version": "2.1.0",
@@ -1230,14 +1138,6 @@
       "requires": {
         "camelcase": "2.1.1",
         "map-obj": "1.0.1"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        }
       }
     },
     "caniuse-api": {
@@ -1247,15 +1147,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000793",
+        "caniuse-db": "1.0.30000778",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000793",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000793.tgz",
-      "integrity": "sha1-PADGbkI6ehkHx92Wdpp4sq+opy4=",
+      "version": "1.0.30000778",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000778.tgz",
+      "integrity": "sha1-Fnxg6VQqKqYFN8RG+ziB2FOjByo=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1286,28 +1186,25 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
+        "assertion-error": "1.0.2",
         "check-error": "1.0.2",
         "deep-eql": "3.0.1",
         "get-func-name": "2.0.0",
         "pathval": "1.1.0",
-        "type-detect": "4.0.7"
+        "type-detect": "4.0.5"
       }
     },
     "chalk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "3.2.0",
+        "ansi-styles": "2.2.1",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "4.5.0"
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
-    },
-    "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
     },
     "charm": {
       "version": "1.0.2",
@@ -1341,6 +1238,12 @@
         "readdirp": "1.4.0"
       }
     },
+    "ci-info": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "dev": true
+    },
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
@@ -1348,48 +1251,6 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "cli-boxes": {
@@ -1404,17 +1265,10 @@
       "requires": {
         "ansi-regex": "2.1.1",
         "d": "1.0.0",
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.37",
         "es6-iterator": "2.0.3",
         "memoizee": "0.4.11",
         "timers-ext": "0.1.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        }
       }
     },
     "cli-color-tty": {
@@ -1426,12 +1280,17 @@
       }
     },
     "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "1.0.1"
       }
+    },
+    "cli-spinners": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.2.0.tgz",
+      "integrity": "sha1-hQeHN5E7iA9uyf/ntl6D7Hd2KE8="
     },
     "cli-table": {
       "version": "0.3.1",
@@ -1441,18 +1300,28 @@
         "colors": "1.0.3"
       }
     },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      }
+    },
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "cliui": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-      "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "requires": {
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
         "wrap-ansi": "2.1.0"
       }
     },
@@ -1460,6 +1329,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
       "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+      "dev": true
+    },
+    "clone-stats": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
       "dev": true
     },
     "coa": {
@@ -1507,6 +1382,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1514,7 +1390,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "color-string": {
       "version": "0.3.0",
@@ -1574,16 +1451,19 @@
       }
     },
     "configstore": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+      "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
       "requires": {
-        "dot-prop": "4.2.0",
+        "dot-prop": "3.0.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1",
+        "os-tmpdir": "1.0.2",
+        "osenv": "0.1.4",
+        "uuid": "2.0.3",
+        "write-file-atomic": "1.3.4",
+        "xdg-basedir": "2.0.0"
       }
     },
     "content-disposition": {
@@ -1621,6 +1501,45 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cosmiconfig": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+      "dev": true,
+      "requires": {
+        "is-directory": "0.3.1",
+        "js-yaml": "3.10.0",
+        "parse-json": "3.0.0",
+        "require-from-string": "2.0.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        }
+      }
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -1629,13 +1548,22 @@
         "capture-stack-trace": "1.0.0"
       }
     },
+    "create-thenable": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/create-thenable/-/create-thenable-1.0.2.tgz",
+      "integrity": "sha1-4gMXIMzJV12M+jH1wUbnYqgMBTQ=",
+      "dev": true,
+      "requires": {
+        "object.omit": "2.0.1",
+        "unique-concat": "0.2.2"
+      }
+    },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
       "requires": {
         "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
     },
@@ -1662,7 +1590,8 @@
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
     },
     "csproj2ts": {
       "version": "0.0.7",
@@ -1672,7 +1601,7 @@
       "requires": {
         "es6-promise": "2.3.0",
         "lodash": "3.10.1",
-        "semver": "5.5.0",
+        "semver": "5.4.1",
         "xml2js": "0.4.19"
       },
       "dependencies": {
@@ -1739,45 +1668,6 @@
         "postcss-modules-values": "1.3.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "postcss": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
@@ -1787,15 +1677,6 @@
             "chalk": "1.1.3",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -1905,8 +1786,14 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.38"
+        "es5-ext": "0.10.37"
       }
+    },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
     },
     "dateformat": {
       "version": "1.0.12",
@@ -1919,17 +1806,17 @@
       }
     },
     "david": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/david/-/david-11.0.0.tgz",
-      "integrity": "sha1-A52pQnBy+3dn9NqlalTsok3MK8M=",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/david/-/david-9.0.0.tgz",
+      "integrity": "sha1-IkLf7e5kvOXu7/WsWzryXcuytf0=",
       "requires": {
         "async": "2.6.0",
         "cli-color-tty": "2.0.0",
         "cli-table": "0.3.1",
         "exit": "0.1.2",
         "minimist": "1.2.0",
-        "npm": "4.6.1",
-        "semver": "5.5.0",
+        "npm": "3.10.10",
+        "semver": "5.4.1",
         "xtend": "4.0.1"
       }
     },
@@ -1960,14 +1847,6 @@
         "make-dir": "1.1.0",
         "pify": "2.3.0",
         "strip-dirs": "2.1.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
       }
     },
     "decompress-tar": {
@@ -2030,24 +1909,14 @@
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true
-        },
-        "get-stream": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
         }
       }
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -2055,7 +1924,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.7"
+        "type-detect": "4.0.5"
       }
     },
     "deep-equal": {
@@ -2082,17 +1951,6 @@
       "dev": true,
       "requires": {
         "strip-bom": "2.0.0"
-      },
-      "dependencies": {
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        }
       }
     },
     "defined": {
@@ -2107,9 +1965,9 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
       "dev": true
     },
     "destroy": {
@@ -2130,9 +1988,9 @@
       "dev": true
     },
     "dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
       "requires": {
         "is-obj": "1.0.1"
       }
@@ -2169,10 +2027,19 @@
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
     },
     "ee-first": {
       "version": "1.1.1",
@@ -2186,9 +2053,15 @@
       "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
     },
     "electron-to-chromium": {
-      "version": "1.3.31",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
-      "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA==",
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
+      "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
+      "dev": true
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
     "emojis-list": {
@@ -2204,9 +2077,9 @@
       "dev": true
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "dev": true,
       "requires": {
         "once": "1.4.0"
@@ -2221,9 +2094,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.38",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
-      "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
+      "version": "0.10.37",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
+      "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
       "requires": {
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
@@ -2235,7 +2108,7 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.37",
         "es6-symbol": "3.1.1"
       }
     },
@@ -2251,7 +2124,7 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38"
+        "es5-ext": "0.10.37"
       }
     },
     "es6-weak-map": {
@@ -2260,7 +2133,7 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.37",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -2301,6 +2174,16 @@
         }
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz",
+      "integrity": "sha512-P0EohHM1MwL36GX5l1TOEYyt/5d7hcxrX3CqCjibTN3dH7VCAy2kjsC/WB6dUHnpB4mFkZq1Ndfh2DYQ2QMEGQ==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
+      }
+    },
     "esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
@@ -2331,7 +2214,7 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38"
+        "es5-ext": "0.10.37"
       }
     },
     "eventemitter2": {
@@ -2341,16 +2224,16 @@
       "dev": true
     },
     "execa": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
-      "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
+      "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
+      "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
+        "cross-spawn-async": "2.2.5",
         "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
+        "npm-run-path": "1.0.0",
+        "object-assign": "4.1.1",
+        "path-key": "1.0.0",
         "strip-eof": "1.0.0"
       }
     },
@@ -2358,6 +2241,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
     },
     "expand-brackets": {
       "version": "0.1.5",
@@ -2390,7 +2278,7 @@
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
+        "depd": "1.1.1",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
@@ -2442,13 +2330,13 @@
       }
     },
     "external-editor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+      "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.19",
-        "tmp": "0.0.33"
+        "extend": "3.0.1",
+        "spawn-sync": "1.0.15",
+        "tmp": "0.0.29"
       }
     },
     "extglob": {
@@ -2459,6 +2347,22 @@
       "requires": {
         "is-extglob": "1.0.0"
       }
+    },
+    "fancy-log": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "time-stamp": "1.1.0"
+      }
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2540,6 +2444,11 @@
         }
       }
     },
+    "filled-array": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
+      "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q="
+    },
     "finalhandler": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
@@ -2563,12 +2472,19 @@
         }
       }
     },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
+    },
     "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "requires": {
-        "locate-path": "2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "findup-sync": {
@@ -2633,12 +2549,12 @@
       }
     },
     "formatio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "samsam": "1.1.2"
       }
     },
     "forwarded": {
@@ -2660,13 +2576,15 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+      "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "requires": {
         "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.6.2"
       }
     },
     "fs.realpath": {
@@ -2718,6 +2636,12 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
+      "dev": true
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -2725,9 +2649,14 @@
       "dev": true
     },
     "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+      "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "getobject": {
       "version": "0.1.0",
@@ -2813,6 +2742,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
       "requires": {
         "ini": "1.3.5"
       }
@@ -2833,13 +2763,6 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
       }
     },
     "globule": {
@@ -2853,21 +2776,34 @@
         "minimatch": "3.0.4"
       }
     },
+    "glogg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+      "dev": true,
+      "requires": {
+        "sparkles": "1.0.0"
+      }
+    },
     "got": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
       "requires": {
         "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
+        "duplexer2": "0.1.4",
         "is-redirect": "1.0.0",
         "is-retry-allowed": "1.1.0",
         "is-stream": "1.1.0",
         "lowercase-keys": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
+        "node-status-codes": "1.0.0",
+        "object-assign": "4.1.1",
+        "parse-json": "2.2.0",
+        "pinkie-promise": "2.0.1",
+        "read-all-stream": "3.1.0",
+        "readable-stream": "2.3.3",
+        "timed-out": "3.1.3",
+        "unzip-response": "1.0.2",
         "url-parse-lax": "1.0.0"
       }
     },
@@ -2975,48 +2911,6 @@
       "requires": {
         "chalk": "1.1.3",
         "file-sync-cmp": "0.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "grunt-contrib-watch": {
@@ -3046,9 +2940,9 @@
       }
     },
     "grunt-dojo2": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/grunt-dojo2/-/grunt-dojo2-0.1.1.tgz",
-      "integrity": "sha512-vHz5uCmHEDxvNHcWYRBuvB7xa34g+25oLbsXzbcBPtYTJJtwrKy4YQ8gl1hHWQUSFvLJfj+CE15yU4mdmLzBxA==",
+      "version": "2.0.0-beta2.15",
+      "resolved": "https://registry.npmjs.org/grunt-dojo2/-/grunt-dojo2-2.0.0-beta2.15.tgz",
+      "integrity": "sha512-inDpdjlZrb6F5VTIlMDDCPxN1wtM27axEW9feHrmzh/x1CyelfzsvfkbbmqkP/XHlVrGNmHkO8BuTSDqCDn+BA==",
       "dev": true,
       "requires": {
         "codecov.io": "0.1.6",
@@ -3064,7 +2958,7 @@
         "grunt-ts": "5.5.1",
         "grunt-tslint": "4.0.1",
         "grunt-typings": "0.1.5",
-        "intern": "4.1.5",
+        "intern": "4.1.3",
         "istanbul-lib-coverage": "1.1.1",
         "istanbul-lib-report": "1.1.2",
         "istanbul-reports": "1.1.3",
@@ -3074,7 +2968,7 @@
         "postcss-cssnext": "2.11.0",
         "postcss-import": "9.1.0",
         "postcss-modules": "0.6.4",
-        "remap-istanbul": "0.10.0",
+        "remap-istanbul": "0.9.5",
         "resolve-from": "2.0.0",
         "shelljs": "0.7.8",
         "tslint": "4.5.1",
@@ -3083,62 +2977,260 @@
         "umd-wrapper": "0.1.0"
       },
       "dependencies": {
-        "execa": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
-          "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
+        "ansi-align": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
+          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "dev": true,
           "requires": {
-            "cross-spawn-async": "2.2.5",
-            "is-stream": "1.1.0",
-            "npm-run-path": "1.0.0",
-            "object-assign": "4.1.1",
-            "path-key": "1.0.0",
-            "strip-eof": "1.0.0"
+            "string-width": "2.1.1"
           }
         },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "npm-run-path": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-          "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-          "dev": true,
-          "requires": {
-            "path-key": "1.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-key": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-          "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "pkg-dir": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "color-convert": "1.9.1"
           }
+        },
+        "boxen": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+          "dev": true,
+          "requires": {
+            "ansi-align": "2.0.0",
+            "camelcase": "4.1.0",
+            "chalk": "2.3.0",
+            "cli-boxes": "1.0.0",
+            "string-width": "2.1.1",
+            "term-size": "1.2.0",
+            "widest-line": "2.0.0"
+          }
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "colors": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+          "dev": true
+        },
+        "configstore": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
+          "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+          "dev": true,
+          "requires": {
+            "dot-prop": "4.2.0",
+            "graceful-fs": "4.1.11",
+            "make-dir": "1.1.0",
+            "unique-string": "1.0.0",
+            "write-file-atomic": "2.3.0",
+            "xdg-basedir": "3.0.0"
+          }
+        },
+        "diff": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
+        },
+        "dot-prop": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+          "dev": true,
+          "requires": {
+            "is-obj": "1.0.1"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "got": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "dev": true,
+          "requires": {
+            "create-error-class": "3.0.2",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.0",
+            "safe-buffer": "5.1.1",
+            "timed-out": "4.0.1",
+            "unzip-response": "2.0.1",
+            "url-parse-lax": "1.0.0"
+          }
+        },
+        "grunt-tslint": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
+          "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "latest-version": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
+          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+          "dev": true,
+          "requires": {
+            "package-json": "4.0.1"
+          }
+        },
+        "package-json": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
+          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+          "dev": true,
+          "requires": {
+            "got": "6.7.1",
+            "registry-auth-token": "3.3.1",
+            "registry-url": "3.1.0",
+            "semver": "5.4.1"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+          "dev": true
+        },
+        "tslint": {
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
+          "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "colors": "1.1.2",
+            "diff": "3.4.0",
+            "findup-sync": "0.3.0",
+            "glob": "7.1.2",
+            "optimist": "0.6.1",
+            "resolve": "1.1.7",
+            "tsutils": "1.9.1",
+            "update-notifier": "2.3.0"
+          }
+        },
+        "unzip-response": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+          "dev": true
+        },
+        "update-notifier": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
+          "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+          "dev": true,
+          "requires": {
+            "boxen": "1.3.0",
+            "chalk": "2.3.0",
+            "configstore": "3.1.1",
+            "import-lazy": "2.1.0",
+            "is-installed-globally": "0.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "3.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "3.0.0"
+          }
+        },
+        "widest-line": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+          "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+          "dev": true,
+          "requires": {
+            "string-width": "2.1.1"
+          }
+        },
+        "write-file-atomic": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+          "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "signal-exit": "3.0.2"
+          }
+        },
+        "xdg-basedir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+          "dev": true
         }
       }
     },
@@ -3185,50 +3277,10 @@
         "lodash": "4.3.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
         "lodash": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
           "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
@@ -3280,48 +3332,6 @@
         "chalk": "1.1.3",
         "diff": "2.2.3",
         "postcss": "5.2.18"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "grunt-text-replace": {
@@ -3342,7 +3352,7 @@
         "lodash": "2.4.1",
         "ncp": "0.5.1",
         "rimraf": "2.2.6",
-        "semver": "5.5.0",
+        "semver": "5.4.1",
         "strip-bom": "2.0.0",
         "typescript": "1.8.9",
         "underscore": "1.5.1",
@@ -3361,15 +3371,6 @@
           "integrity": "sha1-xZWXVpsU2VatKcrMQr3d9fDqT0w=",
           "dev": true
         },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
         "typescript": {
           "version": "1.8.9",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.8.9.tgz",
@@ -3385,9 +3386,9 @@
       }
     },
     "grunt-tslint": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
-      "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-5.0.1.tgz",
+      "integrity": "sha1-dDK9G9VuijolAACI1cYf3MNC8MI=",
       "dev": true
     },
     "grunt-typings": {
@@ -3397,137 +3398,76 @@
       "dev": true,
       "requires": {
         "typings-core": "1.6.1"
+      }
+    },
+    "gulp-util": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
+      "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
+      "dev": true,
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "1.0.12",
+        "fancy-log": "1.3.0",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
+        "replace-ext": "0.0.1",
+        "through2": "2.0.1",
+        "vinyl": "0.5.3"
       },
       "dependencies": {
-        "configstore": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
-          "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
+        "lodash.template": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+          "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
           "dev": true,
           "requires": {
-            "dot-prop": "3.0.0",
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.1",
-            "os-tmpdir": "1.0.2",
-            "osenv": "0.1.4",
-            "uuid": "2.0.3",
-            "write-file-atomic": "1.3.4",
-            "xdg-basedir": "2.0.0"
+            "lodash._basecopy": "3.0.1",
+            "lodash._basetostring": "3.0.1",
+            "lodash._basevalues": "3.0.0",
+            "lodash._isiterateecall": "3.0.9",
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.escape": "3.2.0",
+            "lodash.keys": "3.1.2",
+            "lodash.restparam": "3.6.1",
+            "lodash.templatesettings": "3.1.1"
           }
         },
-        "detect-indent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+        "lodash.templatesettings": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+          "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.escape": "3.2.0"
           }
         },
-        "dot-prop": {
+        "object-assign": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-          "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-          "dev": true,
-          "requires": {
-            "is-obj": "1.0.1"
-          }
-        },
-        "popsicle": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-8.2.0.tgz",
-          "integrity": "sha1-/0QBAFyrQ6lBipFBBhHAAZdxLSE=",
-          "dev": true,
-          "requires": {
-            "any-promise": "1.3.0",
-            "arrify": "1.0.1",
-            "concat-stream": "1.6.0",
-            "form-data": "2.3.1",
-            "make-error-cause": "1.2.2",
-            "throwback": "1.1.1",
-            "tough-cookie": "2.3.3",
-            "xtend": "4.0.1"
-          }
-        },
-        "promise-finally": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/promise-finally/-/promise-finally-2.2.1.tgz",
-          "integrity": "sha1-ImFsS6kCkW6Yi9RsVNfKoIkQzXc=",
-          "dev": true,
-          "requires": {
-            "any-promise": "1.3.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "typings-core": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/typings-core/-/typings-core-1.6.1.tgz",
-          "integrity": "sha1-zkspMeovGbuPPay+xpmDrE6WSjc=",
-          "dev": true,
-          "requires": {
-            "any-promise": "1.3.0",
-            "array-uniq": "1.0.3",
-            "configstore": "2.1.0",
-            "debug": "2.6.9",
-            "detect-indent": "4.0.0",
-            "graceful-fs": "4.1.11",
-            "has": "1.0.1",
-            "invariant": "2.2.2",
-            "is-absolute": "0.2.6",
-            "listify": "1.0.0",
-            "lockfile": "1.0.3",
-            "make-error-cause": "1.2.2",
-            "mkdirp": "0.5.1",
-            "object.pick": "1.3.0",
-            "parse-json": "2.2.0",
-            "popsicle": "8.2.0",
-            "popsicle-proxy-agent": "3.0.0",
-            "popsicle-retry": "3.2.1",
-            "popsicle-rewrite": "1.0.0",
-            "popsicle-status": "2.0.1",
-            "promise-finally": "2.2.1",
-            "rc": "1.2.4",
-            "rimraf": "2.6.2",
-            "sort-keys": "1.1.2",
-            "string-template": "1.0.0",
-            "strip-bom": "2.0.0",
-            "thenify": "3.3.0",
-            "throat": "3.2.0",
-            "touch": "1.0.0",
-            "typescript": "2.6.2",
-            "xtend": "4.0.1",
-            "zip-object": "0.1.0"
-          }
-        },
-        "write-file-atomic": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
-          }
-        },
-        "xdg-basedir": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-          "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
-          "dev": true,
-          "requires": {
-            "os-homedir": "1.0.2"
-          }
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+          "dev": true
         }
+      }
+    },
+    "gulplog": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "dev": true,
+      "requires": {
+        "glogg": "1.0.0"
       }
     },
     "handlebars": {
@@ -3571,23 +3511,24 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        }
       }
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "has-gulplog": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+      "dev": true,
+      "requires": {
+        "sparkles": "1.0.0"
+      }
     },
     "hawk": {
       "version": "1.1.1",
@@ -3632,8 +3573,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-      "dev": true
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
     },
     "html-comment-regex": {
       "version": "1.1.1",
@@ -3689,10 +3629,36 @@
         "extend": "3.0.1"
       }
     },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
@@ -3715,7 +3681,8 @@
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -3757,51 +3724,82 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-4.0.2.tgz",
-      "integrity": "sha512-+f3qDNeZpkhFJ61NBA9jXDrGGhoQuqfEum9A681c9oHoIbGgVqjogKynjB/vNVP+nVu9w3FbFQ35c0ibU0MaIQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-2.0.0.tgz",
+      "integrity": "sha1-4TUWh7kNFQykA86qPO+x4wZb70s=",
       "requires": {
-        "ansi-escapes": "3.0.0",
-        "chalk": "2.3.0",
-        "cli-cursor": "2.1.0",
+        "ansi-escapes": "1.4.0",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
         "cli-width": "2.2.0",
-        "external-editor": "2.1.0",
+        "external-editor": "1.1.1",
         "figures": "2.0.0",
         "lodash": "4.17.4",
-        "mute-stream": "0.0.7",
+        "mute-stream": "0.0.6",
+        "pinkie-promise": "2.0.1",
         "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
+        "rx": "4.1.0",
         "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
+        "strip-ansi": "3.0.1",
         "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
+            }
+          }
+        }
       }
     },
     "intern": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.5.tgz",
-      "integrity": "sha512-wY3xxstQ2zHpOU/ktjMcyvzmzazyjvlcipD79RqDGm+kyMdJcyI+00qfHvPlzrwhGwX+XVs2+tqwJCiSMKzYUg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.3.tgz",
+      "integrity": "sha512-IWaqzIwc+KQcoyiG+INvvv9L0fPKmgDSj+LySSWgnPc0VnYT1vgEmmxpwSlMPHDtfMMqq28/5/tsQVRx4EM2bQ==",
       "dev": true,
       "requires": {
-        "@dojo/core": "0.3.1",
-        "@dojo/has": "0.1.2",
-        "@dojo/interfaces": "0.2.1",
-        "@dojo/shim": "0.2.5",
+        "@dojo/core": "0.3.0",
+        "@dojo/has": "0.1.1",
+        "@dojo/interfaces": "0.2.0",
+        "@dojo/shim": "0.2.3",
         "@theintern/digdug": "2.0.4",
         "@theintern/leadfoot": "2.0.3",
         "@types/benchmark": "1.0.31",
-        "@types/chai": "4.0.10",
+        "@types/chai": "4.0.8",
         "@types/charm": "1.0.1",
         "@types/diff": "3.2.2",
         "@types/express": "4.0.39",
         "@types/http-errors": "1.5.34",
         "@types/istanbul-lib-coverage": "1.1.0",
         "@types/istanbul-lib-hook": "1.0.0",
-        "@types/istanbul-lib-instrument": "1.7.1",
+        "@types/istanbul-lib-instrument": "1.7.0",
         "@types/istanbul-lib-report": "1.1.0",
-        "@types/istanbul-lib-source-maps": "1.2.1",
+        "@types/istanbul-lib-source-maps": "1.2.0",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.93",
+        "@types/lodash": "4.14.87",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -3831,7 +3829,7 @@
         "shell-quote": "1.6.1",
         "source-map": "0.5.7",
         "statuses": "1.3.1",
-        "tslib": "1.8.1",
+        "tslib": "1.8.0",
         "ws": "2.3.1"
       },
       "dependencies": {
@@ -3844,7 +3842,7 @@
             "bytes": "2.4.0",
             "content-type": "1.0.4",
             "debug": "2.6.7",
-            "depd": "1.1.2",
+            "depd": "1.1.1",
             "http-errors": "1.6.2",
             "iconv-lite": "0.4.15",
             "on-finished": "2.3.0",
@@ -3884,14 +3882,6 @@
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
             "statuses": "1.3.1"
-          },
-          "dependencies": {
-            "depd": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-              "dev": true
-            }
           }
         },
         "iconv-lite": {
@@ -4003,10 +3993,24 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
       "requires": {
         "builtin-modules": "1.1.1"
       }
+    },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.2"
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -4039,15 +4043,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-glob": {
       "version": "1.1.3",
@@ -4059,6 +4065,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
       "requires": {
         "global-dirs": "0.1.1",
         "is-path-inside": "1.0.1"
@@ -4089,10 +4096,20 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
+    "is-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "0.2.4"
+      }
+    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
       }
@@ -4123,6 +4140,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
     },
     "is-relative": {
       "version": "0.2.1",
@@ -4168,8 +4191,7 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-windows": {
       "version": "0.2.0",
@@ -4244,12 +4266,6 @@
             "path-is-absolute": "1.0.1"
           }
         },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "nopt": {
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -4303,7 +4319,7 @@
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
         "istanbul-lib-coverage": "1.1.1",
-        "semver": "5.5.0"
+        "semver": "5.4.1"
       }
     },
     "istanbul-lib-report": {
@@ -4318,12 +4334,6 @@
         "supports-color": "3.2.3"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
@@ -4368,10 +4378,71 @@
         "handlebars": "4.0.11"
       }
     },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
+    },
+    "jest-validate": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-get-type": "21.2.0",
+        "leven": "2.1.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "js-base64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.1.tgz",
-      "integrity": "sha512-2h586r2I/CqU7z1aa1kBgWaVAXWAZK+zHnceGi/jFgn7+7VSluxYer/i3xOZVearCxxXvyDkLtTBo+OeJCA3kA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
+      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==",
       "dev": true
     },
     "js-tokens": {
@@ -4408,9 +4479,9 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -4420,22 +4491,6 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
-    },
-    "jspm-config": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/jspm-config/-/jspm-config-0.3.4.tgz",
-      "integrity": "sha1-RMJpAuSujs4jZs7cn/FrEKXzkcY=",
-      "requires": {
-        "any-promise": "1.3.0",
-        "graceful-fs": "4.1.11",
-        "make-error-cause": "1.2.2",
-        "object.pick": "1.3.0",
-        "parse-json": "2.2.0",
-        "strip-bom": "3.0.0",
-        "thenify": "3.3.0",
-        "throat": "3.2.0",
-        "xtend": "4.0.1"
-      }
     },
     "jszip": {
       "version": "3.1.5",
@@ -4478,12 +4533,6 @@
         }
       }
     },
-    "just-extend": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
-      "dev": true
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -4493,12 +4542,20 @@
         "is-buffer": "1.1.6"
       }
     },
-    "latest-version": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
-        "package-json": "4.0.1"
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "latest-version": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
+      "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
+      "requires": {
+        "package-json": "2.4.0"
       }
     },
     "lazy-cache": {
@@ -4508,6 +4565,11 @@
       "dev": true,
       "optional": true
     },
+    "lazy-req": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+      "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w="
+    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -4515,6 +4577,12 @@
       "requires": {
         "invert-kv": "1.0.0"
       }
+    },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -4535,45 +4603,303 @@
         "immediate": "3.0.6"
       }
     },
+    "lint-staged": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-6.0.0.tgz",
+      "integrity": "sha512-ZUftK94S4vedpQG1LlA2tc2AuQXXBwc+1lB+j8SEfG5+p2dqu3Ug8iYQ8jdap+uLkhDw4OaJXqE+CZ/L+vfv+Q==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "dedent": "0.7.0",
+        "execa": "0.8.0",
+        "find-parent-dir": "0.3.0",
+        "is-glob": "4.0.0",
+        "jest-validate": "21.2.1",
+        "listr": "0.13.0",
+        "lodash": "4.17.4",
+        "log-symbols": "2.1.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
+        "staged-git-files": "0.0.4",
+        "stringify-object": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "log-symbols": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
+          "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "listify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz",
       "integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM="
     },
+    "listr": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
+      "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.6",
+        "stream-to-observable": "0.2.0",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "cli-spinners": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+          "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+          "dev": true
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        },
+        "ora": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+          "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-spinners": "0.1.2",
+            "object-assign": "4.1.1"
+          }
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
+      },
+      "dependencies": {
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        }
+      }
+    },
     "livereload-js": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
-      "integrity": "sha512-j1R0/FeGa64Y+NmqfZhyoVRzcFlOZ8sNlKzHjh4VvLULFACZhn68XrX5DFg2FhMvSMJmROuFxRSa560ECWKBMg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
+      "integrity": "sha1-bIclfmSKtHW8JOoldFftzB+NC8I=",
       "dev": true
     },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "parse-json": "2.2.0",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
         "strip-bom": "2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        }
       }
     },
     "loader-utils": {
@@ -4592,9 +4918,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
       "requires": {
         "p-locate": "2.0.0",
         "path-exists": "3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
       }
     },
     "lockfile": {
@@ -4607,22 +4942,107 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basetostring": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+      "dev": true
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash._reescape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+      "dev": true
+    },
+    "lodash._reevaluate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+      "dev": true
+    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+    "lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
       "dev": true
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
+    "lodash.escape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+      "dev": true,
+      "requires": {
+        "lodash._root": "3.0.1"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
     },
     "lodash.template": {
@@ -4650,10 +5070,28 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
+    "log-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+      "requires": {
+        "chalk": "1.1.3"
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
+      }
+    },
     "lolex": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
-      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
     "longest": {
@@ -4699,7 +5137,7 @@
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "requires": {
-        "es5-ext": "0.10.38"
+        "es5-ext": "0.10.37"
       }
     },
     "macaddress": {
@@ -4712,21 +5150,30 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
       "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+      "dev": true,
       "requires": {
         "pify": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "make-error": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.2.tgz",
-      "integrity": "sha512-l9ra35l5VWLF24y75Tg8XgfGLX0ueRhph118WKM6H5denx4bB5QF59+4UAm9oJ2qsPQZas/CQUDdtDdfvYHBdQ=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
+      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y="
     },
     "make-error-cause": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
       "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
       "requires": {
-        "make-error": "1.3.2"
+        "make-error": "1.3.0"
       }
     },
     "map-obj": {
@@ -4736,9 +5183,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
-      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
+      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
       "dev": true
     },
     "math-expression-evaluator": {
@@ -4757,6 +5204,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "dev": true,
       "requires": {
         "mimic-fn": "1.1.0"
       }
@@ -4767,7 +5215,7 @@
       "integrity": "sha1-vemBdmPJ5A/bKk6hw2cpYIeujI8=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.37",
         "es6-weak-map": "2.0.2",
         "event-emitter": "0.3.5",
         "is-promise": "2.1.0",
@@ -4861,7 +5309,8 @@
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -4892,9 +5341,9 @@
       }
     },
     "mockery": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
-      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
+      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8=",
       "dev": true
     },
     "ms": {
@@ -4902,10 +5351,54 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "multipipe": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+      "dev": true,
+      "requires": {
+        "duplexer2": "0.0.2"
+      },
+      "dependencies": {
+        "duplexer2": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.1.14"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
     "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+      "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s="
     },
     "nan": {
       "version": "2.8.0",
@@ -4913,6 +5406,12 @@
       "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
       "dev": true,
       "optional": true
+    },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+      "dev": true
     },
     "ncp": {
       "version": "0.5.1",
@@ -4931,41 +5430,10 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
-    "nise": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
-      "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
-      "dev": true,
-      "requires": {
-        "formatio": "1.2.0",
-        "just-extend": "1.1.27",
-        "lolex": "1.6.0",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "lolex": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-          "dev": true
-        },
-        "path-to-regexp": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-          "dev": true,
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        }
-      }
+    "node-status-codes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
     },
     "node-uuid": {
       "version": "1.4.8",
@@ -4985,11 +5453,10 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
+        "semver": "5.4.1",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -5021,20 +5488,17 @@
       }
     },
     "npm": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-4.6.1.tgz",
-      "integrity": "sha1-+Osa0A3FilUUNjtBylNCgX8L1kY=",
+      "version": "3.10.10",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-3.10.10.tgz",
+      "integrity": "sha1-Wx1XfkyIadbIYDvInpzRY3MD5G4=",
       "requires": {
-        "JSONStream": "1.3.1",
-        "abbrev": "1.1.0",
-        "ansi-regex": "2.1.1",
+        "abbrev": "1.0.9",
+        "ansi-regex": "2.0.0",
         "ansicolors": "0.3.2",
         "ansistyles": "0.1.3",
-        "aproba": "1.1.1",
+        "aproba": "1.0.4",
         "archy": "1.0.0",
         "asap": "2.0.5",
-        "bluebird": "3.5.0",
-        "call-limit": "1.1.0",
         "chownr": "1.0.1",
         "cmd-shim": "2.0.2",
         "columnify": "1.5.4",
@@ -5042,22 +5506,21 @@
         "debuglog": "1.0.1",
         "dezalgo": "1.0.3",
         "editor": "1.0.0",
-        "fs-vacuum": "1.2.10",
-        "fs-write-stream-atomic": "1.0.10",
-        "fstream": "1.0.11",
+        "fs-vacuum": "1.2.9",
+        "fs-write-stream-atomic": "1.0.8",
+        "fstream": "1.0.10",
         "fstream-npm": "1.2.0",
-        "glob": "7.1.1",
-        "graceful-fs": "4.1.11",
+        "glob": "7.1.0",
+        "graceful-fs": "4.1.9",
         "has-unicode": "2.0.1",
-        "hosted-git-info": "2.4.2",
+        "hosted-git-info": "2.1.5",
         "iferr": "0.1.5",
         "imurmurhash": "0.1.4",
-        "inflight": "1.0.6",
+        "inflight": "1.0.5",
         "inherits": "2.0.3",
         "ini": "1.3.4",
-        "init-package-json": "1.10.1",
-        "lazy-property": "1.0.0",
-        "lockfile": "1.0.3",
+        "init-package-json": "1.9.4",
+        "lockfile": "1.0.2",
         "lodash._baseindexof": "3.1.0",
         "lodash._baseuniq": "4.6.0",
         "lodash._bindcallback": "3.0.1",
@@ -5069,39 +5532,36 @@
         "lodash.union": "4.6.0",
         "lodash.uniq": "4.5.0",
         "lodash.without": "4.4.0",
-        "mississippi": "1.3.0",
         "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "node-gyp": "3.6.0",
-        "nopt": "4.0.1",
+        "node-gyp": "3.4.0",
+        "nopt": "3.0.6",
         "normalize-git-url": "3.0.2",
-        "normalize-package-data": "2.3.8",
+        "normalize-package-data": "2.3.5",
         "npm-cache-filename": "1.0.2",
         "npm-install-checks": "3.0.0",
-        "npm-package-arg": "4.2.1",
-        "npm-registry-client": "8.1.1",
+        "npm-package-arg": "4.2.0",
+        "npm-registry-client": "7.2.1",
         "npm-user-validate": "0.1.5",
-        "npmlog": "4.0.2",
+        "npmlog": "4.0.0",
         "once": "1.4.0",
-        "opener": "1.4.3",
-        "osenv": "0.1.4",
+        "opener": "1.4.2",
+        "osenv": "0.1.3",
         "path-is-inside": "1.0.2",
         "read": "1.0.7",
         "read-cmd-shim": "1.0.1",
         "read-installed": "4.0.3",
-        "read-package-json": "2.0.5",
+        "read-package-json": "2.0.4",
         "read-package-tree": "5.1.5",
-        "readable-stream": "2.2.9",
+        "readable-stream": "2.1.5",
         "readdir-scoped-modules": "1.0.2",
         "realize-package-specifier": "3.0.3",
-        "request": "2.81.0",
-        "retry": "0.10.1",
-        "rimraf": "2.6.1",
+        "request": "2.75.0",
+        "retry": "0.10.0",
+        "rimraf": "2.5.4",
         "semver": "5.3.0",
         "sha": "2.0.1",
         "slide": "1.1.6",
         "sorted-object": "2.0.1",
-        "sorted-union-stream": "2.1.3",
         "strip-ansi": "3.0.1",
         "tar": "2.2.1",
         "text-table": "0.2.0",
@@ -5109,39 +5569,19 @@
         "umask": "1.1.0",
         "unique-filename": "1.1.0",
         "unpipe": "1.0.0",
-        "update-notifier": "2.1.0",
-        "uuid": "3.0.1",
         "validate-npm-package-license": "3.0.1",
-        "validate-npm-package-name": "3.0.0",
-        "which": "1.2.14",
+        "validate-npm-package-name": "2.2.2",
+        "which": "1.2.11",
         "wrappy": "1.0.2",
-        "write-file-atomic": "1.3.3"
+        "write-file-atomic": "1.2.0"
       },
       "dependencies": {
-        "JSONStream": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "jsonparse": "1.3.0",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
-            }
-          }
-        },
         "abbrev": {
-          "version": "1.1.0",
+          "version": "1.0.9",
           "bundled": true
         },
         "ansi-regex": {
-          "version": "2.1.1",
+          "version": "2.0.0",
           "bundled": true
         },
         "ansicolors": {
@@ -5153,7 +5593,7 @@
           "bundled": true
         },
         "aproba": {
-          "version": "1.1.1",
+          "version": "1.0.4",
           "bundled": true
         },
         "archy": {
@@ -5164,14 +5604,6 @@
           "version": "2.0.5",
           "bundled": true
         },
-        "bluebird": {
-          "version": "3.5.0",
-          "bundled": true
-        },
-        "call-limit": {
-          "version": "1.1.0",
-          "bundled": true
-        },
         "chownr": {
           "version": "1.0.1",
           "bundled": true
@@ -5180,7 +5612,7 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
+            "graceful-fs": "4.1.9",
             "mkdirp": "0.5.1"
           }
         },
@@ -5247,32 +5679,32 @@
           "bundled": true
         },
         "fs-vacuum": {
-          "version": "1.2.10",
+          "version": "1.2.9",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
+            "graceful-fs": "4.1.9",
             "path-is-inside": "1.0.2",
-            "rimraf": "2.6.1"
+            "rimraf": "2.5.4"
           }
         },
         "fs-write-stream-atomic": {
-          "version": "1.0.10",
+          "version": "1.0.8",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
+            "graceful-fs": "4.1.9",
             "iferr": "0.1.5",
             "imurmurhash": "0.1.4",
-            "readable-stream": "2.2.9"
+            "readable-stream": "2.1.5"
           }
         },
         "fstream": {
-          "version": "1.0.11",
+          "version": "1.0.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
+            "graceful-fs": "4.1.9",
             "inherits": "2.0.3",
             "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
+            "rimraf": "2.5.4"
           }
         },
         "fstream-npm": {
@@ -5287,7 +5719,7 @@
               "version": "1.0.5",
               "bundled": true,
               "requires": {
-                "fstream": "1.0.11",
+                "fstream": "1.0.10",
                 "inherits": "2.0.3",
                 "minimatch": "3.0.3"
               },
@@ -5324,11 +5756,11 @@
           }
         },
         "glob": {
-          "version": "7.1.1",
+          "version": "7.1.0",
           "bundled": true,
           "requires": {
             "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
+            "inflight": "1.0.5",
             "inherits": "2.0.3",
             "minimatch": "3.0.3",
             "once": "1.4.0",
@@ -5373,7 +5805,7 @@
           }
         },
         "graceful-fs": {
-          "version": "4.1.11",
+          "version": "4.1.9",
           "bundled": true
         },
         "has-unicode": {
@@ -5381,7 +5813,7 @@
           "bundled": true
         },
         "hosted-git-info": {
-          "version": "2.4.2",
+          "version": "2.1.5",
           "bundled": true
         },
         "iferr": {
@@ -5393,7 +5825,7 @@
           "bundled": true
         },
         "inflight": {
-          "version": "1.0.6",
+          "version": "1.0.5",
           "bundled": true,
           "requires": {
             "once": "1.4.0",
@@ -5409,19 +5841,63 @@
           "bundled": true
         },
         "init-package-json": {
-          "version": "1.10.1",
+          "version": "1.9.4",
           "bundled": true,
           "requires": {
-            "glob": "7.1.1",
-            "npm-package-arg": "4.2.1",
+            "glob": "6.0.4",
+            "npm-package-arg": "4.2.0",
             "promzard": "0.3.0",
             "read": "1.0.7",
-            "read-package-json": "2.0.5",
+            "read-package-json": "2.0.4",
             "semver": "5.3.0",
             "validate-npm-package-license": "3.0.1",
-            "validate-npm-package-name": "3.0.0"
+            "validate-npm-package-name": "2.2.2"
           },
           "dependencies": {
+            "glob": {
+              "version": "6.0.4",
+              "bundled": true,
+              "requires": {
+                "inflight": "1.0.5",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.3",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.0"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.6"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.6",
+                      "bundled": true,
+                      "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.4.2",
+                          "bundled": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
             "promzard": {
               "version": "0.3.0",
               "bundled": true,
@@ -5431,12 +5907,8 @@
             }
           }
         },
-        "lazy-property": {
-          "version": "1.0.0",
-          "bundled": true
-        },
         "lockfile": {
-          "version": "1.0.3",
+          "version": "1.0.2",
           "bundled": true
         },
         "lodash._baseindexof": {
@@ -5500,163 +5972,6 @@
           "version": "4.4.0",
           "bundled": true
         },
-        "mississippi": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "concat-stream": "1.6.0",
-            "duplexify": "3.5.0",
-            "end-of-stream": "1.1.0",
-            "flush-write-stream": "1.0.2",
-            "from2": "2.3.0",
-            "parallel-transform": "1.1.0",
-            "pump": "1.0.2",
-            "pumpify": "1.3.5",
-            "stream-each": "1.2.0",
-            "through2": "2.0.3"
-          },
-          "dependencies": {
-            "concat-stream": {
-              "version": "1.6.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.2.9",
-                "typedarray": "0.0.6"
-              },
-              "dependencies": {
-                "typedarray": {
-                  "version": "0.0.6",
-                  "bundled": true
-                }
-              }
-            },
-            "duplexify": {
-              "version": "3.5.0",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "1.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.2.9",
-                "stream-shift": "1.0.0"
-              },
-              "dependencies": {
-                "end-of-stream": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "once": "1.3.3"
-                  },
-                  "dependencies": {
-                    "once": {
-                      "version": "1.3.3",
-                      "bundled": true,
-                      "requires": {
-                        "wrappy": "1.0.2"
-                      }
-                    }
-                  }
-                },
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "end-of-stream": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "once": "1.3.3"
-              },
-              "dependencies": {
-                "once": {
-                  "version": "1.3.3",
-                  "bundled": true,
-                  "requires": {
-                    "wrappy": "1.0.2"
-                  }
-                }
-              }
-            },
-            "flush-write-stream": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.2.9"
-              }
-            },
-            "from2": {
-              "version": "2.3.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.2.9"
-              }
-            },
-            "parallel-transform": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "cyclist": "0.2.2",
-                "inherits": "2.0.3",
-                "readable-stream": "2.2.9"
-              },
-              "dependencies": {
-                "cyclist": {
-                  "version": "0.2.2",
-                  "bundled": true
-                }
-              }
-            },
-            "pump": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "1.1.0",
-                "once": "1.4.0"
-              }
-            },
-            "pumpify": {
-              "version": "1.3.5",
-              "bundled": true,
-              "requires": {
-                "duplexify": "3.5.0",
-                "inherits": "2.0.3",
-                "pump": "1.0.2"
-              }
-            },
-            "stream-each": {
-              "version": "1.2.0",
-              "bundled": true,
-              "requires": {
-                "end-of-stream": "1.1.0",
-                "stream-shift": "1.0.0"
-              },
-              "dependencies": {
-                "stream-shift": {
-                  "version": "1.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "through2": {
-              "version": "2.0.3",
-              "bundled": true,
-              "requires": {
-                "readable-stream": "2.2.9",
-                "xtend": "4.0.1"
-              },
-              "dependencies": {
-                "xtend": {
-                  "version": "4.0.1",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
@@ -5670,56 +5985,24 @@
             }
           }
         },
-        "move-concurrently": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "copy-concurrently": "1.0.3",
-            "fs-write-stream-atomic": "1.0.10",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1",
-            "run-queue": "1.0.3"
-          },
-          "dependencies": {
-            "copy-concurrently": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "aproba": "1.1.1",
-                "fs-write-stream-atomic": "1.0.10",
-                "iferr": "0.1.5",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.1",
-                "run-queue": "1.0.3"
-              }
-            },
-            "run-queue": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "aproba": "1.1.1"
-              }
-            }
-          }
-        },
         "node-gyp": {
-          "version": "3.6.0",
+          "version": "3.4.0",
           "bundled": true,
           "requires": {
-            "fstream": "1.0.11",
-            "glob": "7.1.1",
-            "graceful-fs": "4.1.11",
+            "fstream": "1.0.10",
+            "glob": "7.1.0",
+            "graceful-fs": "4.1.9",
             "minimatch": "3.0.3",
             "mkdirp": "0.5.1",
             "nopt": "3.0.6",
-            "npmlog": "4.0.2",
-            "osenv": "0.1.4",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
+            "npmlog": "3.1.2",
+            "osenv": "0.1.3",
+            "path-array": "1.0.1",
+            "request": "2.75.0",
+            "rimraf": "2.5.4",
             "semver": "5.3.0",
             "tar": "2.2.1",
-            "which": "1.2.14"
+            "which": "1.2.11"
           },
           "dependencies": {
             "minimatch": {
@@ -5749,41 +6032,188 @@
                 }
               }
             },
-            "nopt": {
-              "version": "3.0.6",
+            "npmlog": {
+              "version": "3.1.2",
               "bundled": true,
               "requires": {
-                "abbrev": "1.1.0"
+                "are-we-there-yet": "1.1.2",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.6.0",
+                "set-blocking": "2.0.0"
+              },
+              "dependencies": {
+                "are-we-there-yet": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "delegates": "1.0.0",
+                    "readable-stream": "2.1.5"
+                  },
+                  "dependencies": {
+                    "delegates": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "gauge": {
+                  "version": "2.6.0",
+                  "bundled": true,
+                  "requires": {
+                    "aproba": "1.0.4",
+                    "console-control-strings": "1.1.0",
+                    "has-color": "0.1.7",
+                    "has-unicode": "2.0.1",
+                    "object-assign": "4.1.0",
+                    "signal-exit": "3.0.0",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wide-align": "1.1.0"
+                  },
+                  "dependencies": {
+                    "has-color": {
+                      "version": "0.1.7",
+                      "bundled": true
+                    },
+                    "object-assign": {
+                      "version": "4.1.0",
+                      "bundled": true
+                    },
+                    "signal-exit": {
+                      "version": "3.0.0",
+                      "bundled": true
+                    },
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.0.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "number-is-nan": "1.0.0"
+                          },
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "number-is-nan": "1.0.0"
+                          },
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wide-align": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "string-width": "1.0.2"
+                      }
+                    }
+                  }
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "path-array": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "array-index": "1.0.0"
+              },
+              "dependencies": {
+                "array-index": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "debug": "2.2.0",
+                    "es6-symbol": "3.1.0"
+                  },
+                  "dependencies": {
+                    "debug": {
+                      "version": "2.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "ms": "0.7.1"
+                      },
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "es6-symbol": {
+                      "version": "3.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "d": "0.1.1",
+                        "es5-ext": "0.10.12"
+                      },
+                      "dependencies": {
+                        "d": {
+                          "version": "0.1.1",
+                          "bundled": true,
+                          "requires": {
+                            "es5-ext": "0.10.12"
+                          }
+                        },
+                        "es5-ext": {
+                          "version": "0.10.12",
+                          "bundled": true,
+                          "requires": {
+                            "es6-iterator": "2.0.0",
+                            "es6-symbol": "3.1.0"
+                          },
+                          "dependencies": {
+                            "es6-iterator": {
+                              "version": "2.0.0",
+                              "bundled": true,
+                              "requires": {
+                                "d": "0.1.1",
+                                "es5-ext": "0.10.12",
+                                "es6-symbol": "3.1.0"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
               }
             }
           }
         },
         "nopt": {
-          "version": "4.0.1",
+          "version": "3.0.6",
           "bundled": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          },
-          "dependencies": {
-            "osenv": {
-              "version": "0.1.4",
-              "bundled": true,
-              "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
-              },
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "bundled": true
-                },
-                "os-tmpdir": {
-                  "version": "1.0.2",
-                  "bundled": true
-                }
-              }
-            }
+            "abbrev": "1.0.9"
           }
         },
         "normalize-git-url": {
@@ -5791,10 +6221,10 @@
           "bundled": true
         },
         "normalize-package-data": {
-          "version": "2.3.8",
+          "version": "2.3.5",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.4.2",
+            "hosted-git-info": "2.1.5",
             "is-builtin-module": "1.0.0",
             "semver": "5.3.0",
             "validate-npm-package-license": "3.0.1"
@@ -5827,43 +6257,197 @@
           }
         },
         "npm-package-arg": {
-          "version": "4.2.1",
+          "version": "4.2.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.4.2",
+            "hosted-git-info": "2.1.5",
             "semver": "5.3.0"
           }
         },
         "npm-registry-client": {
-          "version": "8.1.1",
+          "version": "7.2.1",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.0",
-            "graceful-fs": "4.1.11",
-            "normalize-package-data": "2.3.8",
-            "npm-package-arg": "4.2.1",
-            "npmlog": "4.0.2",
+            "concat-stream": "1.5.2",
+            "graceful-fs": "4.1.9",
+            "normalize-package-data": "2.3.5",
+            "npm-package-arg": "4.2.0",
+            "npmlog": "3.1.2",
             "once": "1.4.0",
-            "request": "2.81.0",
-            "retry": "0.10.1",
+            "request": "2.75.0",
+            "retry": "0.10.0",
             "semver": "5.3.0",
             "slide": "1.1.6"
           },
           "dependencies": {
             "concat-stream": {
-              "version": "1.6.0",
+              "version": "1.5.2",
               "bundled": true,
               "requires": {
                 "inherits": "2.0.3",
-                "readable-stream": "2.2.9",
+                "readable-stream": "2.0.6",
                 "typedarray": "0.0.6"
               },
               "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "bundled": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "bundled": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "bundled": true
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    }
+                  }
+                },
                 "typedarray": {
                   "version": "0.0.6",
                   "bundled": true
                 }
               }
+            },
+            "npmlog": {
+              "version": "3.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "1.1.2",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.6.0",
+                "set-blocking": "2.0.0"
+              },
+              "dependencies": {
+                "are-we-there-yet": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "delegates": "1.0.0",
+                    "readable-stream": "2.1.5"
+                  },
+                  "dependencies": {
+                    "delegates": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "gauge": {
+                  "version": "2.6.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "aproba": "1.0.4",
+                    "console-control-strings": "1.1.0",
+                    "has-color": "0.1.7",
+                    "has-unicode": "2.0.1",
+                    "object-assign": "4.1.0",
+                    "signal-exit": "3.0.0",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wide-align": "1.1.0"
+                  },
+                  "dependencies": {
+                    "has-color": {
+                      "version": "0.1.7",
+                      "bundled": true,
+                      "optional": true
+                    },
+                    "object-assign": {
+                      "version": "4.1.0",
+                      "bundled": true,
+                      "optional": true
+                    },
+                    "signal-exit": {
+                      "version": "3.0.0",
+                      "bundled": true,
+                      "optional": true
+                    },
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.0.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "number-is-nan": "1.0.0"
+                          },
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "number-is-nan": "1.0.0"
+                          },
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wide-align": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "optional": true,
+                      "requires": {
+                        "string-width": "1.0.2"
+                      }
+                    }
+                  }
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "retry": {
+              "version": "0.10.0",
+              "bundled": true
             }
           }
         },
@@ -5872,21 +6456,21 @@
           "bundled": true
         },
         "npmlog": {
-          "version": "4.0.2",
+          "version": "4.0.0",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
+            "are-we-there-yet": "1.1.2",
             "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
+            "gauge": "2.6.0",
             "set-blocking": "2.0.0"
           },
           "dependencies": {
             "are-we-there-yet": {
-              "version": "1.1.4",
+              "version": "1.1.2",
               "bundled": true,
               "requires": {
                 "delegates": "1.0.0",
-                "readable-stream": "2.2.9"
+                "readable-stream": "2.1.5"
               },
               "dependencies": {
                 "delegates": {
@@ -5900,49 +6484,63 @@
               "bundled": true
             },
             "gauge": {
-              "version": "2.7.4",
+              "version": "2.6.0",
               "bundled": true,
               "requires": {
-                "aproba": "1.1.1",
+                "aproba": "1.0.4",
                 "console-control-strings": "1.1.0",
+                "has-color": "0.1.7",
                 "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
+                "object-assign": "4.1.0",
+                "signal-exit": "3.0.0",
                 "string-width": "1.0.2",
                 "strip-ansi": "3.0.1",
                 "wide-align": "1.1.0"
               },
               "dependencies": {
+                "has-color": {
+                  "version": "0.1.7",
+                  "bundled": true
+                },
                 "object-assign": {
-                  "version": "4.1.1",
+                  "version": "4.1.0",
                   "bundled": true
                 },
                 "signal-exit": {
-                  "version": "3.0.2",
+                  "version": "3.0.0",
                   "bundled": true
                 },
                 "string-width": {
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "code-point-at": "1.1.0",
+                    "code-point-at": "1.0.0",
                     "is-fullwidth-code-point": "1.0.0",
                     "strip-ansi": "3.0.1"
                   },
                   "dependencies": {
                     "code-point-at": {
-                      "version": "1.1.0",
-                      "bundled": true
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "number-is-nan": "1.0.0"
+                      },
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        }
+                      }
                     },
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "1.0.0"
                       },
                       "dependencies": {
                         "number-is-nan": {
-                          "version": "1.0.1",
+                          "version": "1.0.0",
                           "bundled": true
                         }
                       }
@@ -5972,23 +6570,23 @@
           }
         },
         "opener": {
-          "version": "1.4.3",
+          "version": "1.4.2",
           "bundled": true
         },
         "osenv": {
-          "version": "0.1.4",
+          "version": "0.1.3",
           "bundled": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "1.0.1",
+            "os-tmpdir": "1.0.1"
           },
           "dependencies": {
             "os-homedir": {
-              "version": "1.0.2",
+              "version": "1.0.1",
               "bundled": true
             },
             "os-tmpdir": {
-              "version": "1.0.2",
+              "version": "1.0.1",
               "bundled": true
             }
           }
@@ -6014,7 +6612,7 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "4.1.9"
           }
         },
         "read-installed": {
@@ -6022,8 +6620,8 @@
           "bundled": true,
           "requires": {
             "debuglog": "1.0.1",
-            "graceful-fs": "4.1.11",
-            "read-package-json": "2.0.5",
+            "graceful-fs": "4.1.9",
+            "read-package-json": "2.0.4",
             "readdir-scoped-modules": "1.0.2",
             "semver": "5.3.0",
             "slide": "1.1.6",
@@ -6037,15 +6635,59 @@
           }
         },
         "read-package-json": {
-          "version": "2.0.5",
+          "version": "2.0.4",
           "bundled": true,
           "requires": {
-            "glob": "7.1.1",
-            "graceful-fs": "4.1.11",
+            "glob": "6.0.4",
+            "graceful-fs": "4.1.9",
             "json-parse-helpfulerror": "1.0.3",
-            "normalize-package-data": "2.3.8"
+            "normalize-package-data": "2.3.5"
           },
           "dependencies": {
+            "glob": {
+              "version": "6.0.4",
+              "bundled": true,
+              "requires": {
+                "inflight": "1.0.5",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.3",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.0"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.0.3",
+                  "bundled": true,
+                  "requires": {
+                    "brace-expansion": "1.1.6"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.6",
+                      "bundled": true,
+                      "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.4.2",
+                          "bundled": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "bundled": true
+                }
+              }
+            },
             "json-parse-helpfulerror": {
               "version": "1.0.3",
               "bundled": true,
@@ -6068,12 +6710,12 @@
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
             "once": "1.4.0",
-            "read-package-json": "2.0.5",
+            "read-package-json": "2.0.4",
             "readdir-scoped-modules": "1.0.2"
           }
         },
         "readable-stream": {
-          "version": "2.2.9",
+          "version": "2.1.5",
           "bundled": true,
           "requires": {
             "buffer-shims": "1.0.0",
@@ -6081,7 +6723,7 @@
             "inherits": "2.0.3",
             "isarray": "1.0.0",
             "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.0",
+            "string_decoder": "0.10.31",
             "util-deprecate": "1.0.2"
           },
           "dependencies": {
@@ -6102,11 +6744,8 @@
               "bundled": true
             },
             "string_decoder": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "buffer-shims": "1.0.0"
-              }
+              "version": "0.10.31",
+              "bundled": true
             },
             "util-deprecate": {
               "version": "1.0.2",
@@ -6120,7 +6759,7 @@
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
-            "graceful-fs": "4.1.11",
+            "graceful-fs": "4.1.9",
             "once": "1.4.0"
           }
         },
@@ -6129,35 +6768,34 @@
           "bundled": true,
           "requires": {
             "dezalgo": "1.0.3",
-            "npm-package-arg": "4.2.1"
+            "npm-package-arg": "4.2.0"
           }
         },
         "request": {
-          "version": "2.81.0",
+          "version": "2.75.0",
           "bundled": true,
           "requires": {
             "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
+            "aws4": "1.4.1",
+            "bl": "1.1.2",
+            "caseless": "0.11.0",
             "combined-stream": "1.0.5",
             "extend": "3.0.0",
             "forever-agent": "0.6.1",
-            "form-data": "2.1.2",
-            "har-validator": "4.2.1",
+            "form-data": "2.0.0",
+            "har-validator": "2.0.6",
             "hawk": "3.1.3",
             "http-signature": "1.1.1",
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.14",
+            "mime-types": "2.1.12",
+            "node-uuid": "1.4.7",
             "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
+            "qs": "6.2.1",
             "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
+            "tough-cookie": "2.3.1",
+            "tunnel-agent": "0.4.3"
           },
           "dependencies": {
             "aws-sign2": {
@@ -6165,11 +6803,54 @@
               "bundled": true
             },
             "aws4": {
-              "version": "1.6.0",
+              "version": "1.4.1",
               "bundled": true
             },
+            "bl": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "readable-stream": "2.0.6"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "bundled": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "bundled": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "bundled": true
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
             "caseless": {
-              "version": "0.12.0",
+              "version": "0.11.0",
               "bundled": true
             },
             "combined-stream": {
@@ -6194,12 +6875,12 @@
               "bundled": true
             },
             "form-data": {
-              "version": "2.1.2",
+              "version": "2.0.0",
               "bundled": true,
               "requires": {
                 "asynckit": "0.4.0",
                 "combined-stream": "1.0.5",
-                "mime-types": "2.1.14"
+                "mime-types": "2.1.12"
               },
               "dependencies": {
                 "asynckit": {
@@ -6209,43 +6890,109 @@
               }
             },
             "har-validator": {
-              "version": "4.2.1",
+              "version": "2.0.6",
               "bundled": true,
               "requires": {
-                "ajv": "4.11.4",
-                "har-schema": "1.0.5"
+                "chalk": "1.1.3",
+                "commander": "2.9.0",
+                "is-my-json-valid": "2.15.0",
+                "pinkie-promise": "2.0.1"
               },
               "dependencies": {
-                "ajv": {
-                  "version": "4.11.4",
+                "chalk": {
+                  "version": "1.1.3",
                   "bundled": true,
                   "requires": {
-                    "co": "4.6.0",
-                    "json-stable-stringify": "1.0.1"
+                    "ansi-styles": "2.2.1",
+                    "escape-string-regexp": "1.0.5",
+                    "has-ansi": "2.0.0",
+                    "strip-ansi": "3.0.1",
+                    "supports-color": "2.0.0"
                   },
                   "dependencies": {
-                    "co": {
-                      "version": "4.6.0",
+                    "ansi-styles": {
+                      "version": "2.2.1",
                       "bundled": true
                     },
-                    "json-stable-stringify": {
-                      "version": "1.0.1",
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "bundled": true
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "jsonify": "0.0.0"
-                      },
-                      "dependencies": {
-                        "jsonify": {
-                          "version": "0.0.0",
-                          "bundled": true
-                        }
+                        "ansi-regex": "2.0.0"
                       }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "bundled": true
                     }
                   }
                 },
-                "har-schema": {
-                  "version": "1.0.5",
-                  "bundled": true
+                "commander": {
+                  "version": "2.9.0",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-readlink": "1.0.1"
+                  },
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.15.0",
+                  "bundled": true,
+                  "requires": {
+                    "generate-function": "2.0.0",
+                    "generate-object-property": "1.2.0",
+                    "jsonpointer": "4.0.0",
+                    "xtend": "4.0.1"
+                  },
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "bundled": true,
+                      "requires": {
+                        "is-property": "1.0.2"
+                      },
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "4.0.0",
+                      "bundled": true
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "pinkie": "2.0.4"
+                  },
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "bundled": true
+                    }
+                  }
                 }
               }
             },
@@ -6292,7 +7039,7 @@
               "requires": {
                 "assert-plus": "0.2.0",
                 "jsprim": "1.3.1",
-                "sshpk": "1.11.0"
+                "sshpk": "1.10.1"
               },
               "dependencies": {
                 "assert-plus": {
@@ -6326,18 +7073,18 @@
                   }
                 },
                 "sshpk": {
-                  "version": "1.11.0",
+                  "version": "1.10.1",
                   "bundled": true,
                   "requires": {
                     "asn1": "0.2.3",
                     "assert-plus": "1.0.0",
-                    "bcrypt-pbkdf": "1.0.1",
-                    "dashdash": "1.14.1",
+                    "bcrypt-pbkdf": "1.0.0",
+                    "dashdash": "1.14.0",
                     "ecc-jsbn": "0.1.1",
                     "getpass": "0.1.6",
                     "jodid25519": "1.0.2",
-                    "jsbn": "0.1.1",
-                    "tweetnacl": "0.14.5"
+                    "jsbn": "0.1.0",
+                    "tweetnacl": "0.14.3"
                   },
                   "dependencies": {
                     "asn1": {
@@ -6349,15 +7096,15 @@
                       "bundled": true
                     },
                     "bcrypt-pbkdf": {
-                      "version": "1.0.1",
+                      "version": "1.0.0",
                       "bundled": true,
                       "optional": true,
                       "requires": {
-                        "tweetnacl": "0.14.5"
+                        "tweetnacl": "0.14.3"
                       }
                     },
                     "dashdash": {
-                      "version": "1.14.1",
+                      "version": "1.14.0",
                       "bundled": true,
                       "requires": {
                         "assert-plus": "1.0.0"
@@ -6368,7 +7115,7 @@
                       "bundled": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "0.1.0"
                       }
                     },
                     "getpass": {
@@ -6383,16 +7130,16 @@
                       "bundled": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "0.1.0"
                       }
                     },
                     "jsbn": {
-                      "version": "0.1.1",
+                      "version": "0.1.0",
                       "bundled": true,
                       "optional": true
                     },
                     "tweetnacl": {
-                      "version": "0.14.5",
+                      "version": "0.14.3",
                       "bundled": true,
                       "optional": true
                     }
@@ -6413,32 +7160,28 @@
               "bundled": true
             },
             "mime-types": {
-              "version": "2.1.14",
+              "version": "2.1.12",
               "bundled": true,
               "requires": {
-                "mime-db": "1.26.0"
+                "mime-db": "1.24.0"
               },
               "dependencies": {
                 "mime-db": {
-                  "version": "1.26.0",
+                  "version": "1.24.0",
                   "bundled": true
                 }
               }
+            },
+            "node-uuid": {
+              "version": "1.4.7",
+              "bundled": true
             },
             "oauth-sign": {
               "version": "0.8.2",
               "bundled": true
             },
-            "performance-now": {
-              "version": "0.2.0",
-              "bundled": true
-            },
             "qs": {
-              "version": "6.4.0",
-              "bundled": true
-            },
-            "safe-buffer": {
-              "version": "5.0.1",
+              "version": "6.2.1",
               "bundled": true
             },
             "stringstream": {
@@ -6446,36 +7189,24 @@
               "bundled": true
             },
             "tough-cookie": {
-              "version": "2.3.2",
-              "bundled": true,
-              "requires": {
-                "punycode": "1.4.1"
-              },
-              "dependencies": {
-                "punycode": {
-                  "version": "1.4.1",
-                  "bundled": true
-                }
-              }
+              "version": "2.3.1",
+              "bundled": true
             },
             "tunnel-agent": {
-              "version": "0.6.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.0.1"
-              }
+              "version": "0.4.3",
+              "bundled": true
             }
           }
         },
         "retry": {
-          "version": "0.10.1",
+          "version": "0.10.0",
           "bundled": true
         },
         "rimraf": {
-          "version": "2.6.1",
+          "version": "2.5.4",
           "bundled": true,
           "requires": {
-            "glob": "7.1.1"
+            "glob": "7.1.0"
           }
         },
         "semver": {
@@ -6486,8 +7217,8 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "readable-stream": "2.2.9"
+            "graceful-fs": "4.1.9",
+            "readable-stream": "2.1.5"
           }
         },
         "slide": {
@@ -6498,59 +7229,11 @@
           "version": "2.0.1",
           "bundled": true
         },
-        "sorted-union-stream": {
-          "version": "2.1.3",
-          "bundled": true,
-          "requires": {
-            "from2": "1.3.0",
-            "stream-iterate": "1.1.1"
-          },
-          "dependencies": {
-            "from2": {
-              "version": "1.3.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "1.1.14"
-              },
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.14",
-                  "bundled": true,
-                  "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
-                  },
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "bundled": true
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "bundled": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "stream-iterate": {
-              "version": "1.1.1",
-              "bundled": true
-            }
-          }
-        },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "2.0.0"
           }
         },
         "tar": {
@@ -6558,7 +7241,7 @@
           "bundled": true,
           "requires": {
             "block-stream": "0.0.8",
-            "fstream": "1.0.11",
+            "fstream": "1.0.10",
             "inherits": "2.0.3"
           },
           "dependencies": {
@@ -6603,470 +7286,6 @@
           "version": "1.0.0",
           "bundled": true
         },
-        "update-notifier": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "boxen": "1.0.0",
-            "chalk": "1.1.3",
-            "configstore": "3.0.0",
-            "is-npm": "1.0.0",
-            "latest-version": "3.0.0",
-            "lazy-req": "2.0.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "3.0.0"
-          },
-          "dependencies": {
-            "boxen": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "ansi-align": "1.1.0",
-                "camelcase": "4.0.0",
-                "chalk": "1.1.3",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.0.0",
-                "term-size": "0.1.1",
-                "widest-line": "1.0.0"
-              },
-              "dependencies": {
-                "ansi-align": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "1.0.2"
-                  },
-                  "dependencies": {
-                    "string-width": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      },
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "number-is-nan": "1.0.1"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "camelcase": {
-                  "version": "4.0.0",
-                  "bundled": true
-                },
-                "cli-boxes": {
-                  "version": "1.0.0",
-                  "bundled": true
-                },
-                "string-width": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "3.0.1"
-                  },
-                  "dependencies": {
-                    "is-fullwidth-code-point": {
-                      "version": "2.0.0",
-                      "bundled": true
-                    }
-                  }
-                },
-                "term-size": {
-                  "version": "0.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "execa": "0.4.0"
-                  },
-                  "dependencies": {
-                    "execa": {
-                      "version": "0.4.0",
-                      "bundled": true,
-                      "requires": {
-                        "cross-spawn-async": "2.2.5",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "1.0.0",
-                        "object-assign": "4.1.1",
-                        "path-key": "1.0.0",
-                        "strip-eof": "1.0.0"
-                      },
-                      "dependencies": {
-                        "cross-spawn-async": {
-                          "version": "2.2.5",
-                          "bundled": true,
-                          "requires": {
-                            "lru-cache": "4.0.2",
-                            "which": "1.2.14"
-                          },
-                          "dependencies": {
-                            "lru-cache": {
-                              "version": "4.0.2",
-                              "bundled": true,
-                              "requires": {
-                                "pseudomap": "1.0.2",
-                                "yallist": "2.0.0"
-                              },
-                              "dependencies": {
-                                "pseudomap": {
-                                  "version": "1.0.2",
-                                  "bundled": true
-                                },
-                                "yallist": {
-                                  "version": "2.0.0",
-                                  "bundled": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "npm-run-path": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "path-key": "1.0.0"
-                          }
-                        },
-                        "object-assign": {
-                          "version": "4.1.1",
-                          "bundled": true
-                        },
-                        "path-key": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "strip-eof": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "widest-line": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "1.0.2"
-                  },
-                  "dependencies": {
-                    "string-width": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      },
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "number-is-nan": "1.0.1"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              },
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "bundled": true
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "bundled": true
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "bundled": true
-                }
-              }
-            },
-            "configstore": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "dot-prop": "4.1.1",
-                "graceful-fs": "4.1.11",
-                "mkdirp": "0.5.1",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "1.3.3",
-                "xdg-basedir": "3.0.0"
-              },
-              "dependencies": {
-                "dot-prop": {
-                  "version": "4.1.1",
-                  "bundled": true,
-                  "requires": {
-                    "is-obj": "1.0.1"
-                  },
-                  "dependencies": {
-                    "is-obj": {
-                      "version": "1.0.1",
-                      "bundled": true
-                    }
-                  }
-                },
-                "unique-string": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "requires": {
-                    "crypto-random-string": "1.0.0"
-                  },
-                  "dependencies": {
-                    "crypto-random-string": {
-                      "version": "1.0.0",
-                      "bundled": true
-                    }
-                  }
-                }
-              }
-            },
-            "is-npm": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "latest-version": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "package-json": "3.1.0"
-              },
-              "dependencies": {
-                "package-json": {
-                  "version": "3.1.0",
-                  "bundled": true,
-                  "requires": {
-                    "got": "6.7.1",
-                    "registry-auth-token": "3.1.0",
-                    "registry-url": "3.1.0",
-                    "semver": "5.3.0"
-                  },
-                  "dependencies": {
-                    "got": {
-                      "version": "6.7.1",
-                      "bundled": true,
-                      "requires": {
-                        "create-error-class": "3.0.2",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "is-redirect": "1.0.0",
-                        "is-retry-allowed": "1.1.0",
-                        "is-stream": "1.1.0",
-                        "lowercase-keys": "1.0.0",
-                        "safe-buffer": "5.0.1",
-                        "timed-out": "4.0.1",
-                        "unzip-response": "2.0.1",
-                        "url-parse-lax": "1.0.0"
-                      },
-                      "dependencies": {
-                        "create-error-class": {
-                          "version": "3.0.2",
-                          "bundled": true,
-                          "requires": {
-                            "capture-stack-trace": "1.0.0"
-                          },
-                          "dependencies": {
-                            "capture-stack-trace": {
-                              "version": "1.0.0",
-                              "bundled": true
-                            }
-                          }
-                        },
-                        "duplexer3": {
-                          "version": "0.1.4",
-                          "bundled": true
-                        },
-                        "get-stream": {
-                          "version": "3.0.0",
-                          "bundled": true
-                        },
-                        "is-redirect": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "is-retry-allowed": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true
-                        },
-                        "lowercase-keys": {
-                          "version": "1.0.0",
-                          "bundled": true
-                        },
-                        "safe-buffer": {
-                          "version": "5.0.1",
-                          "bundled": true
-                        },
-                        "timed-out": {
-                          "version": "4.0.1",
-                          "bundled": true
-                        },
-                        "unzip-response": {
-                          "version": "2.0.1",
-                          "bundled": true
-                        },
-                        "url-parse-lax": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "requires": {
-                            "prepend-http": "1.0.4"
-                          },
-                          "dependencies": {
-                            "prepend-http": {
-                              "version": "1.0.4",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "registry-auth-token": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "rc": "1.1.7"
-                      },
-                      "dependencies": {
-                        "rc": {
-                          "version": "1.1.7",
-                          "bundled": true,
-                          "requires": {
-                            "deep-extend": "0.4.1",
-                            "ini": "1.3.4",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
-                          },
-                          "dependencies": {
-                            "deep-extend": {
-                              "version": "0.4.1",
-                              "bundled": true
-                            },
-                            "minimist": {
-                              "version": "1.2.0",
-                              "bundled": true
-                            },
-                            "strip-json-comments": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "registry-url": {
-                      "version": "3.1.0",
-                      "bundled": true,
-                      "requires": {
-                        "rc": "1.1.7"
-                      },
-                      "dependencies": {
-                        "rc": {
-                          "version": "1.1.7",
-                          "bundled": true,
-                          "requires": {
-                            "deep-extend": "0.4.1",
-                            "ini": "1.3.4",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
-                          },
-                          "dependencies": {
-                            "deep-extend": {
-                              "version": "0.4.1",
-                              "bundled": true
-                            },
-                            "minimist": {
-                              "version": "1.2.0",
-                              "bundled": true
-                            },
-                            "strip-json-comments": {
-                              "version": "2.0.1",
-                              "bundled": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "lazy-req": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "semver-diff": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "semver": "5.3.0"
-              }
-            },
-            "xdg-basedir": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true
-        },
         "validate-npm-package-license": {
           "version": "3.0.1",
           "bundled": true,
@@ -7109,27 +7328,27 @@
           }
         },
         "validate-npm-package-name": {
-          "version": "3.0.0",
+          "version": "2.2.2",
           "bundled": true,
           "requires": {
-            "builtins": "1.0.3"
+            "builtins": "0.0.7"
           },
           "dependencies": {
             "builtins": {
-              "version": "1.0.3",
+              "version": "0.0.7",
               "bundled": true
             }
           }
         },
         "which": {
-          "version": "1.2.14",
+          "version": "1.2.11",
           "bundled": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "1.1.2"
           },
           "dependencies": {
             "isexe": {
-              "version": "2.0.0",
+              "version": "1.1.2",
               "bundled": true
             }
           }
@@ -7139,22 +7358,51 @@
           "bundled": true
         },
         "write-file-atomic": {
-          "version": "1.3.3",
+          "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
+            "graceful-fs": "4.1.9",
             "imurmurhash": "0.1.4",
             "slide": "1.1.6"
           }
         }
       }
     },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+    "npm-path": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
+      "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
+      "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "which": "1.3.0"
+      }
+    },
+    "npm-run-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
+      "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
+      "dev": true,
+      "requires": {
+        "path-key": "1.0.0"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "2.12.2",
+        "npm-path": "2.0.3",
+        "which": "1.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        }
       }
     },
     "num2fraction": {
@@ -7222,12 +7470,9 @@
       "dev": true
     },
     "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "requires": {
-        "mimic-fn": "1.1.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "optimist": {
       "version": "0.6.1",
@@ -7269,37 +7514,34 @@
         }
       }
     },
+    "ora": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.3.0.tgz",
+      "integrity": "sha1-NnoHitJc+wltpQERXrW0AeB9dJU=",
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.2.0",
+        "log-symbols": "1.0.2"
+      }
+    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          }
-        }
+        "lcid": "1.0.0"
       }
+    },
+    "os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc="
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -7310,7 +7552,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "dev": true,
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
@@ -7319,38 +7560,39 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "p-limit": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-      "requires": {
-        "p-try": "1.0.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+      "dev": true
     },
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
       "requires": {
-        "p-limit": "1.2.0"
+        "p-limit": "1.1.0"
       }
     },
-    "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
     },
     "package-json": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
+      "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
       "requires": {
-        "got": "6.7.1",
+        "got": "5.7.1",
         "registry-auth-token": "3.3.1",
         "registry-url": "3.1.0",
-        "semver": "5.5.0"
+        "semver": "5.4.1"
       }
     },
     "pako": {
@@ -7415,9 +7657,12 @@
       "dev": true
     },
     "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -7427,12 +7672,14 @@
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
     },
     "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
+      "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
@@ -7450,19 +7697,10 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
       }
     },
     "pathval": {
@@ -7483,9 +7721,9 @@
       "integrity": "sha1-FggOlwqud5kTdWwtrviOqnSG30E="
     },
     "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -7512,11 +7750,11 @@
       }
     },
     "pkg-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "1.1.2"
       }
     },
     "platform": {
@@ -7535,55 +7773,19 @@
         "postcss": "5.2.18"
       }
     },
-    "plugin-error": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
-      "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
-      "dev": true,
-      "requires": {
-        "ansi-cyan": "0.1.1",
-        "ansi-red": "0.1.1",
-        "arr-diff": "1.1.0",
-        "arr-union": "2.1.0",
-        "extend-shallow": "1.1.4"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0",
-            "array-slice": "0.2.3"
-          }
-        },
-        "extend-shallow": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
-          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
-          "dev": true,
-          "requires": {
-            "kind-of": "1.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
-          "dev": true
-        }
-      }
-    },
     "popsicle": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-9.2.0.tgz",
-      "integrity": "sha512-petRj39w05GvH1WKuGFmzxR9+k+R9E7zX5XWTFee7P/qf88hMuLT7aAO/RsmldpQMtJsWQISkTQlfMRECKlxhw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-8.2.0.tgz",
+      "integrity": "sha1-/0QBAFyrQ6lBipFBBhHAAZdxLSE=",
       "requires": {
+        "any-promise": "1.3.0",
+        "arrify": "1.0.1",
         "concat-stream": "1.6.0",
         "form-data": "2.3.1",
         "make-error-cause": "1.2.2",
-        "tough-cookie": "2.3.3"
+        "throwback": "1.1.1",
+        "tough-cookie": "2.3.3",
+        "xtend": "4.0.1"
       }
     },
     "popsicle-proxy-agent": {
@@ -7621,59 +7823,11 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "js-base64": "2.4.1",
+        "js-base64": "2.4.0",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-              "dev": true
-            }
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
@@ -7889,48 +8043,6 @@
         "postcss-replace-overflow-wrap": "1.0.0",
         "postcss-selector-matches": "2.0.5",
         "postcss-selector-not": "2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
       }
     },
     "postcss-custom-media": {
@@ -8061,19 +8173,45 @@
       "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.16",
+        "postcss": "6.0.14",
         "postcss-media-query-parser": "0.2.3"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
         "postcss": {
-          "version": "6.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "5.1.0"
+            "supports-color": "4.5.0"
           }
         },
         "source-map": {
@@ -8083,9 +8221,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -8234,18 +8372,44 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.16"
+        "postcss": "6.0.14"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
         "postcss": {
-          "version": "6.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "5.1.0"
+            "supports-color": "4.5.0"
           }
         },
         "source-map": {
@@ -8255,9 +8419,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -8272,18 +8436,44 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.16"
+        "postcss": "6.0.14"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
         "postcss": {
-          "version": "6.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "5.1.0"
+            "supports-color": "4.5.0"
           }
         },
         "source-map": {
@@ -8293,9 +8483,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -8310,18 +8500,44 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.16"
+        "postcss": "6.0.14"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
         "postcss": {
-          "version": "6.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "5.1.0"
+            "supports-color": "4.5.0"
           }
         },
         "source-map": {
@@ -8331,9 +8547,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -8348,18 +8564,44 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.16"
+        "postcss": "6.0.14"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
         "postcss": {
-          "version": "6.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "5.1.0"
+            "supports-color": "4.5.0"
           }
         },
         "source-map": {
@@ -8369,9 +8611,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -8594,6 +8836,39 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
+      }
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -8623,9 +8898,12 @@
       }
     },
     "promise-finally": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/promise-finally/-/promise-finally-3.0.0.tgz",
-      "integrity": "sha1-3dXQ+JVDKxIGzrjaEnUGTRjnqiM="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/promise-finally/-/promise-finally-2.2.1.tgz",
+      "integrity": "sha1-ImFsS6kCkW6Yi9RsVNfKoIkQzXc=",
+      "requires": {
+        "any-promise": "1.3.0"
+      }
     },
     "proxy-addr": {
       "version": "1.1.5",
@@ -8742,14 +9020,23 @@
       }
     },
     "rc": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.4.tgz",
-      "integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
+      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
       "requires": {
         "deep-extend": "0.4.2",
         "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
+      }
+    },
+    "read-all-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+      "requires": {
+        "pinkie-promise": "2.0.1",
+        "readable-stream": "2.3.3"
       }
     },
     "read-cache": {
@@ -8759,21 +9046,12 @@
       "dev": true,
       "requires": {
         "pify": "2.3.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
       }
     },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
       "requires": {
         "load-json-file": "1.1.0",
         "normalize-package-data": "2.4.0",
@@ -8784,31 +9062,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
       "requires": {
         "find-up": "1.1.2",
         "read-pkg": "1.1.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        }
       }
     },
     "readable-stream": {
@@ -8940,9 +9196,9 @@
       "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
       "dev": true
     },
     "regex-cache": {
@@ -8970,7 +9226,7 @@
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "requires": {
-        "rc": "1.2.4",
+        "rc": "1.2.2",
         "safe-buffer": "5.1.1"
       }
     },
@@ -8979,7 +9235,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "requires": {
-        "rc": "1.2.4"
+        "rc": "1.2.2"
       }
     },
     "regjsgen": {
@@ -9006,15 +9262,15 @@
       }
     },
     "remap-istanbul": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.10.0.tgz",
-      "integrity": "sha512-C3vinclZ2p8na07f/f+JWLchmiofgqroyxBrkKPA4kkbjsHHa94HFd5ZYkYrMEs9cbsufh53t5DFJyTK8UDVjg==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.9.5.tgz",
+      "integrity": "sha1-oYYXsfMe7Fp9vud1OCmLd1YGqqg=",
       "dev": true,
       "requires": {
         "amdefine": "1.0.1",
+        "gulp-util": "3.0.7",
         "istanbul": "0.4.5",
         "minimatch": "3.0.4",
-        "plugin-error": "0.1.2",
         "source-map": "0.5.7",
         "through2": "2.0.1"
       }
@@ -9041,10 +9297,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
       "requires": {
         "is-finite": "1.0.2"
       }
+    },
+    "replace-ext": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+      "dev": true
     },
     "request": {
       "version": "2.42.0",
@@ -9118,6 +9379,12 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
+    "require-from-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -9136,12 +9403,12 @@
       "dev": true
     },
     "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
       }
     },
     "resumer": {
@@ -9191,17 +9458,26 @@
         "is-promise": "2.1.0"
       }
     },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+    "rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
     },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+    "rxjs": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+      "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+      "dev": true,
       "requires": {
-        "rx-lite": "4.0.8"
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {
@@ -9210,9 +9486,9 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
       "dev": true
     },
     "sax": {
@@ -9231,16 +9507,16 @@
       }
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "semver-diff": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
-        "semver": "5.5.0"
+        "semver": "5.4.1"
       }
     },
     "send": {
@@ -9250,7 +9526,7 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
+        "depd": "1.1.1",
         "destroy": "1.0.4",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
@@ -9274,14 +9550,6 @@
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
             "statuses": "1.3.1"
-          },
-          "dependencies": {
-            "depd": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-              "dev": true
-            }
           }
         },
         "mime": {
@@ -9331,6 +9599,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
       "requires": {
         "shebang-regex": "1.0.0"
       }
@@ -9338,7 +9607,8 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "shell-quote": {
       "version": "1.6.1",
@@ -9372,45 +9642,41 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "sinon": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.6.tgz",
-      "integrity": "sha1-nLNGvdsYDWioBEKf/hSXjX+v1ik=",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
       "dev": true,
       "requires": {
-        "diff": "3.4.0",
-        "formatio": "1.2.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.3.1",
-        "nise": "1.2.0",
-        "supports-color": "5.1.0",
-        "type-detect": "4.0.7"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": "0.10.3"
       }
+    },
+    "sinon-as-promised": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/sinon-as-promised/-/sinon-as-promised-4.0.3.tgz",
+      "integrity": "sha1-wFRbFoX9gTWIpO1pcBJIftEdFRs=",
+      "dev": true,
+      "requires": {
+        "create-thenable": "1.0.2",
+        "native-promise-only": "0.8.1"
+      }
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
     },
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "dev": true
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
     "sntp": {
       "version": "0.2.4",
@@ -9436,11 +9702,25 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
+    "sparkles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+      "dev": true
+    },
+    "spawn-sync": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+      "requires": {
+        "concat-stream": "1.6.0",
+        "os-shim": "0.1.3"
+      }
+    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true,
       "requires": {
         "spdx-license-ids": "1.2.2"
       }
@@ -9448,14 +9728,12 @@
     "spdx-expression-parse": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-      "dev": true
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
     },
     "spdx-license-ids": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-      "dev": true
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
     },
     "split": {
       "version": "0.2.10",
@@ -9472,6 +9750,12 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -9485,6 +9769,15 @@
       "dev": true,
       "requires": {
         "duplexer": "0.1.1"
+      }
+    },
+    "stream-to-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
+      "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
+      "dev": true,
+      "requires": {
+        "any-observable": "0.2.0"
       }
     },
     "strict-uri-encode": {
@@ -9505,12 +9798,13 @@
       "integrity": "sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y="
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -9521,6 +9815,17 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "stringify-object": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
+      "integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
+      }
+    },
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
@@ -9529,17 +9834,20 @@
       "optional": true
     },
     "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
     },
     "strip-dirs": {
       "version": "2.1.0",
@@ -9553,7 +9861,8 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "strip-indent": {
       "version": "1.0.1",
@@ -9570,12 +9879,9 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-      "requires": {
-        "has-flag": "2.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "svgo": {
       "version": "0.7.2",
@@ -9610,6 +9916,12 @@
         }
       }
     },
+    "symbol-observable": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+      "dev": true
+    },
     "tape": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.0.tgz",
@@ -9633,7 +9945,7 @@
       "dev": true,
       "requires": {
         "bl": "1.2.1",
-        "end-of-stream": "1.4.1",
+        "end-of-stream": "1.4.0",
         "readable-stream": "2.3.3",
         "xtend": "4.0.1"
       },
@@ -9653,14 +9965,27 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
       "requires": {
         "execa": "0.7.0"
       },
       "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
         "execa": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
           "requires": {
             "cross-spawn": "5.1.0",
             "get-stream": "3.0.0",
@@ -9670,14 +9995,29 @@
             "signal-exit": "3.0.2",
             "strip-eof": "1.0.0"
           }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
         }
       }
-    },
-    "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-      "dev": true
     },
     "thenify": {
       "version": "3.3.0",
@@ -9733,22 +10073,27 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/throwback/-/throwback-1.1.1.tgz",
       "integrity": "sha1-8AfnwXYEptFtegfEGqDo/txhhKQ=",
-      "dev": true,
       "requires": {
         "any-promise": "1.3.0"
       }
     },
+    "time-stamp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+      "dev": true
+    },
     "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
     },
     "timers-ext": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
       "integrity": "sha1-YcxHp2wavTGV8UUn+XjViulMUgQ=",
       "requires": {
-        "es5-ext": "0.10.38",
+        "es5-ext": "0.10.37",
         "next-tick": "1.0.0"
       }
     },
@@ -9761,7 +10106,7 @@
         "body-parser": "1.14.2",
         "debug": "2.2.0",
         "faye-websocket": "0.10.0",
-        "livereload-js": "2.3.0",
+        "livereload-js": "2.2.2",
         "parseurl": "1.3.2",
         "qs": "5.1.0"
       },
@@ -9790,9 +10135,9 @@
       }
     },
     "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+      "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
       "requires": {
         "os-tmpdir": "1.0.2"
       }
@@ -9832,14 +10177,14 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
-      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
+      "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg=="
     },
     "tslint": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
-      "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.2.0.tgz",
+      "integrity": "sha1-FqKt3yDLdIOF9UTpoO2rCGvDQRQ=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
@@ -9848,9 +10193,10 @@
         "findup-sync": "0.3.0",
         "glob": "7.1.2",
         "optimist": "0.6.1",
-        "resolve": "1.1.7",
-        "tsutils": "1.9.1",
-        "update-notifier": "2.3.0"
+        "resolve": "1.5.0",
+        "semver": "5.4.1",
+        "tslib": "1.8.0",
+        "tsutils": "1.9.1"
       },
       "dependencies": {
         "colors": {
@@ -9864,7 +10210,26 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
           "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
           "dev": true
+        },
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          }
         }
+      }
+    },
+    "tslint-plugin-prettier": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
+      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-prettier": "2.4.0",
+        "tslib": "1.8.0"
       }
     },
     "tsutils": {
@@ -9889,9 +10254,9 @@
       }
     },
     "type-detect": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.7.tgz",
-      "integrity": "sha512-4Rh17pAMVdMWzktddFhISRnUnFIStObtUMNGzDwlA6w/77bmGv3aBbRdCmQR6IjzfkTo9otnW+2K/cDRhKSxDA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
+      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
       "dev": true
     },
     "type-is": {
@@ -9921,16 +10286,42 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
         },
         "async-each": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
           "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
           "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
         },
         "chokidar": {
           "version": "1.7.0",
@@ -9949,28 +10340,39 @@
             "readdirp": "2.1.0"
           }
         },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            }
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
           }
         },
         "fsevents": {
@@ -10877,6 +11279,12 @@
             }
           }
         },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
         "glob-parent": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
@@ -10886,14 +11294,17 @@
             "is-glob": "2.0.1"
           }
         },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
@@ -10916,6 +11327,32 @@
             "strip-bom": "3.0.0"
           }
         },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
         "path-type": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
@@ -10924,12 +11361,6 @@
           "requires": {
             "pify": "2.3.0"
           }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
         },
         "read-pkg": {
           "version": "2.0.0",
@@ -10964,14 +11395,45 @@
             "set-immediate-shim": "1.0.1"
           }
         },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
         },
         "yargs": {
           "version": "8.0.2",
@@ -11019,7 +11481,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.93",
+        "@types/lodash": "4.14.87",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",
@@ -11027,7 +11489,7 @@
         "handlebars": "4.0.5",
         "highlight.js": "9.12.0",
         "lodash": "4.17.4",
-        "marked": "0.3.12",
+        "marked": "0.3.7",
         "minimatch": "3.0.4",
         "progress": "1.1.8",
         "shelljs": "0.7.8",
@@ -11041,7 +11503,7 @@
           "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
           "dev": true,
           "requires": {
-            "@types/node": "8.5.9"
+            "@types/node": "6.0.92"
           }
         },
         "@types/minimatch": {
@@ -11078,15 +11540,6 @@
             "uglify-js": "2.8.29"
           }
         },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        },
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
@@ -11116,42 +11569,52 @@
       "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
     },
     "typings-core": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/typings-core/-/typings-core-2.3.3.tgz",
-      "integrity": "sha1-CexUzVsR3V8e8vwKsx03ACyita0=",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/typings-core/-/typings-core-1.6.1.tgz",
+      "integrity": "sha1-zkspMeovGbuPPay+xpmDrE6WSjc=",
       "requires": {
+        "any-promise": "1.3.0",
         "array-uniq": "1.0.3",
-        "configstore": "3.1.1",
+        "configstore": "2.1.0",
         "debug": "2.6.9",
-        "detect-indent": "5.0.0",
+        "detect-indent": "4.0.0",
         "graceful-fs": "4.1.11",
         "has": "1.0.1",
         "invariant": "2.2.2",
         "is-absolute": "0.2.6",
-        "jspm-config": "0.3.4",
         "listify": "1.0.0",
         "lockfile": "1.0.3",
         "make-error-cause": "1.2.2",
         "mkdirp": "0.5.1",
         "object.pick": "1.3.0",
         "parse-json": "2.2.0",
-        "popsicle": "9.2.0",
+        "popsicle": "8.2.0",
         "popsicle-proxy-agent": "3.0.0",
         "popsicle-retry": "3.2.1",
         "popsicle-rewrite": "1.0.0",
         "popsicle-status": "2.0.1",
-        "promise-finally": "3.0.0",
-        "rc": "1.2.4",
+        "promise-finally": "2.2.1",
+        "rc": "1.2.2",
         "rimraf": "2.6.2",
         "sort-keys": "1.1.2",
         "string-template": "1.0.0",
-        "strip-bom": "3.0.0",
+        "strip-bom": "2.0.0",
         "thenify": "3.3.0",
         "throat": "3.2.0",
         "touch": "1.0.0",
         "typescript": "2.6.2",
         "xtend": "4.0.1",
         "zip-object": "0.1.0"
+      },
+      "dependencies": {
+        "detect-indent": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+          "requires": {
+            "repeating": "2.0.1"
+          }
+        }
       }
     },
     "uglify-js": {
@@ -11184,6 +11647,13 @@
             "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           }
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+          "dev": true,
+          "optional": true
         },
         "wordwrap": {
           "version": "0.0.2",
@@ -11274,10 +11744,17 @@
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
     },
+    "unique-concat": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/unique-concat/-/unique-concat-0.2.2.tgz",
+      "integrity": "sha1-khD5vcqsxeHjkpSQ18AZ35bxhxI=",
+      "dev": true
+    },
     "unique-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
       "requires": {
         "crypto-random-string": "1.0.0"
       }
@@ -11292,11 +11769,6 @@
         "viewport-dimensions": "0.2.0"
       }
     },
-    "universalify": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
-    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -11304,24 +11776,23 @@
       "dev": true
     },
     "unzip-response": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
     },
     "update-notifier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
+      "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
       "requires": {
-        "boxen": "1.3.0",
-        "chalk": "2.3.0",
-        "configstore": "3.1.1",
-        "import-lazy": "2.1.0",
-        "is-installed-globally": "0.1.0",
+        "boxen": "0.6.0",
+        "chalk": "1.1.3",
+        "configstore": "2.1.0",
         "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
+        "latest-version": "2.0.0",
+        "lazy-req": "1.1.0",
         "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
+        "xdg-basedir": "2.0.0"
       }
     },
     "url-parse-lax": {
@@ -11341,6 +11812,23 @@
         "tape": "2.3.0"
       }
     },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        }
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -11355,14 +11843,12 @@
     "uuid": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-      "dev": true
+      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true,
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
@@ -11385,6 +11871,17 @@
       "resolved": "https://registry.npmjs.org/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz",
       "integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w=",
       "dev": true
+    },
+    "vinyl": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+      "dev": true,
+      "requires": {
+        "clone": "1.0.3",
+        "clone-stats": "0.0.1",
+        "replace-ext": "0.0.1"
+      }
     },
     "websocket-driver": {
       "version": "0.7.0",
@@ -11417,24 +11914,22 @@
       }
     },
     "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
     },
     "widest-line": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "1.0.2"
       }
     },
     "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
-      "optional": true
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
     },
     "wordwrap": {
       "version": "0.0.3",
@@ -11449,39 +11944,6 @@
       "requires": {
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
       }
     },
     "wrappy": {
@@ -11490,13 +11952,13 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
       "requires": {
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "slide": "1.1.6"
       }
     },
     "ws": {
@@ -11518,9 +11980,12 @@
       }
     },
     "xdg-basedir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+      "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "xml2js": {
       "version": "0.4.19",
@@ -11554,30 +12019,40 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.1.tgz",
-      "integrity": "sha512-7uRL1HZdCbc1QTP+X8mehOPuCYKC/XTaqAPj7gABLfTt6pgLyVRn3QVte4qhtilZouWCvqd1kipgMKl5tKsFiw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-5.0.0.tgz",
+      "integrity": "sha1-M1UUSXfQV1fbuG1uOOwFYSOzpm4=",
       "requires": {
-        "cliui": "4.0.0",
+        "cliui": "3.2.0",
         "decamelize": "1.2.0",
-        "find-up": "2.1.0",
         "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
+        "lodash.assign": "4.2.0",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
         "require-directory": "2.1.1",
         "require-main-filename": "1.0.1",
         "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "window-size": "0.2.0",
         "y18n": "3.2.1",
-        "yargs-parser": "8.1.0"
+        "yargs-parser": "3.2.0"
       }
     },
     "yargs-parser": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-      "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-3.2.0.tgz",
+      "integrity": "sha1-UIE1XRnZ0MjF2BrakIy05tGGZk8=",
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "3.0.0",
+        "lodash.assign": "4.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+        }
       }
     },
     "yauzl": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "sinon": "^4.1.3",
     "lint-staged": "6.0.0",
     "prettier": "1.9.2",
-    "sinon-as-promised": "^4.0.2",
     "tslint": "5.2.0",
     "typescript": "~2.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "url": "https://github.com/dojo/cli.git"
   },
   "scripts": {
+    "precommit": "lint-staged",
+    "prettier": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "test": "grunt test"
   },
   "bin": {
@@ -70,9 +72,30 @@
     "glob": "^7.0.3",
     "grunt": "~1.0.1",
     "grunt-dojo2": "latest",
+    "grunt-tslint": "5.0.1",
+    "husky": "0.14.3",
     "intern": "~4.1.0",
     "mockery": "^2.1.0",
     "sinon": "^4.1.3",
+    "lint-staged": "6.0.0",
+    "prettier": "1.9.2",
+    "sinon-as-promised": "^4.0.2",
+    "tslint": "5.2.0",
+    "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "tabWidth": 4,
+    "useTabs": true,
+    "parser": "typescript",
+    "printWidth": 120,
+    "arrowParens": "always"
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "prettier": "1.9.2",
     "sinon-as-promised": "^4.0.2",
     "tslint": "5.2.0",
-    "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
   },
   "lint-staged": {

--- a/src/CommandHelper.ts
+++ b/src/CommandHelper.ts
@@ -40,8 +40,7 @@ export class SingleCommandHelper implements CommandHelper {
 		if (command) {
 			const helper = new HelperFactory(this, yargs, this._context, this._configurationFactory);
 			return command.run(helper.sandbox(group, command.name), args);
-		}
-		else {
+		} else {
 			return Promise.reject(new Error('The command does not exist'));
 		}
 	}

--- a/src/Helper.ts
+++ b/src/Helper.ts
@@ -9,12 +9,17 @@ import { CommandHelper, Helper } from './interfaces';
  * other tasks.
  */
 export class HelperFactory {
-	constructor(commandHelper: CommandHelper, yargs: Argv, context: any, configurationFactory: ConfigurationHelperFactory) {
+	constructor(
+		commandHelper: CommandHelper,
+		yargs: Argv,
+		context: any,
+		configurationFactory: ConfigurationHelperFactory
+	) {
 		this.command = commandHelper;
 		this.yargs = yargs;
 		this.context = context;
 		this.configurationFactory = configurationFactory;
-	};
+	}
 	command: CommandHelper;
 	yargs: Argv;
 	context: any;

--- a/src/allCommands.ts
+++ b/src/allCommands.ts
@@ -1,13 +1,6 @@
-import {
-	loadCommands,
-	enumerateInstalledCommands,
-	enumerateBuiltInCommands
-} from './loadCommands';
+import { loadCommands, enumerateInstalledCommands, enumerateBuiltInCommands } from './loadCommands';
 import { LoadedCommands } from './interfaces';
-import {
-	initCommandLoader,
-	createBuiltInCommandLoader }
-	from './command';
+import { initCommandLoader, createBuiltInCommandLoader } from './command';
 import config from './config';
 
 const commands: LoadedCommands = {
@@ -44,7 +37,10 @@ export default async function loadAllCommands(): Promise<LoadedCommands> {
 	const installedCommands = await loadExternalCommands();
 
 	commands.commandsMap = new Map([...installedCommands.commandsMap, ...builtInCommands.commandsMap]);
-	commands.yargsCommandNames = new Map([...installedCommands.yargsCommandNames, ...builtInCommands.yargsCommandNames]);
+	commands.yargsCommandNames = new Map([
+		...installedCommands.yargsCommandNames,
+		...builtInCommands.yargsCommandNames
+	]);
 	loaded = true;
 	return Promise.resolve(commands);
 }

--- a/src/command.ts
+++ b/src/command.ts
@@ -9,7 +9,7 @@ const cliui = require('cliui');
  * 		- '@dojo/cli-serve-dist'
  */
 export function initCommandLoader(searchPrefixes: string[]): (path: string) => CommandWrapper {
-	const commandRegExp = new RegExp(`(?:${searchPrefixes.join('|').replace('\/', '\\/')})-([^-]+)-(.+)$`);
+	const commandRegExp = new RegExp(`(?:${searchPrefixes.join('|').replace('/', '\\/')})-([^-]+)-(.+)$`);
 
 	return function load(path: string): CommandWrapper {
 		let module = require(path);
@@ -18,7 +18,7 @@ export function initCommandLoader(searchPrefixes: string[]): (path: string) => C
 			const command = convertModuleToCommand(module);
 			const { description, register, run, alias, eject } = command;
 			//  derive the group and name from the module directory name, e.g. dojo-cli-group-name
-			const [ , group, name] = <string[]> commandRegExp.exec(path);
+			const [, group, name] = <string[]>commandRegExp.exec(path);
 
 			return {
 				name,
@@ -40,7 +40,6 @@ export function initCommandLoader(searchPrefixes: string[]): (path: string) => C
  * Creates a builtIn command loader function.
  */
 export function createBuiltInCommandLoader(): (path: string) => CommandWrapper {
-
 	return function load(path: string): CommandWrapper {
 		const module = require(path);
 
@@ -71,8 +70,7 @@ export function convertModuleToCommand(module: any): Command {
 
 	if (module.description && module.register && module.run) {
 		return module;
-	}
-	else {
+	} else {
 		throw new Error(`Module does not satisfy the Command interface`);
 	}
 }
@@ -81,16 +79,15 @@ export function getGroupDescription(commandNames: Set<string>, commands: Command
 	const numCommands = commandNames.size;
 	if (numCommands > 1) {
 		return getMultiCommandDescription(commandNames, commands);
-	}
-	else {
-		const { description } = <CommandWrapper> commands.get(Array.from(commandNames.keys())[0]);
+	} else {
+		const { description } = <CommandWrapper>commands.get(Array.from(commandNames.keys())[0]);
 		return description;
 	}
 }
 
 function getMultiCommandDescription(commandNames: Set<string>, commands: CommandsMap): string {
 	const descriptions = Array.from(commandNames.keys(), (commandName) => {
-		const { name, description } = (<CommandWrapper> commands.get(commandName));
+		const { name, description } = <CommandWrapper>commands.get(commandName);
 		return `${name}  \t${description}`;
 	});
 	const ui = cliui({

--- a/src/commands/eject.ts
+++ b/src/commands/eject.ts
@@ -13,7 +13,7 @@ const { green, underline, yellow } = chalk;
 const copiedFilesDir = 'config';
 const ejectedKey = 'ejected';
 
-export interface EjectArgs extends Argv {};
+export interface EjectArgs extends Argv {}
 
 export interface EjectableCommandWrapper extends CommandWrapper {
 	eject(helper: Helper): EjectOutput;
@@ -40,23 +40,24 @@ function copyFiles(commandName: string, { path, files }: FileCopyConfig): void {
 }
 
 async function run(helper: Helper, args: EjectArgs): Promise<any> {
-	return inquirer.prompt({
-		type: 'confirm',
-		name: 'eject',
-		message: 'Are you sure you want to eject (this is a permanent operation)?',
-		default: false
-	}).then((answer) => {
-		if (!answer.eject) {
-			throw Error('Aborting eject');
-		}
-		return loadExternalCommands()
-			.then(async (commands) => {
+	return inquirer
+		.prompt({
+			type: 'confirm',
+			name: 'eject',
+			message: 'Are you sure you want to eject (this is a permanent operation)?',
+			default: false
+		})
+		.then((answer) => {
+			if (!answer.eject) {
+				throw Error('Aborting eject');
+			}
+			return loadExternalCommands().then(async (commands) => {
 				const npmPackages: NpmPackage = {
 					dependencies: {},
 					devDependencies: {}
 				};
 
-				const toEject = [ ...commands.commandsMap.values() ].reduce((toEject, command) => {
+				const toEject = [...commands.commandsMap.values()].reduce((toEject, command) => {
 					if (isEjectableCommandWrapper(command)) {
 						toEject.add(command);
 					}
@@ -93,8 +94,7 @@ async function run(helper: Helper, args: EjectArgs): Promise<any> {
 							console.log(' ' + hint);
 						});
 					}
-				}
-				else {
+				} else {
 					console.log('There are no commands that can be ejected');
 				}
 			});

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -22,7 +22,7 @@ async function run(helper: Helper, args: {}) {
 	const { commandsMap } = await loadExternalCommands();
 	const values = [];
 
-	for (let [ , value ] of commandsMap.entries()) {
+	for (let [, value] of commandsMap.entries()) {
 		const name = `${value.group}-${value.name}`;
 		if (values.indexOf(value) === -1 && json[name] === undefined) {
 			json[name] = {};

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -43,7 +43,7 @@ type DavidDependencies = {
 	[dependencyName: string]: {
 		stable: string;
 		latest: string;
-	}
+	};
 };
 
 /**
@@ -67,21 +67,23 @@ function areCommandsOutdated(moduleVersions: ModuleVersion[]): Promise<any> {
 
 	return new Promise((resolve, reject) => {
 		// we want to fetch the latest stable version for our devDependencies
-		david.getUpdatedDependencies(manifest, { dev: true }, function (err: any, deps: DavidDependencies) {
+		david.getUpdatedDependencies(manifest, { dev: true }, function(err: any, deps: DavidDependencies) {
 			if (err) {
 				reject(err);
 			}
-			resolve(moduleVersions.map((command) => {
-				const canBeUpdated = deps[command.name];    // david returns all deps that can be updated
-				const versionStr = canBeUpdated ?
-					`${command.version} ${chalk.yellow(`(can be updated to ${deps[command.name].latest})`)}.` :
-					`${command.version} (on latest stable version).`;
-				return {
-					name: command.name,
-					version: versionStr,
-					group: command.group
-				};
-			}));
+			resolve(
+				moduleVersions.map((command) => {
+					const canBeUpdated = deps[command.name]; // david returns all deps that can be updated
+					const versionStr = canBeUpdated
+						? `${command.version} ${chalk.yellow(`(can be updated to ${deps[command.name].latest})`)}.`
+						: `${command.version} (on latest stable version).`;
+					return {
+						name: command.name,
+						version: versionStr,
+						group: command.group
+					};
+				})
+			);
 		});
 	});
 }
@@ -109,22 +111,23 @@ function createOutput(myPackageDetails: PackageDetails, commandVersions: ModuleV
 	let output = '';
 	if (commandVersions.length) {
 		output += versionRegisteredCommands;
-		output += '\n'
-			+ commandVersions.map((command) => `${command.group} (${command.name}) ${command.version}`).join('\n')
-			+ '\n';
-	}
-	else {
+		output +=
+			'\n' +
+			commandVersions.map((command) => `${command.group} (${command.name}) ${command.version}`).join('\n') +
+			'\n';
+	} else {
 		output += versionNoRegisteredCommands;
 	}
 
-	output += versionCurrentVersion.replace('\{version\}', myPackageDetails.version);
+	output += versionCurrentVersion.replace('{version}', myPackageDetails.version);
 	return output;
 }
 
 function register(options: OptionsHelper): void {
 	options('o', {
 		alias: 'outdated',
-		describe: 'Output a list of installed commands and check if any can be updated to a more recent stable version.',
+		describe:
+			'Output a list of installed commands and check if any can be updated to a more recent stable version.',
 		demand: false,
 		type: 'boolean'
 	});
@@ -172,8 +175,11 @@ function buildVersions(commandsMap: CommandsMap): ModuleVersion[] {
 	 * Loop over commandsMap and create a new map with one entry per command, then loop over each entry and extract
 	 * the package details.
 	 */
-	const consolidatedCommands = [ ...new Map<string, string>([ ...commandsMap ]
-		.map(([, command]) => <[string, string]> [ command.path, command.group ])) ];
+	const consolidatedCommands = [
+		...new Map<string, string>(
+			[...commandsMap].map(([, command]) => <[string, string]>[command.path, command.group])
+		)
+	];
 
 	const versionInfo = consolidatedCommands
 		.map(([path, group]) => {
@@ -189,7 +195,7 @@ function buildVersions(commandsMap: CommandsMap): ModuleVersion[] {
 			// remove inbuilt commands or commands that dont have a valid version in the package.json
 			return val.version !== versionNoVersion && val.version !== INBUILT_COMMAND_VERSION;
 		})
-		.sort((a, b) => a.group > b.group ? 1 : -1);
+		.sort((a, b) => (a.group > b.group ? 1 : -1));
 	return versionInfo;
 }
 
@@ -203,15 +209,16 @@ function buildVersions(commandsMap: CommandsMap): ModuleVersion[] {
  */
 function createVersionsString(commandsMap: CommandsMap, checkOutdated: boolean): Promise<string> {
 	const packagePath = pkgDir.sync(__dirname);
-	const myPackageDetails = readPackageDetails(packagePath);	// fetch the cli's package details
+	const myPackageDetails = readPackageDetails(packagePath); // fetch the cli's package details
 	const versions: ModuleVersion[] = buildVersions(commandsMap);
 
 	if (checkOutdated) {
-		return areCommandsOutdated(versions)
-			.then((commandVersions: ModuleVersion[]) => createOutput(myPackageDetails, commandVersions),
-				(err) => {
-					return `Something went wrong trying to fetch command versions: ${err.message}`;
-				});
+		return areCommandsOutdated(versions).then(
+			(commandVersions: ModuleVersion[]) => createOutput(myPackageDetails, commandVersions),
+			(err) => {
+				return `Something went wrong trying to fetch command versions: ${err.message}`;
+			}
+		);
 	} else {
 		return Promise.resolve(createOutput(myPackageDetails, versions));
 	}

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,11 +4,7 @@ const packagePath = pkgDir.sync(__dirname);
 import { CliConfig } from './interfaces';
 
 export default {
-	searchPaths: [
-		'node_modules',
-		join(__dirname, '..', '..'),
-		join(packagePath, 'node_modules')
-	],
-	searchPrefixes: [ '@dojo/cli', 'dojo-cli' ],
-	builtInCommandLocation: join(__dirname, '/commands')  // better to be relative to this file (like an import) than link to publish structure
+	searchPaths: ['node_modules', join(__dirname, '..', '..'), join(packagePath, 'node_modules')],
+	searchPrefixes: ['@dojo/cli', 'dojo-cli'],
+	builtInCommandLocation: join(__dirname, '/commands') // better to be relative to this file (like an import) than link to publish structure
 } as CliConfig;

--- a/src/detachedCheckForNewCommands.ts
+++ b/src/detachedCheckForNewCommands.ts
@@ -4,8 +4,10 @@ import * as Configstore from 'configstore';
 const options = JSON.parse(process.argv[2]);
 const conf = new Configstore(options.name);
 
-getLatestCommands(options.name, conf).then(() => {
-	process.exit();
-}).catch(() => {
-	process.exit(1);
-});
+getLatestCommands(options.name, conf)
+	.then(() => {
+		process.exit();
+	})
+	.catch(() => {
+		process.exit(1);
+	});

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ async function init() {
 	try {
 		const packagePath = pkgDir.sync(__dirname);
 		const packageJsonFilePath = join(packagePath, 'package.json');
-		const packageJson = <any> require(packageJsonFilePath);
+		const packageJson = <any>require(packageJsonFilePath);
 
 		updateNotifier(packageJson);
 

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -7,9 +7,9 @@ export interface NpmPackageDetails {
 }
 
 export type CliConfig = {
-	searchPaths: string[],
-	searchPrefixes: string[],
-	builtInCommandLocation: string
+	searchPaths: string[];
+	searchPrefixes: string[];
+	builtInCommandLocation: string;
 };
 
 export interface Config {
@@ -97,8 +97,8 @@ export interface CommandError {
 export type YargsCommandNames = Map<string, Set<string>>;
 
 export type LoadedCommands = {
-	commandsMap: CommandsMap,
-	yargsCommandNames: YargsCommandNames
+	commandsMap: CommandsMap;
+	yargsCommandNames: YargsCommandNames;
 };
 
 export interface CommandWrapper extends Command {

--- a/src/loadCommands.ts
+++ b/src/loadCommands.ts
@@ -18,7 +18,7 @@ export function isEjected(groupName: string, command: string): boolean {
  * @param config
  * @returns {Promise<string []>} the paths of all installed commands
  */
-export async function enumerateInstalledCommands (config: CliConfig): Promise <string []> {
+export async function enumerateInstalledCommands(config: CliConfig): Promise<string[]> {
 	const { searchPrefixes } = config;
 	const globPaths = searchPrefixes.reduce((globPaths: string[], key) => {
 		return globPaths.concat(config.searchPaths.map((depPath) => pathResolve(depPath, `${key}-*`)));
@@ -31,7 +31,7 @@ export async function enumerateInstalledCommands (config: CliConfig): Promise <s
  * @param config
  * @returns {Promise<string []>} the paths of all builtIn commands
  */
-export async function enumerateBuiltInCommands (config: CliConfig): Promise <string []> {
+export async function enumerateBuiltInCommands(config: CliConfig): Promise<string[]> {
 	const builtInCommandParentDirGlob = join(config.builtInCommandLocation, '/*.js');
 	return globby(builtInCommandParentDirGlob, { ignore: '**/*.map' });
 }
@@ -49,15 +49,15 @@ export async function enumerateBuiltInCommands (config: CliConfig): Promise <str
  * @returns Promise This function is async and returns a promise once all
  * of the commands have been loaded.
  */
-export async function loadCommands(paths: string[], load: (path: string) => CommandWrapper ): Promise <LoadedCommands> {
-	return new Promise <LoadedCommands> ((resolve, reject) => {
+export async function loadCommands(paths: string[], load: (path: string) => CommandWrapper): Promise<LoadedCommands> {
+	return new Promise<LoadedCommands>((resolve, reject) => {
 		const commandsMap: CommandsMap = new Map();
 		const yargsCommandNames: YargsCommandNames = new Map();
 
 		paths.forEach((path) => {
 			try {
 				const commandWrapper = load(path);
-				const {group, name} = commandWrapper;
+				const { group, name } = commandWrapper;
 				let compositeKey = group;
 				if (name) {
 					compositeKey = `${group}-${name}`;
@@ -79,8 +79,7 @@ export async function loadCommands(paths: string[], load: (path: string) => Comm
 						groupCommandNames.add(compositeKey);
 					}
 				}
-			}
-			catch (error) {
+			} catch (error) {
 				error.message = `Failed to load module ${path}\nNested error: ${error.message}`;
 				reject(error);
 			}

--- a/src/npmInstall.ts
+++ b/src/npmInstall.ts
@@ -1,7 +1,7 @@
 import { NpmPackage } from './interfaces';
 const cs: any = require('cross-spawn');
 
-function convertToInlineDependencies(dependencies: {[key: string]: string}): string[] {
+function convertToInlineDependencies(dependencies: { [key: string]: string }): string[] {
 	return Object.keys(dependencies).reduce((inlineDependencies: string[], key: string) => {
 		inlineDependencies.push(`${key}@${dependencies[key]}`);
 		return inlineDependencies;
@@ -10,7 +10,8 @@ function convertToInlineDependencies(dependencies: {[key: string]: string}): str
 
 async function npmInstall(args: string[] = []) {
 	return new Promise((resolve, reject) => {
-		cs.spawn('npm', ['--silent', 'install', ...args], { stdio: 'inherit' })
+		cs
+			.spawn('npm', ['--silent', 'install', ...args], { stdio: 'inherit' })
 			.on('close', () => {
 				resolve();
 			})

--- a/src/template.ts
+++ b/src/template.ts
@@ -24,8 +24,8 @@ export function writeRenderedFile(str: string, destination: string): Promise<voi
 	});
 }
 
-export default async function (source: string, destination: string, replacements: Object): Promise<void> {
+export default async function(source: string, destination: string, replacements: Object): Promise<void> {
 	console.info(chalk.green.bold(' create ') + destination);
 	const str = await ejsRender(source, replacements);
 	await writeRenderedFile(str, destination);
-};
+}

--- a/tests/support/MockModule.ts
+++ b/tests/support/MockModule.ts
@@ -27,15 +27,14 @@ export default class MockModule {
 			let dependency;
 			try {
 				dependency = require(resolvePath(this.basePath, dependencyName));
-			}
-			catch (e) {
+			} catch (e) {
 				dependency = {};
 			}
 			const mock: any = {};
 
 			for (let prop in dependency) {
 				if (typeof dependency[prop] === 'function') {
-					mock[prop] = function () {};
+					mock[prop] = function() {};
 					this.sandbox.stub(mock, prop);
 				} else {
 					mock[prop] = dependency[prop];
@@ -46,8 +45,7 @@ export default class MockModule {
 				const ctor = this.sandbox.stub().returns(mock);
 				mockery.registerMock(dependencyName, ctor);
 				mock.ctor = ctor;
-			}
-			else {
+			} else {
 				mockery.registerMock(dependencyName, mock);
 			}
 			this.mocks[dependencyName] = mock;

--- a/tests/support/commands/test-prefix-foo-bar.ts
+++ b/tests/support/commands/test-prefix-foo-bar.ts
@@ -3,7 +3,7 @@ export const name = 'test-builtin';
 export const group = 'test-group';
 export function register() {
 	return 'registered';
-};
-export function	run() {
+}
+export function run() {
 	return new Promise((resolve) => 'ran');
 }

--- a/tests/support/dash-names-foo-bar-baz.ts
+++ b/tests/support/dash-names-foo-bar-baz.ts
@@ -1,7 +1,7 @@
 export const description = 'test-description';
 export function register() {
 	return 'registered';
-};
+}
 export function run() {
 	return new Promise((resolve) => 'ran');
 }

--- a/tests/support/eject/command-with-full-eject.ts
+++ b/tests/support/eject/command-with-full-eject.ts
@@ -3,8 +3,8 @@ export const name = 'test-eject';
 export const group = 'test-group';
 export function register() {
 	return 'registered';
-};
-export function	run() {
+}
+export function run() {
 	return new Promise((resolve) => 'ran');
 }
 export function eject(helper: any, npm: any, files: any) {
@@ -19,11 +19,7 @@ export function eject(helper: any, npm: any, files: any) {
 		},
 		copy: {
 			path: 'testPath',
-			files: [
-				'./file1',
-				'./file2',
-				'/file3'
-			]
+			files: ['./file1', './file2', '/file3']
 		}
 	};
 }

--- a/tests/support/eject/command-with-hints.ts
+++ b/tests/support/eject/command-with-hints.ts
@@ -3,8 +3,8 @@ export const name = 'test-eject';
 export const group = 'test-group';
 export function register() {
 	return 'registered';
-};
-export function	run() {
+}
+export function run() {
 	return new Promise((resolve) => 'ran');
 }
 export function eject(helper: any, npm: any, files: any) {
@@ -19,14 +19,8 @@ export function eject(helper: any, npm: any, files: any) {
 		},
 		copy: {
 			path: 'testPath',
-			files: [
-				'./file1',
-				'./file2'
-			]
+			files: ['./file1', './file2']
 		},
-		hints: [
-			'hint 1',
-			'hint 2'
-		]
+		hints: ['hint 1', 'hint 2']
 	};
 }

--- a/tests/support/eject/command-with-nofile-eject.ts
+++ b/tests/support/eject/command-with-nofile-eject.ts
@@ -3,8 +3,8 @@ export const name = 'test-eject';
 export const group = 'test-group';
 export function register() {
 	return 'registered';
-};
-export function	run() {
+}
+export function run() {
 	return new Promise((resolve) => 'ran');
 }
 export function eject(helper: any, npm: any, files: any) {

--- a/tests/support/test-prefix-foo-bar.ts
+++ b/tests/support/test-prefix-foo-bar.ts
@@ -1,7 +1,7 @@
 export const description = 'test-description';
 export function register() {
 	return 'registered';
-};
-export function	run() {
+}
+export function run() {
 	return new Promise((resolve) => 'ran');
 }

--- a/tests/support/test-prefix-foo-baz.ts
+++ b/tests/support/test-prefix-foo-baz.ts
@@ -1,7 +1,7 @@
 export const description = 'test-description';
 export function register() {
 	return 'registered';
-};
-export function	run() {
+}
+export function run() {
 	return new Promise((resolve) => 'ran');
 }

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -1,13 +1,17 @@
-import {CommandWrapper} from '../../src/interfaces';
+import { CommandWrapper } from '../../src/interfaces';
 import { stub, spy } from 'sinon';
 
-export type GroupDef = [{
-	groupName: string;
-	commands: [{
-		commandName: string;
-		fails?: boolean;
-	}]
-}];
+export type GroupDef = [
+	{
+		groupName: string;
+		commands: [
+			{
+				commandName: string;
+				fails?: boolean;
+			}
+		];
+	}
+];
 
 export interface CommandWrapperConfig {
 	group?: string;
@@ -24,15 +28,16 @@ export function getCommandsMap(groupDef: GroupDef) {
 	groupDef.forEach((group) => {
 		group.commands.forEach((command) => {
 			const compositeKey = `${group.groupName}-${command.commandName}`;
-			const runSpy = spy(() => command.fails ?
-					Promise.reject(new Error(compositeKey)) :
-					Promise.resolve(compositeKey)
+			const runSpy = spy(
+				() => (command.fails ? Promise.reject(new Error(compositeKey)) : Promise.resolve(compositeKey))
 			);
 			const commandWrapper = {
 				name: command.commandName,
 				group: group.groupName,
 				description: compositeKey,
-				register: stub().callsArgWith(0, 'key', {}).returns(compositeKey),
+				register: stub()
+					.callsArgWith(0, 'key', {})
+					.returns(compositeKey),
 				runSpy,
 				run: runSpy
 			};
@@ -41,15 +46,17 @@ export function getCommandsMap(groupDef: GroupDef) {
 	});
 
 	return commands;
-};
+}
 
-const yargsFunctions = [ 'demand', 'usage', 'epilog', 'help', 'alias', 'strict', 'option' ];
+const yargsFunctions = ['demand', 'usage', 'epilog', 'help', 'alias', 'strict', 'option'];
 export function getYargsStub() {
 	const yargsStub: any = {};
 	yargsFunctions.forEach((fnc) => {
 		yargsStub[fnc] = stub().returns(yargsStub);
 	});
-	yargsStub.command = stub().callsArgWith(2, yargsStub).returns(yargsStub);
+	yargsStub.command = stub()
+		.callsArgWith(2, yargsStub)
+		.returns(yargsStub);
 	return yargsStub;
 }
 
@@ -63,7 +70,7 @@ export function getCommandWrapper(name: string, runs: boolean = true) {
 }
 
 export function getCommandWrapperWithConfiguration(config: CommandWrapperConfig): CommandWrapper {
-	const {group = '', name = '', description = '', path = '', runs = false, eject = false } = config;
+	const { group = '', name = '', description = '', path = '', runs = false, eject = false } = config;
 
 	const commandWrapper: CommandWrapper = {
 		group,

--- a/tests/support/util.ts
+++ b/tests/support/util.ts
@@ -6,11 +6,14 @@ export interface Thenable<T> {
 }
 
 export function isEventuallyRejected<T>(promise: Thenable<T>): Thenable<boolean> {
-	return promise.then<any>(function () {
-		throw new Error('unexpected code path');
-	}, function () {
-		return true; // expect rejection
-	});
+	return promise.then<any>(
+		function() {
+			throw new Error('unexpected code path');
+		},
+		function() {
+			return true; // expect rejection
+		}
+	);
 }
 
 export function throwImmediatly() {

--- a/tests/unit/CommandHelper.ts
+++ b/tests/unit/CommandHelper.ts
@@ -9,14 +9,11 @@ import configurationHelperFactory from '../../src/configurationHelper';
 const groupDef: GroupDef = [
 	{
 		groupName: 'group1',
-		commands: [ { commandName: 'command1' } ]
+		commands: [{ commandName: 'command1' }]
 	},
 	{
 		groupName: 'group2',
-		commands: [
-			{ commandName: 'command1' },
-			{ commandName: 'failcommand', fails: true }
-		]
+		commands: [{ commandName: 'command1' }, { commandName: 'failcommand', fails: true }]
 	}
 ];
 let commandsMap: any;
@@ -24,16 +21,16 @@ let commandHelper: any;
 const templateStub: SinonStub = stub();
 
 const context = {
-	'testKey': 'testValue'
+	testKey: 'testValue'
 };
 
 registerSuite('CommandHelper', {
-	'beforeEach'() {
+	beforeEach() {
 		templateStub.reset();
-		mockery.enable({warnOnUnregistered: false, useCleanCache: true});
+		mockery.enable({ warnOnUnregistered: false, useCleanCache: true });
 
 		mockery.registerMock('./template', {
-			'default': templateStub
+			default: templateStub
 		});
 
 		commandsMap = getCommandsMap(groupDef);
@@ -41,7 +38,7 @@ registerSuite('CommandHelper', {
 		commandHelper = new commandHelperCtor(commandsMap, context, configurationHelperFactory);
 	},
 
-	'afterEach'() {
+	afterEach() {
 		mockery.deregisterAll();
 		mockery.disable();
 	},
@@ -61,79 +58,81 @@ registerSuite('CommandHelper', {
 		},
 		'Should run a command that exists and return a promise that resolves'() {
 			const key = 'group1-command1';
-			return commandHelper.run(key).then((response: string) => {
-				assert.equal(key, response);
-			})
-			.catch(() => {
-				assert.fail(null, null, 'commandHelper.run should not have rejected promise');
-			});
+			return commandHelper
+				.run(key)
+				.then((response: string) => {
+					assert.equal(key, response);
+				})
+				.catch(() => {
+					assert.fail(null, null, 'commandHelper.run should not have rejected promise');
+				});
 		},
 		'Should run a command that exists with args and return a promise that resolves'() {
 			const key = 'group1-command1';
-			return commandHelper.run(key, undefined, 'args').then((response: string) => {
-				const mockCommand = commandsMap.get(key);
-				assert.isTrue(mockCommand.runSpy.called);
-				assert.equal(mockCommand.runSpy.getCall(0).args[1], 'args');
-				assert.equal(key, response);
-			})
-			.catch(() => {
-				assert.fail(null, null, 'commandHelper.run should not have rejected promise');
-			});
+			return commandHelper
+				.run(key, undefined, 'args')
+				.then((response: string) => {
+					const mockCommand = commandsMap.get(key);
+					assert.isTrue(mockCommand.runSpy.called);
+					assert.equal(mockCommand.runSpy.getCall(0).args[1], 'args');
+					assert.equal(key, response);
+				})
+				.catch(() => {
+					assert.fail(null, null, 'commandHelper.run should not have rejected promise');
+				});
 		},
 		'Should run a command that exists and return a rejected promise when it fails'() {
 			const key = 'group2-failcommand';
-			return commandHelper.run(key).then(
-				(response: string) => {
-					assert.fail(null, null, 'Should not have resolved');
-				},
-				(error: Error) => {
-					assert.equal(key, error.message);
-				}
-			)
-			.catch(() => {
-				assert.fail(null, null, 'commandHelper.run should not have rejected promise');
-			});
+			return commandHelper
+				.run(key)
+				.then(
+					(response: string) => {
+						assert.fail(null, null, 'Should not have resolved');
+					},
+					(error: Error) => {
+						assert.equal(key, error.message);
+					}
+				)
+				.catch(() => {
+					assert.fail(null, null, 'commandHelper.run should not have rejected promise');
+				});
 		},
 		'Should not run a command that does not exist and return a rejected promise'() {
 			const key = 'nogroup-nocommand';
 			const expectedErrorMsg = 'The command does not exist';
-			return commandHelper.run(key).then(
-				(response: string) => {
-					assert.fail(null, null, 'Should not have resolved');
-				},
-				(error: Error) => {
-					assert.equal(expectedErrorMsg, error.message);
-				}
-			)
-			.catch(() => {
-				assert.fail(null, null, 'commandHelper.run should not have rejected promise');
-			});
+			return commandHelper
+				.run(key)
+				.then(
+					(response: string) => {
+						assert.fail(null, null, 'Should not have resolved');
+					},
+					(error: Error) => {
+						assert.equal(expectedErrorMsg, error.message);
+					}
+				)
+				.catch(() => {
+					assert.fail(null, null, 'commandHelper.run should not have rejected promise');
+				});
 		},
 		'Should call template for each file in the config'() {
 			const testRenderData = {
-				'appName': 'testName'
+				appName: 'testName'
 			};
 
-			const testFilesConfig = [
-				{ src: 'test/a', dest: 'dest/a' },
-				{ src: 'test/b', dest: 'dest/b' }
-			];
+			const testFilesConfig = [{ src: 'test/a', dest: 'dest/a' }, { src: 'test/b', dest: 'dest/b' }];
 
 			commandHelper.renderFiles(testFilesConfig, testRenderData);
 			assert.equal(2, templateStub.callCount);
 		},
 		'Should call template with the src and dest from config'() {
 			const testRenderData = {
-				'appName': 'testName'
+				appName: 'testName'
 			};
 
-			const testFilesConfig = [
-				{ src: 'test/a', dest: 'dest/a' },
-				{ src: 'test/b', dest: 'dest/b' }
-			];
+			const testFilesConfig = [{ src: 'test/a', dest: 'dest/a' }, { src: 'test/b', dest: 'dest/b' }];
 
 			commandHelper.renderFiles(testFilesConfig, testRenderData);
-			const [ file1, file2 ] = testFilesConfig;
+			const [file1, file2] = testFilesConfig;
 			assert.isTrue(templateStub.firstCall.calledWithMatch(file1.src, file1.dest));
 			assert.isTrue(templateStub.secondCall.calledWithMatch(file2.src, file2.dest));
 		}

--- a/tests/unit/allCommands.ts
+++ b/tests/unit/allCommands.ts
@@ -5,7 +5,6 @@ import MockModule from '../support/MockModule';
 import * as sinon from 'sinon';
 
 describe('AllCommands', () => {
-
 	let moduleUnderTest: any;
 	let mockModule: MockModule;
 	let sandbox: any;
@@ -15,22 +14,16 @@ describe('AllCommands', () => {
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
 		mockModule = new MockModule('../../src/allCommands', require);
-		mockModule.dependencies([
-			'./command',
-			'./loadCommands',
-			'./config']);
+		mockModule.dependencies(['./command', './loadCommands', './config']);
 		mockCommand = mockModule.getMock('./command');
 		mockLoadCommands = mockModule.getMock('./loadCommands');
 
 		mockLoadCommands.loadCommands = sandbox.stub().resolves({
 			commandsMap: new Map([
-				['key1', {name: 'a', group: 'c', path: 'as'}],
-				['key2', {name: 'b', group: 'd', path: 'asas'}]
+				['key1', { name: 'a', group: 'c', path: 'as' }],
+				['key2', { name: 'b', group: 'd', path: 'asas' }]
 			]),
-			yargsCommandNames: new Map([
-				['key3', new Set(['a', 'b'])],
-				['key4', new Set(['d', 'e'])]
-			])
+			yargsCommandNames: new Map([['key3', new Set(['a', 'b'])], ['key4', new Set(['d', 'e'])]])
 		});
 		moduleUnderTest = mockModule.getModuleUnderTest();
 	});
@@ -41,16 +34,27 @@ describe('AllCommands', () => {
 	});
 
 	it('should run loadCommands to completion', () => {
-		return moduleUnderTest.default()
-			.then(function(){
+		return moduleUnderTest
+			.default()
+			.then(function() {
 				assert.isTrue(mockCommand.createBuiltInCommandLoader.calledOnce, 'should call builtin command loader');
 				assert.isTrue(mockCommand.initCommandLoader.calledOnce, 'should call installed command loader');
-				assert.isTrue(mockLoadCommands.enumerateBuiltInCommands.calledOnce, 'should call builtin command enumerator');
-				assert.isTrue(mockLoadCommands.enumerateInstalledCommands.calledOnce, 'should call installed command enumerator');
-				assert.isTrue(mockLoadCommands.enumerateInstalledCommands.calledAfter(mockLoadCommands.enumerateBuiltInCommands));
+				assert.isTrue(
+					mockLoadCommands.enumerateBuiltInCommands.calledOnce,
+					'should call builtin command enumerator'
+				);
+				assert.isTrue(
+					mockLoadCommands.enumerateInstalledCommands.calledOnce,
+					'should call installed command enumerator'
+				);
+				assert.isTrue(
+					mockLoadCommands.enumerateInstalledCommands.calledAfter(mockLoadCommands.enumerateBuiltInCommands)
+				);
 				assert.isTrue(mockLoadCommands.loadCommands.calledTwice, 'should call load commands twice');
-				assert.isTrue(mockLoadCommands.loadCommands.calledAfter(mockLoadCommands.enumerateInstalledCommands),
-					'should call loadcommands after both enumerations');
+				assert.isTrue(
+					mockLoadCommands.loadCommands.calledAfter(mockLoadCommands.enumerateInstalledCommands),
+					'should call loadcommands after both enumerations'
+				);
 			})
 			.catch(() => {
 				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
@@ -58,21 +62,47 @@ describe('AllCommands', () => {
 	});
 
 	it('should perform initialsation only once', () => {
-		return moduleUnderTest.default()
-			.then(function(){
-				assert.isTrue(mockCommand.createBuiltInCommandLoader.calledOnce, 'should call builtin command loader once');
+		return moduleUnderTest
+			.default()
+			.then(function() {
+				assert.isTrue(
+					mockCommand.createBuiltInCommandLoader.calledOnce,
+					'should call builtin command loader once'
+				);
 				assert.isTrue(mockCommand.initCommandLoader.calledOnce, 'should call installed command loader once');
-				assert.isTrue(mockLoadCommands.enumerateBuiltInCommands.calledOnce, 'should call builtin command enumerator once');
-				assert.isTrue(mockLoadCommands.enumerateInstalledCommands.calledOnce, 'should call installed command enumerator once');
+				assert.isTrue(
+					mockLoadCommands.enumerateBuiltInCommands.calledOnce,
+					'should call builtin command enumerator once'
+				);
+				assert.isTrue(
+					mockLoadCommands.enumerateInstalledCommands.calledOnce,
+					'should call installed command enumerator once'
+				);
 				assert.isTrue(mockLoadCommands.loadCommands.calledTwice, 'should call load commands twice');
 
-				moduleUnderTest.default()
-					.then(function(){
-						assert.isTrue(mockCommand.createBuiltInCommandLoader.calledOnce, 'should call builtin command loader once only');
-						assert.isTrue(mockCommand.initCommandLoader.calledOnce, 'should call installed command loader once only');
-						assert.isTrue(mockLoadCommands.enumerateBuiltInCommands.calledOnce, 'should call builtin command enumerator once only');
-						assert.isTrue(mockLoadCommands.enumerateInstalledCommands.calledOnce, 'should call installed command enumerator once only');
-						assert.isTrue(mockLoadCommands.loadCommands.calledTwice, 'should call load commands twice only');
+				moduleUnderTest
+					.default()
+					.then(function() {
+						assert.isTrue(
+							mockCommand.createBuiltInCommandLoader.calledOnce,
+							'should call builtin command loader once only'
+						);
+						assert.isTrue(
+							mockCommand.initCommandLoader.calledOnce,
+							'should call installed command loader once only'
+						);
+						assert.isTrue(
+							mockLoadCommands.enumerateBuiltInCommands.calledOnce,
+							'should call builtin command enumerator once only'
+						);
+						assert.isTrue(
+							mockLoadCommands.enumerateInstalledCommands.calledOnce,
+							'should call installed command enumerator once only'
+						);
+						assert.isTrue(
+							mockLoadCommands.loadCommands.calledTwice,
+							'should call load commands twice only'
+						);
 					})
 					.catch(() => {
 						assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
@@ -83,22 +113,49 @@ describe('AllCommands', () => {
 			});
 	});
 	it('should reset the command cache', () => {
-		return moduleUnderTest.default()
-			.then(function(){
-				assert.isTrue(mockCommand.createBuiltInCommandLoader.calledOnce, 'should call builtin command loader once');
+		return moduleUnderTest
+			.default()
+			.then(function() {
+				assert.isTrue(
+					mockCommand.createBuiltInCommandLoader.calledOnce,
+					'should call builtin command loader once'
+				);
 				assert.isTrue(mockCommand.initCommandLoader.calledOnce, 'should call installed command loader once');
-				assert.isTrue(mockLoadCommands.enumerateBuiltInCommands.calledOnce, 'should call builtin command enumerator once');
-				assert.isTrue(mockLoadCommands.enumerateInstalledCommands.calledOnce, 'should call installed command enumerator once');
+				assert.isTrue(
+					mockLoadCommands.enumerateBuiltInCommands.calledOnce,
+					'should call builtin command enumerator once'
+				);
+				assert.isTrue(
+					mockLoadCommands.enumerateInstalledCommands.calledOnce,
+					'should call installed command enumerator once'
+				);
 				assert.isTrue(mockLoadCommands.loadCommands.calledTwice, 'should call load commands twice only');
 
 				moduleUnderTest.reset();
-				moduleUnderTest.default()
-					.then(function(){
-						assert.isTrue(mockCommand.createBuiltInCommandLoader.calledTwice, 'should call builtin command loader once');
-						assert.isTrue(mockCommand.initCommandLoader.calledTwice, 'should call installed command loader once');
-						assert.isTrue(mockLoadCommands.enumerateBuiltInCommands.calledTwice, 'should call builtin command enumerator once');
-						assert.isTrue(mockLoadCommands.enumerateInstalledCommands.calledTwice, 'should call installed command enumerator once');
-						assert.equal(mockLoadCommands.loadCommands.callCount, 4, 'should call load commands twice only');
+				moduleUnderTest
+					.default()
+					.then(function() {
+						assert.isTrue(
+							mockCommand.createBuiltInCommandLoader.calledTwice,
+							'should call builtin command loader once'
+						);
+						assert.isTrue(
+							mockCommand.initCommandLoader.calledTwice,
+							'should call installed command loader once'
+						);
+						assert.isTrue(
+							mockLoadCommands.enumerateBuiltInCommands.calledTwice,
+							'should call builtin command enumerator once'
+						);
+						assert.isTrue(
+							mockLoadCommands.enumerateInstalledCommands.calledTwice,
+							'should call installed command enumerator once'
+						);
+						assert.equal(
+							mockLoadCommands.loadCommands.callCount,
+							4,
+							'should call load commands twice only'
+						);
 					})
 					.catch(() => {
 						assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');

--- a/tests/unit/bin/dojo.ts
+++ b/tests/unit/bin/dojo.ts
@@ -8,7 +8,6 @@ import { CommandsMap, CommandWrapper, LoadedCommands } from '../../../src/interf
 import { getCommandWrapperWithConfiguration } from '../../support/testHelper';
 
 describe('cli .bin', () => {
-	let moduleUnderTest: any;
 	let mockModule: MockModule;
 	let mockYargs: any;
 	let mockAllCommandsPromise: Promise<any>;
@@ -47,7 +46,6 @@ describe('cli .bin', () => {
 		mockAllCommands.default = sandbox.stub().resolves(mockAllCommandsPromise);
 		mockRegisterCommands = mockModule.getMock('./registerCommands');
 		mockRegisterCommands.default = sandbox.stub();
-		moduleUnderTest = mockModule.getModuleUnderTest();
 
 		// Give a stacktrace for the unhandled rejections should they occur
 		process.on('unhandledRejection', (reason: string, p: any) => {

--- a/tests/unit/bin/dojo.ts
+++ b/tests/unit/bin/dojo.ts
@@ -37,13 +37,13 @@ describe('cli .bin', () => {
 			group: 'eject',
 			name: ''
 		});
-		const commandMap: CommandsMap = new Map<string, CommandWrapper>([
-			['eject', installedCommandWrapper1]
-		]);
+		const commandMap: CommandsMap = new Map<string, CommandWrapper>([['eject', installedCommandWrapper1]]);
 		commands.commandsMap = commandMap;
-		mockAllCommandsPromise = new Promise((resolve) => setTimeout(() => {
-			resolve(commands);
-		}, 1000));
+		mockAllCommandsPromise = new Promise((resolve) =>
+			setTimeout(() => {
+				resolve(commands);
+			}, 1000)
+		);
 		mockAllCommands.default = sandbox.stub().resolves(mockAllCommandsPromise);
 		mockRegisterCommands = mockModule.getMock('./registerCommands');
 		mockRegisterCommands.default = sandbox.stub();
@@ -61,13 +61,14 @@ describe('cli .bin', () => {
 	});
 
 	it('should call registerCommands', () => {
-		mockAllCommandsPromise.then(() => {
-			setTimeout(() => {
-				assert.isTrue(mockRegisterCommands.default.called);
-			}, 100);
-		})
-		.catch((error: Error) => {
-			assert.fail(null, null, error.message);
-		});
+		mockAllCommandsPromise
+			.then(() => {
+				setTimeout(() => {
+					assert.isTrue(mockRegisterCommands.default.called);
+				}, 100);
+			})
+			.catch((error: Error) => {
+				assert.fail(null, null, error.message);
+			});
 	});
 });

--- a/tests/unit/command.ts
+++ b/tests/unit/command.ts
@@ -11,19 +11,19 @@ import expectedEsModuleCommand from '../support/esmodule-prefix-foo-bar';
 
 const testGroup = 'foo';
 const testName = 'bar';
-const testSearchPrefixes = [ 'test-prefix' ];
-const testEsModuleSearchPrefixes = [ 'esmodule-prefix' ];
-const testEsModuleFailSearchPrefixes = [ 'esmodule-fail' ];
-const testSearchPrefixesDashedNames = [ 'dash-names' ];
+const testSearchPrefixes = ['test-prefix'];
+const testEsModuleSearchPrefixes = ['esmodule-prefix'];
+const testEsModuleFailSearchPrefixes = ['esmodule-fail'];
+const testSearchPrefixesDashedNames = ['dash-names'];
 let commandWrapper: any;
 const groupDef: GroupDef = [
 	{
 		groupName: 'group1',
-		commands: [ { commandName: 'command1' } ]
+		commands: [{ commandName: 'command1' }]
 	},
 	{
 		groupName: 'group2',
-		commands: [ { commandName: 'command1' } ]
+		commands: [{ commandName: 'command1' }]
 	}
 ];
 const commandsMap = getCommandsMap(groupDef);
@@ -36,12 +36,14 @@ function getCommandPath(prefixes: string[]): string[] {
 }
 
 function getBuiltInCommandPath(invalid: boolean): string {
-	return invalid ? `../tests/support/commands/invalid-built-in-command` : `../tests/support/commands/test-prefix-foo-bar`;
+	return invalid
+		? `../tests/support/commands/invalid-built-in-command`
+		: `../tests/support/commands/test-prefix-foo-bar`;
 }
 
 registerSuite('command', {
-	'load': {
-		'beforeEach'() {
+	load: {
+		beforeEach() {
 			loader = command.initCommandLoader(testSearchPrefixes);
 			commandWrapper = loader(getCommandPath(testSearchPrefixes)[0]);
 		},
@@ -63,7 +65,7 @@ registerSuite('command', {
 		}
 	},
 	'load built in command': {
-		'beforeEach'() {
+		beforeEach() {
 			loader = command.createBuiltInCommandLoader();
 			commandWrapper = loader(getBuiltInCommandPath(false));
 		},
@@ -83,7 +85,7 @@ registerSuite('command', {
 		}
 	},
 	'load esmodule default': {
-		'beforeEach'() {
+		beforeEach() {
 			loader = command.initCommandLoader(testEsModuleSearchPrefixes);
 			commandWrapper = loader(getCommandPath(testEsModuleSearchPrefixes)[0]);
 		},
@@ -105,7 +107,7 @@ registerSuite('command', {
 		}
 	},
 	'load esmodule that does not meet Command interface': {
-		'before'() {
+		before() {
 			loader = command.initCommandLoader(testEsModuleFailSearchPrefixes);
 		},
 
@@ -114,16 +116,18 @@ registerSuite('command', {
 				try {
 					commandWrapper = loader(getCommandPath(testEsModuleFailSearchPrefixes)[0]);
 					assert.fail(null, null, 'Should not get here');
-				}
-				catch (error) {
+				} catch (error) {
 					assert.isTrue(error instanceof Error);
-					assert.equal(error.message, `Path: ../tests/support/esmodule-fail-foo-bar returned module that does not satisfy the Command interface. Error: Module does not satisfy the Command interface`);
+					assert.equal(
+						error.message,
+						`Path: ../tests/support/esmodule-fail-foo-bar returned module that does not satisfy the Command interface. Error: Module does not satisfy the Command interface`
+					);
 				}
 			}
 		}
 	},
 	'load builtin command that does not meet Command interface': {
-		'before'() {
+		before() {
 			loader = command.createBuiltInCommandLoader();
 		},
 
@@ -132,8 +136,7 @@ registerSuite('command', {
 				try {
 					commandWrapper = loader(getBuiltInCommandPath(true));
 					assert.fail(null, null, 'Should not get here');
-				}
-				catch (error) {
+				} catch (error) {
 					assert.isTrue(error instanceof Error);
 					assert.isTrue(error.message.indexOf('does not satisfy the Command interface') > -1);
 				}
@@ -141,7 +144,7 @@ registerSuite('command', {
 		}
 	},
 	'load of commands parsed correctly': {
-		'before'() {
+		before() {
 			loader = command.initCommandLoader(testSearchPrefixesDashedNames);
 			commandWrapper = loader('../tests/support/dash-names-foo-bar-baz');
 		},
@@ -153,8 +156,8 @@ registerSuite('command', {
 			}
 		}
 	},
-	'getGroupDescription': {
-		'before'() {
+	getGroupDescription: {
+		before() {
 			loader = command.initCommandLoader(testSearchPrefixes);
 		},
 
@@ -168,7 +171,9 @@ registerSuite('command', {
 				const key1 = 'group1-command1';
 				const key2 = 'group2-command1';
 				const description = command.getGroupDescription(new Set([key1, key2]), commandsMap);
-				const expected = `${commandsMap.get(key1).name}  ${commandsMap.get(key1).description}\n${commandsMap.get(key1).name}  ${commandsMap.get(key2).description}`;
+				const expected = `${commandsMap.get(key1).name}  ${commandsMap.get(key1).description}\n${
+					commandsMap.get(key1).name
+				}  ${commandsMap.get(key2).description}`;
 
 				assert.equal(expected, description);
 			}

--- a/tests/unit/commands/eject.ts
+++ b/tests/unit/commands/eject.ts
@@ -19,10 +19,8 @@ describe('eject command', () => {
 	let mockFsExtra: any;
 	let mockInquirer: any;
 	let mockNpmInstall: any;
-	let mockPackageJson: any;
 	let mockAllExternalCommands: any;
 	let consoleLogStub: sinon.SinonStub;
-	let consoleWarnStub: sinon.SinonStub;
 	let sandbox: sinon.SinonSandbox;
 
 	function loadCommand(command: string): any {
@@ -62,9 +60,7 @@ describe('eject command', () => {
 		mockInquirer.prompt = sandbox.stub().resolves({ eject: true });
 		mockAllExternalCommands = mockModule.getMock('../allCommands');
 		mockNpmInstall = mockModule.getMock('../npmInstall');
-		mockPackageJson = mockModule.getMock(`${ejectPackagePath}/package.json`);
 		consoleLogStub = sandbox.stub(console, 'log');
-		consoleWarnStub = sandbox.stub(console, 'warn');
 		moduleUnderTest = mockModule.getModuleUnderTest().default;
 	});
 

--- a/tests/unit/commands/eject.ts
+++ b/tests/unit/commands/eject.ts
@@ -44,7 +44,16 @@ describe('eject command', () => {
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
 		mockModule = new MockModule('../../../src/commands/eject', require);
-		mockModule.dependencies(['inquirer', 'fs', 'fs-extra', 'pkg-dir', '../allCommands', '../npmInstall', `${ejectPackagePath}/package.json`, '../configurationHelper']);
+		mockModule.dependencies([
+			'inquirer',
+			'fs',
+			'fs-extra',
+			'pkg-dir',
+			'../allCommands',
+			'../npmInstall',
+			`${ejectPackagePath}/package.json`,
+			'../configurationHelper'
+		]);
 		mockPkgDir = mockModule.getMock('pkg-dir');
 		mockPkgDir.ctor.sync = sandbox.stub().returns(ejectPackagePath);
 		mockFsExtra = mockModule.getMock('fs-extra');
@@ -70,12 +79,15 @@ describe('eject command', () => {
 
 		const helper = getHelper();
 		mockInquirer.prompt = sandbox.stub().resolves({ eject: false });
-		mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({commandsMap: commandMap});
-		return moduleUnderTest.run(helper, {}).then(() => {
-			assert.fail('The promise should not have resolved');
-		}, (error: { message: string }) => {
-			assert.equal(error.message, abortOutput);
-		});
+		mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({ commandsMap: commandMap });
+		return moduleUnderTest.run(helper, {}).then(
+			() => {
+				assert.fail('The promise should not have resolved');
+			},
+			(error: { message: string }) => {
+				assert.equal(error.message, abortOutput);
+			}
+		);
 	});
 
 	it(`should warn if all commands are skipped`, () => {
@@ -95,12 +107,15 @@ describe('eject command', () => {
 			['version', installedCommandWrapper2]
 		]);
 		const helper = getHelper();
-		mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({commandsMap: commandMap});
-		return moduleUnderTest.run(helper, {}).then(() => {
-			assert.equal(consoleLogStub.args[0][0], runOutput);
-		}, () => {
-			assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
-		});
+		mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({ commandsMap: commandMap });
+		return moduleUnderTest.run(helper, {}).then(
+			() => {
+				assert.equal(consoleLogStub.args[0][0], runOutput);
+			},
+			() => {
+				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
+			}
+		);
 	});
 
 	describe('save ejected config', () => {
@@ -109,7 +124,7 @@ describe('eject command', () => {
 				['apple', loadCommand('command-with-full-eject')]
 			]);
 			const helper = getHelper();
-			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({commandsMap: commandMap});
+			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({ commandsMap: commandMap });
 
 			const configurationHelper = mockModule.getMock('../configurationHelper').default;
 
@@ -118,12 +133,15 @@ describe('eject command', () => {
 				set: setStub
 			});
 
-			return moduleUnderTest.run(helper, {}).then(() => {
-				assert.isTrue(setStub.calledOnce);
-				assert.isTrue(setStub.firstCall.calledWith({ ejected: true }));
-			}, () => {
-				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
-			});
+			return moduleUnderTest.run(helper, {}).then(
+				() => {
+					assert.isTrue(setStub.calledOnce);
+					assert.isTrue(setStub.firstCall.calledWith({ ejected: true }));
+				},
+				() => {
+					assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
+				}
+			);
 		});
 	});
 
@@ -133,13 +151,16 @@ describe('eject command', () => {
 				['apple', loadCommand('command-with-full-eject')]
 			]);
 			const helper = getHelper();
-			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({commandsMap: commandMap});
-			return moduleUnderTest.run(helper, {}).then(() => {
-				assert.isTrue(mockNpmInstall.installDependencies.calledOnce);
-				assert.isTrue(mockNpmInstall.installDevDependencies.calledOnce);
-			}, () => {
-				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
-			});
+			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({ commandsMap: commandMap });
+			return moduleUnderTest.run(helper, {}).then(
+				() => {
+					assert.isTrue(mockNpmInstall.installDependencies.calledOnce);
+					assert.isTrue(mockNpmInstall.installDevDependencies.calledOnce);
+				},
+				() => {
+					assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
+				}
+			);
 		});
 	});
 
@@ -149,15 +170,30 @@ describe('eject command', () => {
 				['apple', loadCommand('command-with-full-eject')]
 			]);
 			const helper = getHelper();
-			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({commandsMap: commandMap});
-			return moduleUnderTest.run(helper, {}).then(() => {
-				assert.isTrue(consoleLogStub.secondCall.calledWith(` ${yellow('creating')} .${sep}config${sep}test-group-test-eject${sep}file1`));
-				assert.isTrue(consoleLogStub.thirdCall.calledWith(` ${yellow('creating')} .${sep}config${sep}test-group-test-eject${sep}file2`));
-				assert.isTrue(consoleLogStub.getCall(3).calledWith(` ${yellow('creating')} .${sep}config${sep}test-group-test-eject${sep}file3`));
-				assert.isTrue(mockFsExtra.copySync.calledThrice);
-			}, () => {
-				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
-			});
+			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({ commandsMap: commandMap });
+			return moduleUnderTest.run(helper, {}).then(
+				() => {
+					assert.isTrue(
+						consoleLogStub.secondCall.calledWith(
+							` ${yellow('creating')} .${sep}config${sep}test-group-test-eject${sep}file1`
+						)
+					);
+					assert.isTrue(
+						consoleLogStub.thirdCall.calledWith(
+							` ${yellow('creating')} .${sep}config${sep}test-group-test-eject${sep}file2`
+						)
+					);
+					assert.isTrue(
+						consoleLogStub
+							.getCall(3)
+							.calledWith(` ${yellow('creating')} .${sep}config${sep}test-group-test-eject${sep}file3`)
+					);
+					assert.isTrue(mockFsExtra.copySync.calledThrice);
+				},
+				() => {
+					assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
+				}
+			);
 		});
 
 		it('should not copy files if no files are specified', () => {
@@ -165,12 +201,15 @@ describe('eject command', () => {
 				['apple', loadCommand('command-with-nofile-eject')]
 			]);
 			const helper = getHelper();
-			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({commandsMap: commandMap});
-			return moduleUnderTest.run(helper, {}).then(() => {
-				assert.isTrue(mockFsExtra.copySync.notCalled);
-			}, () => {
-				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
-			});
+			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({ commandsMap: commandMap });
+			return moduleUnderTest.run(helper, {}).then(
+				() => {
+					assert.isTrue(mockFsExtra.copySync.notCalled);
+				},
+				() => {
+					assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
+				}
+			);
 		});
 	});
 
@@ -180,17 +219,23 @@ describe('eject command', () => {
 				['apple', loadCommand('command-with-hints')]
 			]);
 			const helper = getHelper();
-			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({commandsMap: commandMap});
-			return moduleUnderTest.run(helper, {}).then(() => {
-				const logCallCount = consoleLogStub.callCount;
-				assert.isTrue(consoleLogStub.callCount > 3, '1');
-				const hintsCall = logCallCount - 3;
-				assert.isTrue(consoleLogStub.getCall(hintsCall).calledWith(underline('\nhints')), 'should underline hints');
-				assert.isTrue(consoleLogStub.getCall(hintsCall + 1).calledWith(' hint 1'), 'should show hint1');
-				assert.isTrue(consoleLogStub.getCall(hintsCall + 2).calledWith(' hint 2'), 'should show hint2');
-			}, () => {
-				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
-			});
+			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves({ commandsMap: commandMap });
+			return moduleUnderTest.run(helper, {}).then(
+				() => {
+					const logCallCount = consoleLogStub.callCount;
+					assert.isTrue(consoleLogStub.callCount > 3, '1');
+					const hintsCall = logCallCount - 3;
+					assert.isTrue(
+						consoleLogStub.getCall(hintsCall).calledWith(underline('\nhints')),
+						'should underline hints'
+					);
+					assert.isTrue(consoleLogStub.getCall(hintsCall + 1).calledWith(' hint 1'), 'should show hint1');
+					assert.isTrue(consoleLogStub.getCall(hintsCall + 2).calledWith(' hint 2'), 'should show hint2');
+				},
+				() => {
+					assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
+				}
+			);
 		});
 	});
 });

--- a/tests/unit/commands/init.ts
+++ b/tests/unit/commands/init.ts
@@ -5,7 +5,6 @@ import MockModule from '../../support/MockModule';
 import * as sinon from 'sinon';
 
 describe('init command', () => {
-
 	let mockModule: MockModule;
 	let sandbox: sinon.SinonSandbox;
 	let fs: any;
@@ -13,7 +12,7 @@ describe('init command', () => {
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
 		mockModule = new MockModule('../../../src/commands/init', require);
-		mockModule.dependencies([ 'fs', 'pkg-dir', '../allCommands' ]);
+		mockModule.dependencies(['fs', 'pkg-dir', '../allCommands']);
 
 		sandbox.stub(console, 'log');
 
@@ -52,58 +51,55 @@ describe('init command', () => {
 		fs.readFileSync = sandbox.stub().returns(undefined);
 		const moduleUnderTest = mockModule.getModuleUnderTest().default;
 		await moduleUnderTest.run();
-		const [ , content ] = fs.writeFileSync.firstCall.args;
-		assert.equal(
-			content,
-			JSON.stringify({ 'build-webpack': {}, 'test-intern': {} }, null, '\t')
-		);
+		const [, content] = fs.writeFileSync.firstCall.args;
+		assert.equal(content, JSON.stringify({ 'build-webpack': {}, 'test-intern': {} }, null, '\t'));
 	});
 
 	it('updates a .dojorc with the available commands', async () => {
 		fs.readFileSync = sandbox.stub().returns('{}');
 		const moduleUnderTest = mockModule.getModuleUnderTest().default;
 		await moduleUnderTest.run();
-		const [ , content ] = fs.writeFileSync.firstCall.args;
-		assert.equal(
-			content,
-			JSON.stringify({ 'build-webpack': {}, 'test-intern': {} }, null, '\t')
-		);
+		const [, content] = fs.writeFileSync.firstCall.args;
+		assert.equal(content, JSON.stringify({ 'build-webpack': {}, 'test-intern': {} }, null, '\t'));
 	});
 
 	it('updates a .dojorc, but does not overwrite existing config', async () => {
-		fs.readFileSync = sandbox.stub().returns(
-			JSON.stringify({ 'build-webpack': { 'foo': 'bar' } }, null, '\t')
-		);
+		fs.readFileSync = sandbox.stub().returns(JSON.stringify({ 'build-webpack': { foo: 'bar' } }, null, '\t'));
 		const moduleUnderTest = mockModule.getModuleUnderTest().default;
 		await moduleUnderTest.run();
-		const [ , content ] = fs.writeFileSync.firstCall.args;
+		const [, content] = fs.writeFileSync.firstCall.args;
 		assert.equal(
 			content,
-			JSON.stringify({
-				'build-webpack': {
-					'foo': 'bar'
+			JSON.stringify(
+				{
+					'build-webpack': {
+						foo: 'bar'
+					},
+					'test-intern': {}
 				},
-				'test-intern': {}
-			}, null, '\t')
+				null,
+				'\t'
+			)
 		);
 	});
 
 	it('updates a .dojorc and keeps indent formatting', async () => {
-		fs.readFileSync = sandbox.stub().returns(
-			JSON.stringify({ 'build-webpack': { 'foo': 'bar' } }, null, 2)
-		);
+		fs.readFileSync = sandbox.stub().returns(JSON.stringify({ 'build-webpack': { foo: 'bar' } }, null, 2));
 		const moduleUnderTest = mockModule.getModuleUnderTest().default;
 		await moduleUnderTest.run();
-		const [ , content ] = fs.writeFileSync.firstCall.args;
+		const [, content] = fs.writeFileSync.firstCall.args;
 		assert.equal(
 			content,
-			JSON.stringify({
-				'build-webpack': {
-					'foo': 'bar'
+			JSON.stringify(
+				{
+					'build-webpack': {
+						foo: 'bar'
+					},
+					'test-intern': {}
 				},
-				'test-intern': {}
-			}, null, 2)
+				null,
+				2
+			)
 		);
 	});
-
 });

--- a/tests/unit/commands/version.ts
+++ b/tests/unit/commands/version.ts
@@ -8,11 +8,10 @@ import { join, resolve as pathResolve } from 'path';
 
 import { CommandsMap, CommandWrapper } from '../../../src/interfaces';
 import { getCommandWrapperWithConfiguration } from '../../support/testHelper';
-const validPackageInfo: any =  require('../../support/valid-package/package.json');
+const validPackageInfo: any = require('../../support/valid-package/package.json');
 const anotherValidPackageInfo: any = require('../../support/another-valid-package/package.json');
 
 describe('version command', () => {
-
 	let moduleUnderTest: any;
 	let mockModule: MockModule;
 	let mockDavid: any;
@@ -40,30 +39,33 @@ describe('version command', () => {
 	it('should register supported arguments', () => {
 		const options = sandbox.stub();
 		moduleUnderTest.register(options);
-		assert.deepEqual(
-			options.firstCall.args,
-			[ 'o', {
+		assert.deepEqual(options.firstCall.args, [
+			'o',
+			{
 				alias: 'outdated',
-				describe: 'Output a list of installed commands and check if any can be updated to a more recent stable version.',
+				describe:
+					'Output a list of installed commands and check if any can be updated to a more recent stable version.',
 				demand: false,
 				type: 'boolean'
-			} ]
-		);
+			}
+		]);
 	});
 
 	it(`should run and return 'no registered commands' when there are no installed commands`, () => {
 		const noCommandOutput = `${outputPrefix()}There are no registered commands available.${outputSuffix()}`;
 		const commandMap: CommandsMap = new Map<string, CommandWrapper>();
 
-		const helper = {command: 'version'};
-		mockAllCommands.default = sandbox.stub().resolves({commandsMap: commandMap});
-		return moduleUnderTest.run(helper, { outdated: false }).then(() => {
-			assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
-			assert.equal((<sinon.SinonStub> console.log).args[0][0], noCommandOutput);
-		})
-		.catch(() => {
-			assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
-		});
+		const helper = { command: 'version' };
+		mockAllCommands.default = sandbox.stub().resolves({ commandsMap: commandMap });
+		return moduleUnderTest
+			.run(helper, { outdated: false })
+			.then(() => {
+				assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
+				assert.equal((<sinon.SinonStub>console.log).args[0][0], noCommandOutput);
+			})
+			.catch(() => {
+				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
+			});
 	});
 
 	it(`should run and return 'no registered commands' when passed an invalid path to an installed command`, () => {
@@ -75,48 +77,54 @@ describe('version command', () => {
 			path: join(pathResolve('.'), 'path/that/does/not/exist')
 		});
 
-		const commandMap: CommandsMap = new Map<string, CommandWrapper>([
-			['badCommand', badCommandWrapper]
-		]);
-		mockAllCommands.default = sandbox.stub().resolves({commandsMap: commandMap});
+		const commandMap: CommandsMap = new Map<string, CommandWrapper>([['badCommand', badCommandWrapper]]);
+		mockAllCommands.default = sandbox.stub().resolves({ commandsMap: commandMap });
 
-		const helper = {command: 'version'};
-		return moduleUnderTest.run(helper, { outdated: false }).then(() => {
-			assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
-			assert.equal((<sinon.SinonStub> console.log).args[0][0], noCommandOutput);
-		})
-		.catch(() => {
-			assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
-		});
+		const helper = { command: 'version' };
+		return moduleUnderTest
+			.run(helper, { outdated: false })
+			.then(() => {
+				assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
+				assert.equal((<sinon.SinonStub>console.log).args[0][0], noCommandOutput);
+			})
+			.catch(() => {
+				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
+			});
 	});
 
 	it('should run and return current versions on success', () => {
 		const installedCommandWrapper1 = getCommandWrapperWithConfiguration({
-				group: 'apple',
-				name: 'test',
-				path: join(pathResolve('.'), '_build/tests/support/valid-package')
-			});
+			group: 'apple',
+			name: 'test',
+			path: join(pathResolve('.'), '_build/tests/support/valid-package')
+		});
 		const installedCommandWrapper2 = getCommandWrapperWithConfiguration({
 			group: 'orange',
 			name: 'anotherTest',
 			path: join(pathResolve('.'), '_build/tests/support/another-valid-package')
 		});
 
-		const expectedOutput = `${outputPrefix()}The currently installed groups are:\n\n${installedCommandWrapper1.group} (${validPackageInfo.name}) ${validPackageInfo.version}\n${installedCommandWrapper2.group} (${anotherValidPackageInfo.name}) ${anotherValidPackageInfo.version}\n${outputSuffix()}`;
+		const expectedOutput = `${outputPrefix()}The currently installed groups are:\n\n${
+			installedCommandWrapper1.group
+		} (${validPackageInfo.name}) ${validPackageInfo.version}\n${installedCommandWrapper2.group} (${
+			anotherValidPackageInfo.name
+		}) ${anotherValidPackageInfo.version}\n${outputSuffix()}`;
 
 		const commandMap: CommandsMap = new Map<string, CommandWrapper>([
 			['installedCommand1', installedCommandWrapper1],
 			['installedCommand2', installedCommandWrapper2]
 		]);
-		mockAllCommands.default = sandbox.stub().resolves({commandsMap: commandMap});
-		const helper = {command: 'version'};
-		return moduleUnderTest.run(helper, { outdated: false }).then(() => {
-			assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
-			assert.equal((<sinon.SinonStub> console.log).args[0][0], expectedOutput);
-		})
-		.catch(() => {
-			assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
-		});
+		mockAllCommands.default = sandbox.stub().resolves({ commandsMap: commandMap });
+		const helper = { command: 'version' };
+		return moduleUnderTest
+			.run(helper, { outdated: false })
+			.then(() => {
+				assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
+				assert.equal((<sinon.SinonStub>console.log).args[0][0], expectedOutput);
+			})
+			.catch(() => {
+				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
+			});
 	});
 
 	it('should ignore builtin commands when outputting version info', () => {
@@ -132,22 +140,26 @@ describe('version command', () => {
 			path: join(pathResolve('.'), '/_build/src/commands/builtInCommand.js')
 		});
 
-		const expectedOutput = `${outputPrefix()}The currently installed groups are:\n\n${installedCommandWrapper.group} (${validPackageInfo.name}) ${validPackageInfo.version}\n${outputSuffix()}`;
+		const expectedOutput = `${outputPrefix()}The currently installed groups are:\n\n${
+			installedCommandWrapper.group
+		} (${validPackageInfo.name}) ${validPackageInfo.version}\n${outputSuffix()}`;
 
 		const commandMap: CommandsMap = new Map<string, CommandWrapper>([
 			['installedCommand1', installedCommandWrapper],
 			['builtInCommand1', builtInCommandWrapper]
 		]);
 
-		const helper = {command: 'version'};
-		mockAllCommands.default = sandbox.stub().resolves({commandsMap: commandMap});
-		return moduleUnderTest.run(helper, { outdated: false }).then(() => {
-			assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
-			assert.equal((<sinon.SinonStub> console.log).args[0][0], expectedOutput);
-		})
-		.catch(() => {
-			assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
-		});
+		const helper = { command: 'version' };
+		mockAllCommands.default = sandbox.stub().resolves({ commandsMap: commandMap });
+		return moduleUnderTest
+			.run(helper, { outdated: false })
+			.then(() => {
+				assert.isTrue(mockDavid.getUpdatedDependencies.notCalled);
+				assert.equal((<sinon.SinonStub>console.log).args[0][0], expectedOutput);
+			})
+			.catch(() => {
+				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
+			});
 	});
 
 	it('should run and return current versions and latest version on success', () => {
@@ -159,26 +171,30 @@ describe('version command', () => {
 			path: join(pathResolve('.'), '_build/tests/support/valid-package')
 		});
 
-		const expectedOutput = `${outputPrefix()}The currently installed groups are:\n\n${installedCommandWrapper.group} (${validPackageInfo.name}) ${validPackageInfo.version} (on latest stable version).\n${outputSuffix()}`;
+		const expectedOutput = `${outputPrefix()}The currently installed groups are:\n\n${
+			installedCommandWrapper.group
+		} (${validPackageInfo.name}) ${validPackageInfo.version} (on latest stable version).\n${outputSuffix()}`;
 
 		const commandMap: CommandsMap = new Map<string, CommandWrapper>([
 			['installedCommand1', installedCommandWrapper]
 		]);
 
-		const helper = {command: 'version' };
-		mockAllCommands.default = sandbox.stub().resolves({commandsMap: commandMap});
-		return moduleUnderTest.run(helper, { 'outdated': true }).then(() => {
-			assert.equal('Fetching latest version information...', (<sinon.SinonStub> console.log).args[0][0]);
-			assert.equal((<sinon.SinonStub> console.log).args[1][0], expectedOutput);
-		})
-		.catch(() => {
-			assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
-		});
+		const helper = { command: 'version' };
+		mockAllCommands.default = sandbox.stub().resolves({ commandsMap: commandMap });
+		return moduleUnderTest
+			.run(helper, { outdated: true })
+			.then(() => {
+				assert.equal('Fetching latest version information...', (<sinon.SinonStub>console.log).args[0][0]);
+				assert.equal((<sinon.SinonStub>console.log).args[1][0], expectedOutput);
+			})
+			.catch(() => {
+				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
+			});
 	});
 
 	it('should run and return current versions and upgrade to latest version on success', () => {
 		const latestStableInfo: any = {};
-		latestStableInfo[validPackageInfo.name] = {'latest': '1.2.3'};
+		latestStableInfo[validPackageInfo.name] = { latest: '1.2.3' };
 		mockDavid.getUpdatedDependencies = sandbox.stub().yields(null, latestStableInfo);
 		const installedCommandWrapper = getCommandWrapperWithConfiguration({
 			group: 'apple',
@@ -186,21 +202,27 @@ describe('version command', () => {
 			path: join(pathResolve('.'), '_build/tests/support/valid-package')
 		});
 
-		const expectedOutput = `${outputPrefix()}The currently installed groups are:\n\n${installedCommandWrapper.group} (${validPackageInfo.name}) ${validPackageInfo.version} \u001b[33m(can be updated to ${latestStableInfo[validPackageInfo.name].latest})\u001b[39m.\n${outputSuffix()}`;
+		const expectedOutput = `${outputPrefix()}The currently installed groups are:\n\n${
+			installedCommandWrapper.group
+		} (${validPackageInfo.name}) ${validPackageInfo.version} \u001b[33m(can be updated to ${
+			latestStableInfo[validPackageInfo.name].latest
+		})\u001b[39m.\n${outputSuffix()}`;
 
 		const commandMap: CommandsMap = new Map<string, CommandWrapper>([
 			['installedCommand1', installedCommandWrapper]
 		]);
 
-		const helper = {command: 'version' };
-		mockAllCommands.default = sandbox.stub().resolves({commandsMap: commandMap});
-		return moduleUnderTest.run(helper, { 'outdated': true }).then(() => {
-			assert.equal('Fetching latest version information...', (<sinon.SinonStub> console.log).args[0][0]);
-			assert.equal((<sinon.SinonStub> console.log).args[1][0], expectedOutput);
-		})
-		.catch(() => {
-			assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
-		});
+		const helper = { command: 'version' };
+		mockAllCommands.default = sandbox.stub().resolves({ commandsMap: commandMap });
+		return moduleUnderTest
+			.run(helper, { outdated: true })
+			.then(() => {
+				assert.equal('Fetching latest version information...', (<sinon.SinonStub>console.log).args[0][0]);
+				assert.equal((<sinon.SinonStub>console.log).args[1][0], expectedOutput);
+			})
+			.catch(() => {
+				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
+			});
 	});
 
 	it('should return an error if fetching latest versions fails', () => {
@@ -218,15 +240,17 @@ describe('version command', () => {
 			['installedCommand1', installedCommandWrapper]
 		]);
 
-		const helper = {command: 'version' };
-		mockAllCommands.default = sandbox.stub().resolves({commandsMap: commandMap});
-		return moduleUnderTest.run(helper, { 'outdated': true }).then(() => {
-			assert.equal('Fetching latest version information...', (<sinon.SinonStub> console.log).args[0][0]);
-			assert.equal((<sinon.SinonStub> console.log).args[1][0], expectedOutput);
-		})
-		.catch(() => {
-			assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
-		});
+		const helper = { command: 'version' };
+		mockAllCommands.default = sandbox.stub().resolves({ commandsMap: commandMap });
+		return moduleUnderTest
+			.run(helper, { outdated: true })
+			.then(() => {
+				assert.equal('Fetching latest version information...', (<sinon.SinonStub>console.log).args[0][0]);
+				assert.equal((<sinon.SinonStub>console.log).args[1][0], expectedOutput);
+			})
+			.catch(() => {
+				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
+			});
 	});
 
 	function outputPrefix() {

--- a/tests/unit/config.ts
+++ b/tests/unit/config.ts
@@ -4,7 +4,7 @@ const { assert } = intern.getPlugin('chai');
 import { resolve } from 'path';
 
 import config from '../../src/config';
-const expectedSearchPrefixes = [ '@dojo/cli', 'dojo-cli' ];
+const expectedSearchPrefixes = ['@dojo/cli', 'dojo-cli'];
 
 registerSuite('config', {
 	'Should provide a search prefix'() {

--- a/tests/unit/configurationHelper.ts
+++ b/tests/unit/configurationHelper.ts
@@ -19,15 +19,10 @@ const dojoRcPath = `${packagePath}/.dojorc`;
 
 registerSuite('Configuration Helper', {
 	'package dir exists': {
-		'beforeEach'() {
+		beforeEach() {
 			sandbox = sinon.sandbox.create();
 			mockModule = new MockModule('../../src/configurationHelper', require);
-			mockModule.dependencies([
-				'pkg-dir',
-				'fs',
-				'path',
-				dojoRcPath
-			]);
+			mockModule.dependencies(['pkg-dir', 'fs', 'path', dojoRcPath]);
 			mockPkgDir = mockModule.getMock('pkg-dir');
 			mockPkgDir.ctor.sync = sandbox.stub().returns(packagePath);
 			mockFs = mockModule.getMock('fs');
@@ -39,7 +34,7 @@ registerSuite('Configuration Helper', {
 			moduleUnderTest = mockModule.getModuleUnderTest().default;
 			configurationHelper = moduleUnderTest;
 		},
-		'afterEach'() {
+		afterEach() {
 			sandbox.restore();
 			mockModule.destroy();
 		},
@@ -52,7 +47,10 @@ registerSuite('Configuration Helper', {
 
 				assert.isTrue(mockFs.writeFileSync.calledOnce);
 				assert.equal(mockFs.writeFileSync.firstCall.args[0], dojoRcPath);
-				assert.equal(mockFs.writeFileSync.firstCall.args[1], JSON.stringify({ 'testGroupName-testCommandName': newConfig }, null, 2));
+				assert.equal(
+					mockFs.writeFileSync.firstCall.args[1],
+					JSON.stringify({ 'testGroupName-testCommandName': newConfig }, null, 2)
+				);
 			},
 			'Should merge new config with old when save called'() {
 				const newConfig = { foo: 'bar' };
@@ -60,7 +58,14 @@ registerSuite('Configuration Helper', {
 				mockFs.readFileSync.returns(JSON.stringify({ 'testGroupName-testCommandName': existingConfig }));
 				configurationHelper.sandbox('testGroupName', 'testCommandName').set(newConfig);
 				assert.isTrue(mockFs.writeFileSync.calledOnce);
-				assert.equal(mockFs.writeFileSync.firstCall.args[1], JSON.stringify({ 'testGroupName-testCommandName': Object.assign(existingConfig, newConfig) }, null, 2));
+				assert.equal(
+					mockFs.writeFileSync.firstCall.args[1],
+					JSON.stringify(
+						{ 'testGroupName-testCommandName': Object.assign(existingConfig, newConfig) },
+						null,
+						2
+					)
+				);
 			},
 			'Should merge new commandNames with existing command config when save called'() {
 				const newConfig = { foo: 'bar' };
@@ -68,10 +73,17 @@ registerSuite('Configuration Helper', {
 				mockFs.readFileSync.returns(JSON.stringify({ existingCommandName: existingConfig }));
 				configurationHelper.sandbox('testGroupName', 'testCommandName').set(newConfig);
 				assert.isTrue(mockFs.writeFileSync.calledOnce);
-				assert.deepEqual(mockFs.writeFileSync.firstCall.args[1], JSON.stringify({
-					existingCommandName: existingConfig,
-					'testGroupName-testCommandName': newConfig
-				}, null, 2));
+				assert.deepEqual(
+					mockFs.writeFileSync.firstCall.args[1],
+					JSON.stringify(
+						{
+							existingCommandName: existingConfig,
+							'testGroupName-testCommandName': newConfig
+						},
+						null,
+						2
+					)
+				);
 			},
 			'Should return undefined config when no dojorc for commandName exists'() {
 				mockFs.existsSync.returns(false);
@@ -93,19 +105,18 @@ registerSuite('Configuration Helper', {
 
 				assert.isTrue(mockFs.writeFileSync.calledOnce);
 				assert.equal(mockFs.writeFileSync.firstCall.args[0], dojoRcPath);
-				assert.equal(mockFs.writeFileSync.firstCall.args[1], JSON.stringify({ 'testGroupName-testCommandName': newConfig }, null, 2));
+				assert.equal(
+					mockFs.writeFileSync.firstCall.args[1],
+					JSON.stringify({ 'testGroupName-testCommandName': newConfig }, null, 2)
+				);
 			}
 		}
 	},
 	'package dir does not exist': {
-		'beforeEach'() {
+		beforeEach() {
 			sandbox = sinon.sandbox.create();
 			mockModule = new MockModule('../../src/configurationHelper', require);
-			mockModule.dependencies([
-				'pkg-dir',
-				'fs',
-				'path'
-			]);
+			mockModule.dependencies(['pkg-dir', 'fs', 'path']);
 			mockPkgDir = mockModule.getMock('pkg-dir');
 			mockPkgDir.ctor.sync = sandbox.stub().returns(null);
 			mockFs = mockModule.getMock('fs');
@@ -117,7 +128,7 @@ registerSuite('Configuration Helper', {
 			moduleUnderTest = mockModule.getModuleUnderTest().default;
 			configurationHelper = moduleUnderTest;
 		},
-		'afterEach'() {
+		afterEach() {
 			sandbox.restore();
 			mockModule.destroy();
 		},

--- a/tests/unit/index.ts
+++ b/tests/unit/index.ts
@@ -6,7 +6,6 @@ import * as sinon from 'sinon';
 import { join, resolve as pathResolve } from 'path';
 
 describe('cli main module', () => {
-	let moduleUnderTest: any;
 	let mockModule: MockModule;
 	let mockPkgDir: any;
 	let mockInstallableCommands: any;
@@ -52,7 +51,7 @@ describe('cli main module', () => {
 				});
 				mockRegisterCommands = mockModule.getMock('./registerCommands');
 				sandbox.stub(console, 'log');
-				moduleUnderTest = mockModule.getModuleUnderTest();
+				mockModule.getModuleUnderTest();
 			});
 
 			afterEach(() => {
@@ -90,7 +89,7 @@ describe('cli main module', () => {
 				mockUpdate = mockModule.getMock('./updateNotifier');
 				mockUpdate.default = sandbox.stub().throws(expectedError);
 				sandbox.stub(console, 'log');
-				moduleUnderTest = mockModule.getModuleUnderTest();
+				mockModule.getModuleUnderTest();
 			});
 
 			afterEach(() => {

--- a/tests/unit/index.ts
+++ b/tests/unit/index.ts
@@ -6,7 +6,6 @@ import * as sinon from 'sinon';
 import { join, resolve as pathResolve } from 'path';
 
 describe('cli main module', () => {
-
 	let moduleUnderTest: any;
 	let mockModule: MockModule;
 	let mockPkgDir: any;
@@ -20,7 +19,6 @@ describe('cli main module', () => {
 	it('should run functions in order', () => {
 		describe('inner', () => {
 			beforeEach(() => {
-
 				sandbox = sinon.sandbox.create();
 				mockModule = new MockModule('../../src/index', require);
 				mockModule.dependencies([
@@ -34,22 +32,23 @@ describe('cli main module', () => {
 
 				mockInstallableCommands = mockModule.getMock('./installableCommands');
 				mockInstallableCommands.default = sandbox.stub().resolves([]);
-				mergeStub = mockInstallableCommands.mergeInstalledCommandsWithAvailableCommands = sandbox.stub().returnsArg(0);
+				mergeStub = mockInstallableCommands.mergeInstalledCommandsWithAvailableCommands = sandbox
+					.stub()
+					.returnsArg(0);
 
 				mockPkgDir = mockModule.getMock('pkg-dir');
-				mockPkgDir.ctor.sync = sandbox.stub().returns(join(pathResolve('.'), '/_build/tests/support/valid-package'));
+				mockPkgDir.ctor.sync = sandbox
+					.stub()
+					.returns(join(pathResolve('.'), '/_build/tests/support/valid-package'));
 
 				mockUpdate = mockModule.getMock('./updateNotifier');
 				mockAllCommands = mockModule.getMock('./allCommands');
 				mockAllCommands.default = sandbox.stub().resolves({
 					commandsMap: new Map([
-							['key1', {name: 'a', group: 'c', path: 'as'}],
-							['key2', {name: 'b', group: 'd', path: 'asas'}]
-						]),
-					yargsCommandNames: new Map([
-						['key3', new Set(['a', 'b'])],
-						['key4', new Set(['d', 'e'])]
-					])
+						['key1', { name: 'a', group: 'c', path: 'as' }],
+						['key2', { name: 'b', group: 'd', path: 'asas' }]
+					]),
+					yargsCommandNames: new Map([['key3', new Set(['a', 'b'])], ['key4', new Set(['d', 'e'])]])
 				});
 				mockRegisterCommands = mockModule.getMock('./registerCommands');
 				sandbox.stub(console, 'log');
@@ -67,11 +66,12 @@ describe('cli main module', () => {
 				assert.isTrue(mockAllCommands.default.calledOnce, 'should call init');
 				assert.isTrue(mergeStub.calledAfter(mockAllCommands.default));
 				assert.isTrue(mockRegisterCommands.default.calledOnce, 'should call register commands');
-				assert.isTrue(mockRegisterCommands.default.calledAfter(mergeStub),
-					'should call register commands after commands have been merged');
+				assert.isTrue(
+					mockRegisterCommands.default.calledAfter(mergeStub),
+					'should call register commands after commands have been merged'
+				);
 			});
 		});
-
 	});
 	it('should catch runtime errors', () => {
 		describe('runtime error inner', () => {
@@ -79,15 +79,13 @@ describe('cli main module', () => {
 			const expectedError = new Error(errMessage);
 
 			beforeEach(() => {
-
 				sandbox = sinon.sandbox.create();
 				mockModule = new MockModule('../../src/index', require);
-				mockModule.dependencies([
-					'./updateNotifier',
-					'pkg-dir',
-					'yargs']);
+				mockModule.dependencies(['./updateNotifier', 'pkg-dir', 'yargs']);
 				mockPkgDir = mockModule.getMock('pkg-dir');
-				mockPkgDir.ctor.sync = sandbox.stub().returns(join(pathResolve('.'), '/_build/tests/support/valid-package'));
+				mockPkgDir.ctor.sync = sandbox
+					.stub()
+					.returns(join(pathResolve('.'), '/_build/tests/support/valid-package'));
 
 				mockUpdate = mockModule.getMock('./updateNotifier');
 				mockUpdate.default = sandbox.stub().throws(expectedError);
@@ -102,9 +100,11 @@ describe('cli main module', () => {
 
 			it('catches runtime error', () => {
 				assert.throw(mockUpdate.default, Error, errMessage);
-				assert.equal((console.log as sinon.SinonStub).args[0][0], `Commands are not available: Error: ${errMessage}`);
+				assert.equal(
+					(console.log as sinon.SinonStub).args[0][0],
+					`Commands are not available: Error: ${errMessage}`
+				);
 			});
 		});
-
 	});
 });

--- a/tests/unit/installableCommands.ts
+++ b/tests/unit/installableCommands.ts
@@ -8,7 +8,6 @@ import MockModule from '../support/MockModule';
 import * as sinon from 'sinon';
 
 describe('installableCommands', () => {
-
 	let moduleUnderTest: any;
 	let mockModule: MockModule;
 	let sandbox: sinon.SinonSandbox;
@@ -34,12 +33,7 @@ describe('installableCommands', () => {
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
 		mockModule = new MockModule('../../src/installableCommands', require);
-		mockModule.dependencies([
-			'execa',
-			'cross-spawn',
-			'configstore',
-			'./configurationHelper'
-		]);
+		mockModule.dependencies(['execa', 'cross-spawn', 'configstore', './configurationHelper']);
 
 		mockConfigStore = mockModule.getMock('configstore');
 		mockConfigStoreGet = sinon.stub();
@@ -78,12 +72,15 @@ describe('installableCommands', () => {
 	it('should check for installable commands if the config store is empty', () => {
 		return moduleUnderTest.default('testName').then((commands: NpmPackageDetails[]) => {
 			assert.isTrue(mockConfigStoreGet.calledWith('commands'), 'checks for stored commands');
-			assert.isTrue(mockExeca.ctor.calledWithMatch('npm', [ 'search', '@dojo', 'cli-', '--json', '--searchstaleness', '0' ]), 'calls npm search');
+			assert.isTrue(
+				mockExeca.ctor.calledWithMatch('npm', ['search', '@dojo', 'cli-', '--json', '--searchstaleness', '0']),
+				'calls npm search'
+			);
 		});
 	});
 
 	it('does not await check for installable commands if config store contains commands', () => {
-		mockConfigStoreGet.withArgs('commands').returns([ testCommandDetails ]);
+		mockConfigStoreGet.withArgs('commands').returns([testCommandDetails]);
 		return moduleUnderTest.default('testName').then((commands: NpmPackageDetails[]) => {
 			assert.isTrue(mockConfigStoreGet.calledWith('commands'), 'checks for stored commands');
 			assert.isTrue(mockExeca.ctor.notCalled, 'does not call npm search');
@@ -99,7 +96,10 @@ describe('installableCommands', () => {
 	});
 
 	it('creates installable command prompts', () => {
-		const { commandsMap, yargsCommandNames } = moduleUnderTest.createInstallableCommandPrompts([ testCommandDetails, testCommandDetails2 ]);
+		const { commandsMap, yargsCommandNames } = moduleUnderTest.createInstallableCommandPrompts([
+			testCommandDetails,
+			testCommandDetails2
+		]);
 		assert.equal(commandsMap.size, 3);
 		assert.equal(commandsMap.get('test').name, 'command');
 		assert.equal(commandsMap.get('test').group, 'test');
@@ -111,23 +111,33 @@ describe('installableCommands', () => {
 	});
 
 	it('does not generate duplicate command promps', () => {
-		const { commandsMap, yargsCommandNames } = moduleUnderTest.createInstallableCommandPrompts([ testCommandDetails, testCommandDetails ]);
+		const { commandsMap, yargsCommandNames } = moduleUnderTest.createInstallableCommandPrompts([
+			testCommandDetails,
+			testCommandDetails
+		]);
 		assert.equal(commandsMap.size, 2);
 		assert.equal(yargsCommandNames.size, 1);
 	});
 
 	it('does not create command prompts for ejected commands', () => {
 		configHelperGetStub.returns({ ejected: true });
-		const { commandsMap, yargsCommandNames } = moduleUnderTest.createInstallableCommandPrompts([ testCommandDetails ]);
+		const { commandsMap, yargsCommandNames } = moduleUnderTest.createInstallableCommandPrompts([
+			testCommandDetails
+		]);
 		assert.equal(commandsMap.size, 0);
 		assert.equal(yargsCommandNames.size, 0);
 	});
 
 	it('shows installation instructions for installable commands', () => {
-		const { commandsMap } = moduleUnderTest.createInstallableCommandPrompts([ testCommandDetails ]);
-		return commandsMap.get('test').run().then(() => {
-			(console.log as sinon.SinonStub).calledWith(`\nTo install this command run ${chalk.green('npm i @dojo/cli-test-command')}\n`);
-		});
+		const { commandsMap } = moduleUnderTest.createInstallableCommandPrompts([testCommandDetails]);
+		return commandsMap
+			.get('test')
+			.run()
+			.then(() => {
+				(console.log as sinon.SinonStub).calledWith(
+					`\nTo install this command run ${chalk.green('npm i @dojo/cli-test-command')}\n`
+				);
+			});
 	});
 
 	it('can merge installed commands with available commands', () => {
@@ -139,7 +149,9 @@ describe('installableCommands', () => {
 			commandsMap,
 			yargsCommandNames
 		};
-		const mergedCommands = moduleUnderTest.mergeInstalledCommandsWithAvailableCommands(installedCommands, [ testCommandDetails ]);
+		const mergedCommands = moduleUnderTest.mergeInstalledCommandsWithAvailableCommands(installedCommands, [
+			testCommandDetails
+		]);
 
 		assert.equal(mergedCommands.commandsMap.size, 3);
 		assert.isTrue(mergedCommands.commandsMap.has('test'));

--- a/tests/unit/loadCommands.ts
+++ b/tests/unit/loadCommands.ts
@@ -5,7 +5,7 @@ import { join, resolve as pathResolve } from 'path';
 import { stub, SinonStub, sandbox } from 'sinon';
 import { CliConfig } from '../../src/interfaces';
 import MockModule from '../support/MockModule';
-import { getCommandWrapper, getYargsStub } from '../support/testHelper';
+import { getCommandWrapper } from '../support/testHelper';
 import {
 	enumerateBuiltInCommands as enumBuiltInCommands,
 	enumerateInstalledCommands as enumInstalledCommands,
@@ -13,7 +13,6 @@ import {
 } from '../../src/loadCommands';
 
 let loadStub: SinonStub;
-let yargsStub: any;
 let commandWrapper1: any;
 let commandWrapper2: any;
 let consoleStub: SinonStub;
@@ -43,7 +42,6 @@ registerSuite('loadCommands', {
 		consoleStub = stub(console, 'error');
 		commandWrapper1 = getCommandWrapper('command1');
 		commandWrapper2 = getCommandWrapper('command2');
-		yargsStub = getYargsStub();
 		loadStub = stub();
 		goodConfig = config();
 	},

--- a/tests/unit/loadCommands.ts
+++ b/tests/unit/loadCommands.ts
@@ -25,21 +25,21 @@ let testSandbox: any;
 function config(invalid = false): CliConfig {
 	// tests are run in package-dir (from cli, using grunt test) - FIX to use pkg-dir
 	const config: CliConfig = {
-		searchPaths: [ '_build/tests/support' ],
-		searchPrefixes: [ 'test-prefix' ],
+		searchPaths: ['_build/tests/support'],
+		searchPrefixes: ['test-prefix'],
 		builtInCommandLocation: join(pathResolve('.'), '/_build/tests/support/commands')
 	};
 	const badConfig: CliConfig = {
-		searchPaths: [ 'just/garbage', 'yep/really/bad/paths/here' ],
-		searchPrefixes: [ 'bad-prefix' ],
-		builtInCommandLocation : 'dirThatDoesNotExist'
+		searchPaths: ['just/garbage', 'yep/really/bad/paths/here'],
+		searchPrefixes: ['bad-prefix'],
+		builtInCommandLocation: 'dirThatDoesNotExist'
 	};
 
 	return invalid ? badConfig : config;
 }
 
 registerSuite('loadCommands', {
-	'beforeEach'() {
+	beforeEach() {
 		consoleStub = stub(console, 'error');
 		commandWrapper1 = getCommandWrapper('command1');
 		commandWrapper2 = getCommandWrapper('command2');
@@ -47,13 +47,13 @@ registerSuite('loadCommands', {
 		loadStub = stub();
 		goodConfig = config();
 	},
-	'afterEach'() {
+	afterEach() {
 		consoleStub.restore();
 	},
 
 	tests: {
 		'successful enumeration': {
-			'beforeEach'() {
+			beforeEach() {
 				loadStub.onFirstCall().returns(commandWrapper1);
 				loadStub.onSecondCall().returns(commandWrapper2);
 			},
@@ -65,17 +65,17 @@ registerSuite('loadCommands', {
 				},
 				async 'Should successfully enumerate builtin commands'() {
 					const builtInPaths = await enumBuiltInCommands(goodConfig);
-					assert.equal(builtInPaths.length, 2);   // includes invalid commands
+					assert.equal(builtInPaths.length, 2); // includes invalid commands
 				}
 			}
 		},
 		'unsuccessful enumeration': {
 			async 'Should fail to find installed commands that dont exist'() {
-				goodConfig.searchPrefixes = [ 'bad-prefix' ];
+				goodConfig.searchPrefixes = ['bad-prefix'];
 				const badPrefixPaths = await enumInstalledCommands(goodConfig);
 				assert.equal(badPrefixPaths.length, 0);
 
-				const badInstalledPaths = await enumInstalledCommands(config((true)));
+				const badInstalledPaths = await enumInstalledCommands(config(true));
 				assert.equal(badInstalledPaths.length, 0);
 			},
 			async 'Should fail to find built in commands that dont exist'() {
@@ -84,7 +84,7 @@ registerSuite('loadCommands', {
 			}
 		},
 		'successful load': {
-			'beforeEach'() {
+			beforeEach() {
 				loadStub.onFirstCall().returns(commandWrapper1);
 				loadStub.onSecondCall().returns(commandWrapper2);
 				goodConfig = config();
@@ -121,16 +121,15 @@ registerSuite('loadCommands', {
 		'unsuccessful load': {
 			async 'Should fail to load modules that dont satisfy the Command interface'() {
 				const failConfig = {
-					searchPaths: [ '_build/tests/support' ],
-					searchPrefixes: [ 'esmodule-fail' ]
+					searchPaths: ['_build/tests/support'],
+					searchPrefixes: ['esmodule-fail']
 				};
-				const installedPaths = await enumInstalledCommands(<any> failConfig);
+				const installedPaths = await enumInstalledCommands(<any>failConfig);
 
 				loadStub.onFirstCall().throws();
 				try {
 					await loadCommands(installedPaths, loadStub);
-				}
-				catch (error) {
+				} catch (error) {
 					assert.isTrue(error instanceof Error);
 					assert.isTrue(error.message.indexOf('Failed to load module') > -1);
 				}
@@ -140,9 +139,7 @@ registerSuite('loadCommands', {
 			beforeEach() {
 				testSandbox = sandbox.create();
 				mockModule = new MockModule('../../src/loadCommands', require);
-				mockModule.dependencies([
-					'./configurationHelper'
-				]);
+				mockModule.dependencies(['./configurationHelper']);
 				const configHelper = mockModule.getMock('./configurationHelper').default;
 				testSandbox.stub(configHelper, 'sandbox').returns({
 					get: testSandbox.stub().returns({ ejected: true })

--- a/tests/unit/npmInstall.ts
+++ b/tests/unit/npmInstall.ts
@@ -11,16 +11,16 @@ registerSuite('npmInstall', {
 	before() {
 		npmInstall = require('../../src/npmInstall');
 	},
-	'beforeEach'() {
+	beforeEach() {
 		spawnOnStub = stub();
 		const spawnOnResponse = {
-			'on': spawnOnStub
+			on: spawnOnStub
 		};
 
 		spawnOnStub.returns(spawnOnResponse);
 		spawnStub = stub(cs, 'spawn').returns(spawnOnResponse);
 	},
-	'afterEach'() {
+	afterEach() {
 		spawnStub.restore();
 	},
 
@@ -36,21 +36,20 @@ registerSuite('npmInstall', {
 			try {
 				await npmInstall.default();
 				assert.fail(null, null, 'Should not get here');
-			}
-			catch (error) {
+			} catch (error) {
 				assert.equal(errorMessage, error.message);
 			}
 		},
 		async 'Should install dependencies'() {
 			spawnOnStub.onFirstCall().callsArg(1);
-			await npmInstall.installDependencies({ dependencies: { 'foo': '1.2.3' }});
+			await npmInstall.installDependencies({ dependencies: { foo: '1.2.3' } });
 			assert.isTrue(spawnStub.calledOnce);
 			assert.isTrue(spawnStub.firstCall.args[1].indexOf('--save') > -1);
 			assert.isTrue(spawnStub.firstCall.args[1].indexOf('foo@1.2.3') > -1);
 		},
 		async 'Should install dev dependencies'() {
 			spawnOnStub.onFirstCall().callsArg(1);
-			await npmInstall.installDevDependencies({ devDependencies: { 'bar': '1.2.3' }});
+			await npmInstall.installDevDependencies({ devDependencies: { bar: '1.2.3' } });
 			assert.isTrue(spawnStub.calledOnce);
 			assert.isTrue(spawnStub.firstCall.args[1].indexOf('--save-dev') > -1);
 			assert.isTrue(spawnStub.firstCall.args[1].indexOf('bar@1.2.3') > -1);

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -10,11 +10,11 @@ import * as defaultCommandWrapper from '../support/test-prefix-foo-bar';
 const groupDef: GroupDef = [
 	{
 		groupName: 'group1',
-		commands: [ { commandName: 'command1' } ]
+		commands: [{ commandName: 'command1' }]
 	},
 	{
 		groupName: 'group2',
-		commands: [ { commandName: 'command1' }, { commandName: 'command2' }  ]
+		commands: [{ commandName: 'command1' }, { commandName: 'command2' }]
 	}
 ];
 let commandsMap: any;
@@ -26,21 +26,21 @@ const errorMessage = 'test error message';
 
 function createYargsCommandNames(obj: any): Map<string, Set<any>> {
 	const map = new Map();
-	for ( let key in obj ) {
+	for (let key in obj) {
 		map.set(key, obj[key]);
 	}
 	return map;
 }
 
 registerSuite('registerCommands', {
-	'beforeEach'() {
+	beforeEach() {
 		yargsStub = getYargsStub();
 		commandsMap = getCommandsMap(groupDef);
 	},
 
 	tests: {
 		'Should setup correct yargs arguments'() {
-			const yargsArgs = [ 'demand', 'usage', 'epilog', 'help', 'strict' ];
+			const yargsArgs = ['demand', 'usage', 'epilog', 'help', 'strict'];
 			registerCommands(yargsStub, commandsMap, new Map());
 			yargsArgs.forEach((arg) => {
 				assert.isTrue(yargsStub[arg].calledOnce);
@@ -48,16 +48,20 @@ registerSuite('registerCommands', {
 			assert.isTrue(yargsStub.alias.calledOnce, 'Should be called for help aliases');
 		},
 		'Should call strict for all commands'() {
-			registerCommands(yargsStub, commandsMap, createYargsCommandNames({
-				'group1': new Set([ 'group1-command1' ]),
-				'group2': new Set([ 'group2-command1', 'group2-command2' ])
-			}));
+			registerCommands(
+				yargsStub,
+				commandsMap,
+				createYargsCommandNames({
+					group1: new Set(['group1-command1']),
+					group2: new Set(['group2-command1', 'group2-command2'])
+				})
+			);
 			assert.equal(yargsStub.strict.callCount, 4);
 		},
 		'Should call yargs.command once for each yargsCommandName passed and once for the default command'() {
 			const key = 'group1-command1';
 			const { group, description } = commandsMap.get(key);
-			registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ key ])}));
+			registerCommands(yargsStub, commandsMap, createYargsCommandNames({ group1: new Set([key]) }));
 			assert.isTrue(yargsStub.command.calledTwice);
 			assert.isTrue(yargsStub.command.firstCall.calledWith(group, description), 'First call is for parent');
 			assert.isTrue(yargsStub.command.secondCall.calledWith('command1', key), 'Second call is sub-command');
@@ -65,17 +69,17 @@ registerSuite('registerCommands', {
 		'Should run the passed command when yargs called with group name and command'() {
 			const key = 'group1-command1';
 			const { run } = commandsMap.get(key);
-			registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ key ])}));
+			registerCommands(yargsStub, commandsMap, createYargsCommandNames({ group1: new Set([key]) }));
 			yargsStub.command.secondCall.args[3]();
 			assert.isTrue(run.calledOnce);
 		},
 		'Should call into register method'() {
 			const key = 'group1-command1';
-			registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ key ])}));
+			registerCommands(yargsStub, commandsMap, createYargsCommandNames({ group1: new Set([key]) }));
 			assert.isTrue(yargsStub.option.called);
 		},
-		'alias': {
-			'beforeEach'() {
+		alias: {
+			beforeEach() {
 				const command = commandsMap.get('group1-command1');
 				command.alias = {
 					name: 'alias',
@@ -91,19 +95,29 @@ registerSuite('registerCommands', {
 
 			tests: {
 				'should register add itself as a command'() {
-					registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ 'group1-command1' ])}));
+					registerCommands(
+						yargsStub,
+						commandsMap,
+						createYargsCommandNames({ group1: new Set(['group1-command1']) })
+					);
 					assert.equal(yargsStub.command.thirdCall.args[0], 'alias');
 					assert.equal(yargsStub.command.thirdCall.args[1], 'some description');
 				},
 				'should register options'() {
-					registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ 'group1-command1' ])}));
+					registerCommands(
+						yargsStub,
+						commandsMap,
+						createYargsCommandNames({ group1: new Set(['group1-command1']) })
+					);
 					assert.isTrue(yargsStub.option.calledTwice);
 				},
 				'should not register provided options'() {
 					const key = 'group1-command1';
 					const command = commandsMap.get(key);
-					command.register = stub().callsArgWith(0, 'w', {}).returns(key),
-					registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ key ])}));
+					(command.register = stub()
+						.callsArgWith(0, 'w', {})
+						.returns(key)),
+						registerCommands(yargsStub, commandsMap, createYargsCommandNames({ group1: new Set([key]) }));
 					assert.isTrue(yargsStub.option.calledOnce);
 				},
 				'should register when alias is an array'() {
@@ -120,14 +134,14 @@ registerSuite('registerCommands', {
 							]
 						}
 					];
-					registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ key ])}));
+					registerCommands(yargsStub, commandsMap, createYargsCommandNames({ group1: new Set([key]) }));
 					assert.isTrue(yargsStub.option.calledTwice);
 				},
 				'should augment argv when run'() {
 					const key = 'group1-command1';
 					const command = commandsMap.get(key);
-					registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ key ])}));
-					yargsStub.command.thirdCall.args[3]({'_': ['group', 'command']});
+					registerCommands(yargsStub, commandsMap, createYargsCommandNames({ group1: new Set([key]) }));
+					yargsStub.command.thirdCall.args[3]({ _: ['group', 'command'] });
 					assert.equal(command.run.firstCall.args[1].w, 10);
 				},
 				'should run without options'() {
@@ -138,8 +152,8 @@ registerSuite('registerCommands', {
 							name: 'alias'
 						}
 					];
-					registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ key ])}));
-					yargsStub.command.thirdCall.args[3]({'_': ['group', 'command']});
+					registerCommands(yargsStub, commandsMap, createYargsCommandNames({ group1: new Set([key]) }));
+					yargsStub.command.thirdCall.args[3]({ _: ['group', 'command'] });
 					const properties = Object.keys(command.run.firstCall.args[1]);
 					assert.equal(properties.length, 1);
 					['group', 'command'].forEach((key) => {
@@ -149,16 +163,18 @@ registerSuite('registerCommands', {
 			}
 		},
 		'default command': {
-			'beforeEach'() {
+			beforeEach() {
 				const key = 'group1-command1';
-				defaultRegisterStub = stub(defaultCommandWrapper, 'register').callsArgWith(0, 'key', {}).returns(key);
+				defaultRegisterStub = stub(defaultCommandWrapper, 'register')
+					.callsArgWith(0, 'key', {})
+					.returns(key);
 				defaultRunStub = stub(defaultCommandWrapper, 'run').returns(Promise.resolve());
 				commandsMap.set('group1', defaultCommandWrapper);
-				registerCommands(yargsStub, commandsMap, createYargsCommandNames({'group1': new Set([ key ])}));
+				registerCommands(yargsStub, commandsMap, createYargsCommandNames({ group1: new Set([key]) }));
 			},
-			'afterEach'() {
+			afterEach() {
 				defaultRegisterStub.restore();
-				defaultRunStub .restore();
+				defaultRunStub.restore();
 			},
 
 			tests: {
@@ -166,38 +182,38 @@ registerSuite('registerCommands', {
 					assert.isTrue(defaultRegisterStub.calledOnce);
 				},
 				'Should run default command when yargs called with only group name'() {
-					yargsStub.command.firstCall.args[3]({'_': ['group']});
+					yargsStub.command.firstCall.args[3]({ _: ['group'] });
 					assert.isTrue(defaultRunStub.calledOnce);
 				},
 				'Should not run default command when yargs called with group name and command'() {
-					yargsStub.command.firstCall.args[3]({'_': ['group', 'command']});
+					yargsStub.command.firstCall.args[3]({ _: ['group', 'command'] });
 					assert.isFalse(defaultRunStub.called);
 				},
 				'error message': {
-					'beforeEach'() {
+					beforeEach() {
 						consoleErrorStub = stub(console, 'error');
 						defaultRunStub.returns(Promise.reject(new Error(errorMessage)));
 					},
-					'afterEach'() {
+					afterEach() {
 						consoleErrorStub.restore();
 					},
 
 					tests: {
 						async 'Should show error message if the run command rejects'() {
-							await yargsStub.command.firstCall.args[3]({'_': ['group']});
+							await yargsStub.command.firstCall.args[3]({ _: ['group'] });
 							assert.isTrue(consoleErrorStub.calledOnce);
 							assert.isTrue(consoleErrorStub.firstCall.calledWithMatch(errorMessage));
 						}
 					}
 				},
-				'status codes call process exit': (function () {
+				'status codes call process exit': (function() {
 					let processExitStub: SinonStub;
 
 					return {
-						'beforeEach'() {
+						beforeEach() {
 							processExitStub = stub(process, 'exit');
 						},
-						'afterEach'() {
+						afterEach() {
 							processExitStub.restore();
 						},
 
@@ -205,16 +221,18 @@ registerSuite('registerCommands', {
 							async 'Should not exit process if no status code is returned'() {
 								defaultRunStub.returns(Promise.reject(new Error(errorMessage)));
 
-								await yargsStub.command.firstCall.args[ 3 ]({ '_': [ 'group' ] });
+								await yargsStub.command.firstCall.args[3]({ _: ['group'] });
 								assert.isFalse(processExitStub.called);
 							},
 							async 'Should exit process if status code is returned'() {
-								defaultRunStub.returns(Promise.reject({
-									message: errorMessage,
-									exitCode: 1
-								}));
+								defaultRunStub.returns(
+									Promise.reject({
+										message: errorMessage,
+										exitCode: 1
+									})
+								);
 
-								await yargsStub.command.firstCall.args[ 3 ]({ '_': [ 'group' ] });
+								await yargsStub.command.firstCall.args[3]({ _: ['group'] });
 								assert.isTrue(processExitStub.called);
 							}
 						}

--- a/tests/unit/template.ts
+++ b/tests/unit/template.ts
@@ -28,13 +28,13 @@ registerSuite('template', {
 	},
 
 	tests: {
-	async 'can render ejs file'() {
-		await template(testEjsSrc, testDest, { value });
-		assert.strictEqual(writeFileStub.firstCall.args[1].trim(), value);
-	},
-	async 'write file is called with dest path'() {
-		await template(testEjsSrc, testDest, { value });
-		assert.strictEqual(writeFileStub.firstCall.args[0], testDest);
-	}
+		async 'can render ejs file'() {
+			await template(testEjsSrc, testDest, { value });
+			assert.strictEqual(writeFileStub.firstCall.args[1].trim(), value);
+		},
+		async 'write file is called with dest path'() {
+			await template(testEjsSrc, testDest, { value });
+			assert.strictEqual(writeFileStub.firstCall.args[0], testDest);
+		}
 	}
 });

--- a/tests/unit/text.ts
+++ b/tests/unit/text.ts
@@ -4,19 +4,16 @@ const { assert } = intern.getPlugin('chai');
 import * as text from '../../src/text';
 
 registerSuite('text', {
-	exports: (function (exportedStrings) {
-		const tests: { [key: string]: () => void; } = {};
+	exports: (function(exportedStrings) {
+		const tests: { [key: string]: () => void } = {};
 
-		exportedStrings.forEach(function (exportedString) {
+		exportedStrings.forEach(function(exportedString) {
 			tests[exportedString] = () => {
-				assert.isNotNull((<any> text)[exportedString]);
-				assert.isString((<any> text)[exportedString]);
+				assert.isNotNull((<any>text)[exportedString]);
+				assert.isString((<any>text)[exportedString]);
 			};
 		});
 
 		return tests;
-	})([
-		'helpUsage',
-		'helpEpilog'
-	])
+	})(['helpUsage', 'helpEpilog'])
 });

--- a/tests/unit/updateNotifier.ts
+++ b/tests/unit/updateNotifier.ts
@@ -7,11 +7,11 @@ import { SinonStub, stub } from 'sinon';
 let updateNotifier: any;
 const notifyStub: SinonStub = stub();
 const updateNotifierStub: SinonStub = stub();
-const testPkg = { 'testKey': 'testValue' };
+const testPkg = { testKey: 'testValue' };
 const testInterval = 100;
 
 registerSuite('updateNotifier', {
-	'before'() {
+	before() {
 		mockery.enable({
 			warnOnUnregistered: false
 		});
@@ -20,12 +20,12 @@ registerSuite('updateNotifier', {
 
 		updateNotifier = require('../../src/updateNotifier').default;
 	},
-	'beforeEach'() {
+	beforeEach() {
 		notifyStub.reset();
 		updateNotifierStub.reset();
-		updateNotifierStub.returns({ 'notify': notifyStub });
+		updateNotifierStub.returns({ notify: notifyStub });
 	},
-	'after'() {
+	after() {
 		mockery.deregisterAll();
 		mockery.disable();
 	},
@@ -34,18 +34,22 @@ registerSuite('updateNotifier', {
 		'Should call update-notifier with the passed arguments'() {
 			updateNotifier(testPkg, testInterval);
 			assert.isTrue(updateNotifierStub.calledOnce);
-			assert.isTrue(updateNotifierStub.firstCall.calledWith({
-				'pkg': testPkg,
-				'updateCheckInterval': testInterval
-			}));
+			assert.isTrue(
+				updateNotifierStub.firstCall.calledWith({
+					pkg: testPkg,
+					updateCheckInterval: testInterval
+				})
+			);
 		},
 		'Should default interval to zero if none passed'() {
 			updateNotifier(testPkg);
 			assert.isTrue(updateNotifierStub.calledOnce);
-			assert.isTrue(updateNotifierStub.firstCall.calledWith({
-				'pkg': testPkg,
-				'updateCheckInterval': 0
-			}));
+			assert.isTrue(
+				updateNotifierStub.firstCall.calledWith({
+					pkg: testPkg,
+					updateCheckInterval: 0
+				})
+			);
 		},
 		'Should call notify function once notifier is set up'() {
 			updateNotifier(testPkg, testInterval);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
 		"declaration": false,
 		"module": "commonjs",
 		"moduleResolution": "node",
+		"noUnusedLocals": true,
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,5 @@
 {
-	"rulesDirectory": ["tslint-plugin-prettier"],
 	"rules": {
-		"prettier": true,
 		"align": false,
 		"ban": [],
 		"class-name": true,

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,7 @@
 {
+	"rulesDirectory": ["tslint-plugin-prettier"],
 	"rules": {
+		"prettier": true,
 		"align": false,
 		"ban": [],
 		"class-name": true,
@@ -30,15 +32,12 @@
 		"no-switch-case-fall-through": false,
 		"no-trailing-whitespace": true,
 		"no-unused-expression": false,
-		"no-unused-variable": true,
 		"no-use-before-declare": false,
 		"no-var-keyword": true,
 		"no-var-requires": false,
 		"object-literal-sort-keys": false,
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
-		"quotemark": [ true, "single" ],
 		"radix": true,
-		"semicolon": [ true, "always" ],
 		"trailing-comma": [ true, {
 			"multiline": "never",
 			"singleline": "never"
@@ -58,8 +57,6 @@
 			"property-declaration": "onespace",
 			"variable-declaration": "onespace"
 		} ],
-		"use-strict": false,
-		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords" ],
-		"whitespace": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
+		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords" ]
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds support for `Prettier` to for code style rules and formatting. Include precommit hook that runs prettier on all `.ts` files and an npm script that runs prettier against the codebase.

Related to https://github.com/dojo/meta/issues/206