### PR TITLE
Enable all command line options to be provided by the .dojorc config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Each command supports different `.dojorc` configuration but every command suppor
 }
 ```
 
-This configuration would automatically pass the `build-app-option: foo` to the command but can be overridden by passing the option on the command line:
+This configuration would automatically pass the `build-app-option: foo` to the command but is overridden by passing the option on the command line:
 
 ```shell
 $ dojo build app --build-app-option bar

--- a/README.md
+++ b/README.md
@@ -92,6 +92,35 @@ The CLI has the following built-in groups:
 `npm i @dojo/cli-build-webpack` and `npm i @dojo/cli-test-intern`
 These two groups are not included by default to allow different versions of these groups to be installed per project.
 
+## dojorc
+
+Dojo CLI commands support a JSON configuration file at the root of the project called `.dojorc` . Each command has a dedicated section in the `.dojorc` keyed by the command name minus the `cli-` prefix. For example the command `@dojo/cli-build-app` has the following section in the `.dojorc`:
+
+```json
+{
+	"build-app": {
+
+	}
+}
+```
+
+Each command supports different `.dojorc` configuration but every command supports storing command options in the `.dojorc` that can be overridden by explicitly passing options on the command line:
+
+
+```json
+{
+	"build-app": {
+		"build-app-option": "foo"
+	}
+}
+```
+
+This configuration would automatically pass the `build-app-option: foo` to the command but can be overridden by passing the option on the command line:
+
+```shell
+$ dojo build app --build-app-option bar
+```
+
 ## A warning on ejecting
 
 Once you run `dojo eject`, the configuration and dependencies for the bundled tools are now part of your project.

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -49,8 +49,12 @@ export function getCommandsMap(groupDef: GroupDef) {
 }
 
 const yargsFunctions = ['demand', 'usage', 'epilog', 'help', 'alias', 'strict', 'option'];
-export function getYargsStub() {
-	const yargsStub: any = {};
+export function getYargsStub(aliases: any = {}) {
+	const yargsStub: any = {
+		parsed: {
+			aliases
+		}
+	};
 	yargsFunctions.forEach((fnc) => {
 		yargsStub[fnc] = stub().returns(yargsStub);
 	});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Enable all command line options to be specified via the `.dojorc` but still overridable by the command line when explicitly specified.

Order of precedence:

1) Explicitly specified command line options
2) `.dojorc` configuration
3) Default value for command line options 

Resolves #210 
