### PR TITLE
Allow eject to copy absolute paths

### DIFF
--- a/src/commands/eject.ts
+++ b/src/commands/eject.ts
@@ -1,5 +1,5 @@
 import { copySync } from 'fs-extra';
-import { resolve } from 'path';
+import { basename, isAbsolute, resolve } from 'path';
 import { Argv } from 'yargs';
 import { green, underline, yellow } from 'chalk';
 import * as inquirer from 'inquirer';
@@ -29,8 +29,9 @@ function copyFiles(commandName: string, { path, files }: FileCopyConfig): void {
 	const cwd = process.cwd();
 	if (path && files && files.length > 0) {
 		files.forEach((fileName) => {
-			const sourcePath = resolve(path, fileName);
-			const destPath = resolve(cwd, copiedFilesDir, commandName, fileName);
+			const sourcePath = isAbsolute(fileName) ? fileName : resolve(path, fileName);
+			const destFileName = isAbsolute(fileName) ? basename(fileName) : fileName;
+			const destPath = resolve(cwd, copiedFilesDir, commandName, destFileName);
 
 			console.log(` ${yellow('creating')} ${destPath.replace(cwd, '.')}`);
 			copySync(sourcePath, destPath);

--- a/tests/support/eject/command-with-full-eject.ts
+++ b/tests/support/eject/command-with-full-eject.ts
@@ -21,7 +21,8 @@ export function eject(helper: any, npm: any, files: any) {
 			path: 'testPath',
 			files: [
 				'./file1',
-				'./file2'
+				'./file2',
+				'/file3'
 			]
 		}
 	};

--- a/tests/unit/commands/eject.ts
+++ b/tests/unit/commands/eject.ts
@@ -152,7 +152,8 @@ describe('eject command', () => {
 			return moduleUnderTest.run(helper, {}).then(() => {
 				assert.isTrue(consoleLogStub.secondCall.calledWith(` ${yellow('creating')} .${sep}config${sep}test-group-test-eject${sep}file1`));
 				assert.isTrue(consoleLogStub.thirdCall.calledWith(` ${yellow('creating')} .${sep}config${sep}test-group-test-eject${sep}file2`));
-				assert.isTrue(mockFsExtra.copySync.calledTwice);
+				assert.isTrue(consoleLogStub.getCall(3).calledWith(` ${yellow('creating')} .${sep}config${sep}test-group-test-eject${sep}file3`));
+				assert.isTrue(mockFsExtra.copySync.calledThrice);
 			}, () => {
 				assert.fail(null, null, 'moduleUnderTest.run should not have rejected promise');
 			});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

If an absolute path is listed in the eject's copy config, copy that file using the same file name to the output directory. For example, if the filepath is `/path/to/some-file.js`, then the file will be copied to `config/{group-name}/some-file.js`. Verified locally with a test application.

Resolves #193
