### PR TITLE
Ensure exit code is non zero when command fails

### DIFF
--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -14,18 +14,13 @@ import { helpUsage, helpEpilog } from './text';
  * @param error
  */
 function reportError(error: CommandError) {
-	let exitCode = 0;
-
+	let exitCode = 1;
 	if (error.exitCode !== undefined) {
 		exitCode = error.exitCode;
 	}
 
 	console.error(chalk.red.bold(error.message));
-
-	// only process.exit if we need to explicitly set the exit code
-	if (exitCode !== 0) {
-		process.exit(exitCode);
-	}
+	process.exit(exitCode);
 }
 
 /**

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -22,6 +22,7 @@ let yargsStub: any;
 let defaultRegisterStub: SinonStub;
 let defaultRunStub: SinonStub;
 let consoleErrorStub: SinonStub;
+let processExitStub: SinonStub;
 const errorMessage = 'test error message';
 
 function createYargsCommandNames(obj: any): Map<string, Set<any>> {
@@ -36,6 +37,11 @@ registerSuite('registerCommands', {
 	beforeEach() {
 		yargsStub = getYargsStub();
 		commandsMap = getCommandsMap(groupDef);
+		processExitStub = stub(process, 'exit');
+	},
+
+	afterEach() {
+		processExitStub.restore();
 	},
 
 	tests: {
@@ -203,26 +209,18 @@ registerSuite('registerCommands', {
 							await yargsStub.command.firstCall.args[3]({ _: ['group'] });
 							assert.isTrue(consoleErrorStub.calledOnce);
 							assert.isTrue(consoleErrorStub.firstCall.calledWithMatch(errorMessage));
+							assert.isTrue(processExitStub.called);
 						}
 					}
 				},
 				'status codes call process exit': (function() {
-					let processExitStub: SinonStub;
-
 					return {
-						beforeEach() {
-							processExitStub = stub(process, 'exit');
-						},
-						afterEach() {
-							processExitStub.restore();
-						},
-
 						tests: {
 							async 'Should not exit process if no status code is returned'() {
 								defaultRunStub.returns(Promise.reject(new Error(errorMessage)));
 
 								await yargsStub.command.firstCall.args[3]({ _: ['group'] });
-								assert.isFalse(processExitStub.called);
+								assert.isTrue(processExitStub.called);
 							},
 							async 'Should exit process if status code is returned'() {
 								defaultRunStub.returns(


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Exit with non zero code when running a command fails.

Resolves #209 
