### PR TITLE
Tighten up filtering of returned packages from npm search

### DIFF
--- a/src/installableCommands.ts
+++ b/src/installableCommands.ts
@@ -45,7 +45,7 @@ async function search(timeout: number = 0): Promise<NpmPackageDetails[] | undefi
 		});
 		const commands = JSON.parse(stdout);
 		return commands.filter(({ name }: NpmPackageDetails) => {
-			return name !== '@dojo/cli';
+			return /^@dojo\/cli-/.test(name);
 		});
 	} catch (e) {
 		console.error('Invalid response from npm search');

--- a/tests/unit/installableCommands.ts
+++ b/tests/unit/installableCommands.ts
@@ -88,7 +88,9 @@ describe('installableCommands', () => {
 	});
 
 	it('filters out @dojo/cli from search results', () => {
-		mockExeca.ctor.resolves({ stdout: `[{"name": "@dojo/cli"}, {"name": "@dojo/cli-test"}]` });
+		mockExeca.ctor.resolves({
+			stdout: `[{"name": "dojo-cli-helper"}, {"name": "@dojo/cli"}, {"name": "@dojo/cli-test"}]`
+		});
 		return moduleUnderTest.default('testName').then((commands: NpmPackageDetails[]) => {
 			assert.equal(commands.length, 1);
 			assert.equal(commands[0].name, '@dojo/cli-test');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #218 
