### PR TITLE
Add tslib as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/cli",
-  "version": "0.6.1",
+  "version": "0.6.2-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3080,9 +3080,9 @@
       }
     },
     "grunt-dojo2": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/grunt-dojo2/-/grunt-dojo2-0.1.1.tgz",
-      "integrity": "sha512-vHz5uCmHEDxvNHcWYRBuvB7xa34g+25oLbsXzbcBPtYTJJtwrKy4YQ8gl1hHWQUSFvLJfj+CE15yU4mdmLzBxA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/grunt-dojo2/-/grunt-dojo2-0.1.2.tgz",
+      "integrity": "sha512-BQP02tfM42ysFcrz1FFv+FqHz9OenVM/T3w5bn/ddH3BTC7+g88DHu1Eehsa+HOrjJugInrKSIa8PILH9XODfA==",
       "dev": true,
       "requires": {
         "codecov.io": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "globby": "^6.0.0",
     "inquirer": "^4.0.2",
     "pkg-dir": "^2.0.0",
+    "tslib": "~1.8.1",
     "typings-core": "^2.3.3",
     "update-notifier": "^2.3.0",
     "yargs": "^10.0.3"


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This PR adds `tslib` as a dependency since `importHelpers` is set to `true`.

References dojo/meta#226
