### PR TITLE
Maintain parsed aliases for commands over using yargs internal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/cli",
-  "version": "0.6.2-rc.1",
+  "version": "0.6.2-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -41,18 +41,19 @@
       "dev": true
     },
     "@dojo/shim": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.5.tgz",
-      "integrity": "sha512-RhUPwaMmxWRTTKA3rO5gwRwRvoyVZNRsZMsQof852AwZq2bReUOYy4K9Ed6wF5SKQrJngVxNxiaGFddaZLLwSg==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.7.tgz",
+      "integrity": "sha512-3R/n4a1/17acl9S5Wtay/0rcKzUqtVVJkCLPrGZq4NmRzWop09Unryqg/GV0Y1V7SbcILHKBL7bOTEfrpVX63g==",
       "requires": {
-        "intersection-observer": "0.4.3",
-        "pepjs": "0.4.3",
-        "tslib": "1.8.1"
+        "intersection-observer": "0.4.2",
+        "pepjs": "0.4.2",
+        "tslib": "1.8.1",
+        "web-animations-js": "2.3.1"
       }
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -68,7 +69,7 @@
         "@dojo/core": "0.3.1",
         "@dojo/has": "0.1.2",
         "@dojo/interfaces": "0.2.1",
-        "@dojo/shim": "0.2.5",
+        "@dojo/shim": "0.2.7",
         "decompress": "4.2.0",
         "semver": "5.4.1",
         "tslib": "1.8.1"
@@ -91,16 +92,16 @@
         "@dojo/core": "0.3.1",
         "@dojo/has": "0.1.2",
         "@dojo/interfaces": "0.2.1",
-        "@dojo/shim": "0.2.5",
+        "@dojo/shim": "0.2.7",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.5",
         "tslib": "1.8.1"
       }
     },
     "@types/babel-types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.0.tgz",
-      "integrity": "sha512-PyWcbX0W4r4GcgXLI0Vu4jyJ/Erueo3PwjgvQcOmWAOBW0ObhzBBciEX+sHvjkNE0umI6nqD192FDKvYZTL91A==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.1.tgz",
+      "integrity": "sha512-EkcOk09rjhivbovP8WreGRbXW20YRfe/qdgXOGq3it3u3aAOWDRNsQhL/XPAWFF7zhZZ+uR+nT+3b+TCkIap1w==",
       "dev": true
     },
     "@types/benchmark": {
@@ -116,7 +117,7 @@
       "dev": true,
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "8.9.3"
+        "@types/node": "8.10.0"
       }
     },
     "@types/chai": {
@@ -131,7 +132,7 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.9.3"
+        "@types/node": "8.10.0"
       }
     },
     "@types/configstore": {
@@ -159,9 +160,9 @@
       "dev": true
     },
     "@types/events": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
-      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
       "dev": true
     },
     "@types/execa": {
@@ -170,7 +171,7 @@
       "integrity": "sha512-7dsoPp7r33mdPcxukSrs9WVQgI96fiqffC7K4XvXJnSrTtJov3x1CJUgid7msJ8yCbfkmXJoKJ3HXyQIwZD0NQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.9.3"
+        "@types/node": "8.10.0"
       }
     },
     "@types/express": {
@@ -190,17 +191,17 @@
       "integrity": "sha512-EehCl3tpuqiM8RUb+0255M8PhhSwTtLfmO7zBBdv0ay/VTd/zmrqDfQdZFsa5z/PVMbH2yCMZPXsnrImpATyIw==",
       "dev": true,
       "requires": {
-        "@types/events": "1.1.0",
-        "@types/node": "8.9.3"
+        "@types/events": "1.2.0",
+        "@types/node": "8.10.0"
       }
     },
     "@types/fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-qtxDULQKUenuaDLW003CgC+0T0eiAfH3BrH+vSt87GLzbz5EZ6Ox6mv9rMttvhDOatbb9nYh0E1m7ydoYwUrAg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.1.tgz",
+      "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.9.3"
+        "@types/node": "8.10.0"
       }
     },
     "@types/glob": {
@@ -209,9 +210,9 @@
       "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "dev": true,
       "requires": {
-        "@types/events": "1.1.0",
+        "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "8.9.3"
+        "@types/node": "8.10.0"
       }
     },
     "@types/globby": {
@@ -229,7 +230,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.9.3"
+        "@types/node": "8.10.0"
       }
     },
     "@types/handlebars": {
@@ -278,7 +279,7 @@
       "integrity": "sha512-Ll2qAzv7NItqVliZZ8OMAgAvGstddK2995/7X5YPU84lD3CFnqDfP4sTu5Q1GKReh5Ttw3shKR2e3Fe6Xo0C7A==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "7.0.0",
+        "@types/babel-types": "7.0.1",
         "@types/istanbul-lib-coverage": "1.1.0",
         "source-map": "0.6.1"
       },
@@ -335,9 +336,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.102",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.102.tgz",
-      "integrity": "sha512-k/SxycYmVc6sYo6kzm8cABHcbMs9MXn6jYsja1hLvZ/x9e31VHRRn+1UzWdpv6doVchphvKaOsZ0VTqbF7zvNg==",
+      "version": "4.14.106",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.106.tgz",
+      "integrity": "sha512-tOSvCVrvSqFZ4A/qrqqm6p37GZoawsZtoR0SJhlF7EonNZUgrn8FfT+RNQ11h+NUpMt6QVe36033f3qEKBwfWA==",
       "dev": true
     },
     "@types/marked": {
@@ -371,9 +372,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.3.tgz",
-      "integrity": "sha512-wqrPE4Uvj2fmL0E5JFQiY7D/5bAKvVUfWTnQ5NEV35ULkAU0j3QuqIi9Qyrytz8M5hsrh8Kijt+FsdLQaZR+IA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.0.tgz",
+      "integrity": "sha512-7IGHZQfRfa0bCd7zUBVUGFKFn31SpaLDFfNoCAqkTGQO5JlHC9BwQA/CG9KZlABFxIUtXznyFgechjPQEGrUTg==",
       "dev": true
     },
     "@types/platform": {
@@ -388,7 +389,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "8.9.3"
+        "@types/node": "8.10.0"
       }
     },
     "@types/rx": {
@@ -539,13 +540,13 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "8.9.3"
+        "@types/node": "8.10.0"
       }
     },
     "@types/sinon": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.1.3.tgz",
-      "integrity": "sha512-Xxn32Q3mAJHOMU20bxcT6HiPksUJEkZA+nyZS4NhLo8kKb8hLhkBgp5OeW/BI3+9QmdrvDRk3caYNqtYb+TEbA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.3.0.tgz",
+      "integrity": "sha512-rvgY5bK5ZBRJPuJF0vJI+NC2gt+lakobTa8pnDS/oRH2gk/tooeDEel8piZA8Ng6pxq0A5QGzilIFSyashP6jw==",
       "dev": true
     },
     "@types/source-map": {
@@ -566,7 +567,7 @@
       "integrity": "sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==",
       "dev": true,
       "requires": {
-        "@types/node": "8.9.3"
+        "@types/node": "8.10.0"
       }
     },
     "@types/update-notifier": {
@@ -581,13 +582,13 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.9.3"
+        "@types/node": "8.10.0"
       }
     },
     "@types/yargs": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-10.0.1.tgz",
-      "integrity": "sha512-EvK+v8864qaRCjtqcJa7iUKWYTIvbdSZ4MJd99QTcBpq2FbVllwW7ldRBesBYINgj2Mn0yMQ2yZZJPej1DcJFA==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-10.0.2.tgz",
+      "integrity": "sha512-VbsIazac1gy20qTjEZVgDUhs8uuVmGbFkSGcdHpcMoXSC4+0vn/PRHz9YBqpgxKwUi8qoxf3eHff07w7aKNBOg==",
       "dev": true
     },
     "abbrev": {
@@ -596,12 +597,12 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-      "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "negotiator": "0.6.1"
       }
     },
@@ -655,9 +656,9 @@
       }
     },
     "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
     },
     "ansi-red": {
       "version": "0.1.1",
@@ -674,9 +675,9 @@
       "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
     "ansi-styles": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
         "color-convert": "1.9.1"
       }
@@ -724,12 +725,20 @@
       }
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
+        }
       }
     },
     "arr-diff": {
@@ -859,7 +868,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000808",
+        "caniuse-db": "1.0.30000820",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1006,7 +1015,7 @@
         "babylon": "6.18.0",
         "debug": "2.6.9",
         "globals": "9.18.0",
-        "invariant": "2.2.2",
+        "invariant": "2.2.4",
         "lodash": "4.17.5"
       }
     },
@@ -1117,7 +1126,7 @@
         "on-finished": "2.3.0",
         "qs": "5.2.0",
         "raw-body": "2.1.7",
-        "type-is": "1.6.15"
+        "type-is": "1.6.16"
       },
       "dependencies": {
         "debug": {
@@ -1165,7 +1174,7 @@
       "requires": {
         "ansi-align": "2.0.0",
         "camelcase": "4.1.0",
-        "chalk": "2.3.1",
+        "chalk": "2.3.2",
         "cli-boxes": "1.0.0",
         "string-width": "2.1.1",
         "term-size": "1.2.0",
@@ -1198,8 +1207,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000808",
-        "electron-to-chromium": "1.3.33"
+        "caniuse-db": "1.0.30000820",
+        "electron-to-chromium": "1.3.40"
       }
     },
     "buffer": {
@@ -1209,7 +1218,7 @@
       "dev": true,
       "requires": {
         "base64-js": "0.0.8",
-        "ieee754": "1.1.8",
+        "ieee754": "1.1.11",
         "isarray": "1.0.0"
       }
     },
@@ -1218,6 +1227,11 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1261,15 +1275,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000808",
+        "caniuse-db": "1.0.30000820",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000808",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000808.tgz",
-      "integrity": "sha1-MN/YMAnVcE8C3/s3clBo7RKjZrs=",
+      "version": "1.0.30000820",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000820.tgz",
+      "integrity": "sha1-fCDiXOoXaLJhtyT4LjpqJTqqFGg=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1309,13 +1323,13 @@
       }
     },
     "chalk": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
-      "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+      "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
       "requires": {
-        "ansi-styles": "3.2.0",
+        "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "5.2.0"
+        "supports-color": "5.3.0"
       }
     },
     "chardet": {
@@ -1356,10 +1370,9 @@
       }
     },
     "ci-info": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
-      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
-      "dev": true
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
+      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
     },
     "clap": {
       "version": "1.2.3",
@@ -1494,9 +1507,9 @@
       }
     },
     "clone": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
     "coa": {
@@ -1535,7 +1548,7 @@
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "dev": true,
       "requires": {
-        "clone": "1.0.3",
+        "clone": "1.0.4",
         "color-convert": "1.9.1",
         "color-string": "0.3.0"
       }
@@ -1580,9 +1593,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -1602,23 +1615,24 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
+        "buffer-from": "1.0.0",
         "inherits": "2.0.3",
-        "readable-stream": "2.3.4",
+        "readable-stream": "2.3.5",
         "typedarray": "0.0.6"
       }
     },
     "configstore": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
+        "make-dir": "1.2.0",
         "unique-string": "1.0.0",
         "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
@@ -1666,7 +1680,7 @@
       "dev": true,
       "requires": {
         "is-directory": "0.3.1",
-        "js-yaml": "3.10.0",
+        "js-yaml": "3.11.0",
         "parse-json": "3.0.0",
         "require-from-string": "2.0.1"
       },
@@ -1678,12 +1692,12 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+          "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
+            "argparse": "1.0.10",
             "esprima": "4.0.0"
           }
         },
@@ -1711,7 +1725,7 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.1",
+        "lru-cache": "4.1.2",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
@@ -1722,7 +1736,7 @@
       "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
+        "lru-cache": "4.1.2",
         "which": "1.3.0"
       }
     },
@@ -2017,7 +2031,7 @@
         "decompress-targz": "4.1.1",
         "decompress-unzip": "4.0.1",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.1.0",
+        "make-dir": "1.2.0",
         "pify": "2.3.0",
         "strip-dirs": "2.1.0"
       },
@@ -2247,14 +2261,14 @@
       "dev": true
     },
     "ejs": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
-      "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.8.tgz",
+      "integrity": "sha512-QIDZL54fyV8MDcAsO91BMH1ft2qGGaHIJsJIA/+t+7uvXol1dm413fPcUgUb4k8F/9457rx4/KFE4XfDifrQxQ=="
     },
     "electron-to-chromium": {
-      "version": "1.3.33",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz",
-      "integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU=",
+      "version": "1.3.40",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.40.tgz",
+      "integrity": "sha1-H71tl779crim+SHcONIkE9L2/d8=",
       "dev": true
     },
     "elegant-spinner": {
@@ -2414,7 +2428,7 @@
       "integrity": "sha1-ZwI1ypWYiQpa6BcLg9tyK4Qu2Sc=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "content-disposition": "0.5.2",
         "content-type": "1.0.4",
@@ -2439,7 +2453,7 @@
         "serve-static": "1.12.6",
         "setprototypeof": "1.0.3",
         "statuses": "1.3.1",
-        "type-is": "1.6.15",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.0",
         "vary": "1.1.2"
       },
@@ -2660,13 +2674,13 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
         "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
       }
     },
     "forwarded": {
@@ -2709,7 +2723,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.8.0"
+        "nan": "2.10.0"
       }
     },
     "function-bind": {
@@ -2898,7 +2912,7 @@
         "is-redirect": "1.0.0",
         "is-retry-allowed": "1.1.0",
         "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
+        "lowercase-keys": "1.0.1",
         "safe-buffer": "5.1.1",
         "timed-out": "4.0.1",
         "unzip-response": "2.0.1",
@@ -2930,7 +2944,7 @@
         "glob": "7.0.6",
         "grunt-cli": "1.2.0",
         "grunt-known-options": "1.1.0",
-        "grunt-legacy-log": "1.0.0",
+        "grunt-legacy-log": "1.0.1",
         "grunt-legacy-util": "1.0.0",
         "iconv-lite": "0.4.19",
         "js-yaml": "3.5.5",
@@ -3080,9 +3094,9 @@
       }
     },
     "grunt-dojo2": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/grunt-dojo2/-/grunt-dojo2-0.1.2.tgz",
-      "integrity": "sha512-BQP02tfM42ysFcrz1FFv+FqHz9OenVM/T3w5bn/ddH3BTC7+g88DHu1Eehsa+HOrjJugInrKSIa8PILH9XODfA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/grunt-dojo2/-/grunt-dojo2-0.1.3.tgz",
+      "integrity": "sha512-GmuQ8F2fTTKh7WjU/dkQ+YLGDHvXMjJTYP3Nnox5TMRwZF44V/wzpnL3d/E2L1gajsWMn3qcVTwDtmmnOIeZ3A==",
       "dev": true,
       "requires": {
         "codecov.io": "0.1.6",
@@ -3099,16 +3113,16 @@
         "grunt-tslint": "4.0.1",
         "grunt-typings": "0.1.5",
         "intern": "4.1.5",
-        "istanbul-lib-coverage": "1.1.1",
-        "istanbul-lib-report": "1.1.2",
-        "istanbul-reports": "1.1.3",
+        "istanbul-lib-coverage": "1.1.2",
+        "istanbul-lib-report": "1.1.3",
+        "istanbul-reports": "1.1.4",
         "lodash": "4.17.5",
         "parse-git-config": "0.4.3",
         "pkg-dir": "1.0.0",
         "postcss-cssnext": "2.11.0",
         "postcss-import": "9.1.0",
         "postcss-modules": "0.6.4",
-        "remap-istanbul": "0.10.1",
+        "remap-istanbul": "0.11.0",
         "resolve-from": "2.0.0",
         "shelljs": "0.7.8",
         "tslint": "4.5.1",
@@ -3118,9 +3132,9 @@
       },
       "dependencies": {
         "diff": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
           "dev": true
         },
         "execa": {
@@ -3194,13 +3208,13 @@
           "requires": {
             "babel-code-frame": "6.26.0",
             "colors": "1.1.2",
-            "diff": "3.4.0",
+            "diff": "3.5.0",
             "findup-sync": "0.3.0",
             "glob": "7.1.2",
             "optimist": "0.6.1",
             "resolve": "1.1.7",
             "tsutils": "1.9.1",
-            "update-notifier": "2.3.0"
+            "update-notifier": "2.4.0"
           }
         }
       }
@@ -3212,24 +3226,16 @@
       "dev": true
     },
     "grunt-legacy-log": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.0.tgz",
-      "integrity": "sha1-+4bxgJhHvAfcR4Q/ns1srLYt8tU=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.1.tgz",
+      "integrity": "sha512-rwuyqNKlI0IPz0DvxzJjcEiQEBaBNVeb1LFoZKxSmHLETFUwhwUrqOsPIxURTKSwNZHZ4ht1YLBYmVU0YZAzHQ==",
       "dev": true,
       "requires": {
         "colors": "1.1.2",
         "grunt-legacy-log-utils": "1.0.0",
         "hooker": "0.2.3",
-        "lodash": "3.10.1",
-        "underscore.string": "3.2.3"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        }
+        "lodash": "4.17.5",
+        "underscore.string": "3.3.4"
       }
     },
     "grunt-legacy-log-utils": {
@@ -3315,6 +3321,12 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
           "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
+          "dev": true
+        },
+        "underscore.string": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
+          "integrity": "sha1-gGmSYzZl1eX8tNsfs6hi62jp5to=",
           "dev": true
         },
         "which": {
@@ -3473,7 +3485,7 @@
             "mkdirp": "0.5.1",
             "object-assign": "4.1.1",
             "os-tmpdir": "1.0.2",
-            "osenv": "0.1.4",
+            "osenv": "0.1.5",
             "uuid": "2.0.3",
             "write-file-atomic": "1.3.4",
             "xdg-basedir": "2.0.0"
@@ -3505,11 +3517,11 @@
           "requires": {
             "any-promise": "1.3.0",
             "arrify": "1.0.1",
-            "concat-stream": "1.6.0",
-            "form-data": "2.3.1",
+            "concat-stream": "1.6.2",
+            "form-data": "2.3.2",
             "make-error-cause": "1.2.2",
             "throwback": "1.1.1",
-            "tough-cookie": "2.3.3",
+            "tough-cookie": "2.3.4",
             "xtend": "4.0.1"
           }
         },
@@ -3544,7 +3556,7 @@
             "detect-indent": "4.0.0",
             "graceful-fs": "4.1.11",
             "has": "1.0.1",
-            "invariant": "2.2.2",
+            "invariant": "2.2.4",
             "is-absolute": "0.2.6",
             "listify": "1.0.0",
             "lockfile": "1.0.3",
@@ -3558,7 +3570,7 @@
             "popsicle-rewrite": "1.0.0",
             "popsicle-status": "2.0.1",
             "promise-finally": "2.2.1",
-            "rc": "1.2.5",
+            "rc": "1.2.6",
             "rimraf": "2.6.2",
             "sort-keys": "1.1.2",
             "string-template": "1.0.0",
@@ -3693,9 +3705,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
       "dev": true
     },
     "html-comment-regex": {
@@ -3715,9 +3727,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
-      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
+      "integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA==",
       "dev": true
     },
     "http-proxy-agent": {
@@ -3789,9 +3801,9 @@
       "dev": true
     },
     "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
+      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
       "dev": true
     },
     "immediate": {
@@ -3849,8 +3861,8 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-4.0.2.tgz",
       "integrity": "sha512-+f3qDNeZpkhFJ61NBA9jXDrGGhoQuqfEum9A681c9oHoIbGgVqjogKynjB/vNVP+nVu9w3FbFQ35c0ibU0MaIQ==",
       "requires": {
-        "ansi-escapes": "3.0.0",
-        "chalk": "2.3.1",
+        "ansi-escapes": "3.1.0",
+        "chalk": "2.3.2",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
         "external-editor": "2.1.0",
@@ -3874,7 +3886,7 @@
         "@dojo/core": "0.3.1",
         "@dojo/has": "0.1.2",
         "@dojo/interfaces": "0.2.1",
-        "@dojo/shim": "0.2.5",
+        "@dojo/shim": "0.2.7",
         "@theintern/digdug": "2.0.4",
         "@theintern/leadfoot": "2.0.3",
         "@types/benchmark": "1.0.31",
@@ -3889,7 +3901,7 @@
         "@types/istanbul-lib-report": "1.1.0",
         "@types/istanbul-lib-source-maps": "1.2.1",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.102",
+        "@types/lodash": "4.14.106",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -3905,14 +3917,14 @@
         "express": "4.15.5",
         "glob": "7.1.2",
         "http-errors": "1.6.2",
-        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-coverage": "1.1.2",
         "istanbul-lib-hook": "1.0.7",
         "istanbul-lib-instrument": "1.7.5",
-        "istanbul-lib-report": "1.1.2",
-        "istanbul-lib-source-maps": "1.2.2",
-        "istanbul-reports": "1.1.3",
+        "istanbul-lib-report": "1.1.3",
+        "istanbul-lib-source-maps": "1.2.3",
+        "istanbul-reports": "1.1.4",
         "lodash": "4.17.5",
-        "mime-types": "2.1.17",
+        "mime-types": "2.1.18",
         "minimatch": "3.0.4",
         "platform": "1.3.5",
         "resolve": "1.4.0",
@@ -3938,7 +3950,7 @@
             "on-finished": "2.3.0",
             "qs": "6.4.0",
             "raw-body": "2.2.0",
-            "type-is": "1.6.15"
+            "type-is": "1.6.16"
           }
         },
         "bytes": {
@@ -4029,14 +4041,14 @@
       "dev": true
     },
     "intersection-observer": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.4.3.tgz",
-      "integrity": "sha512-sRobbVo/+DVGkbco/UkuREmXSr5ypWeQ7S7tYDhzIIP3NFtAHLkkFYdivFAIgNe4sfDYBFAjxEgUyxiEmA/dgQ=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.4.2.tgz",
+      "integrity": "sha512-SFGCL4d6A7J+aXNHTx94zV7ydngTKraDBvoJjn5iGgsXYhXgAXIYj8i3ewJoO80BRB7qtBB3sBlrdGNwTktzLg=="
     },
     "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -4100,9 +4112,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
-      "dev": true,
       "requires": {
-        "ci-info": "1.1.2"
+        "ci-info": "1.1.3"
       }
     },
     "is-directory": {
@@ -4395,9 +4406,9 @@
       }
     },
     "istanbul-lib-coverage": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-      "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.2.tgz",
+      "integrity": "sha512-tZYA0v5A7qBSsOzcebJJ/z3lk3oSzH62puG78DbBA1+zupipX2CakDyiPV3pOb8He+jBwVimuwB0dTnh38hX0w==",
       "dev": true
     },
     "istanbul-lib-hook": {
@@ -4420,7 +4431,7 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-coverage": "1.1.2",
         "semver": "5.5.0"
       },
       "dependencies": {
@@ -4433,12 +4444,12 @@
       }
     },
     "istanbul-lib-report": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
-      "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
+      "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-coverage": "1.1.2",
         "mkdirp": "0.5.1",
         "path-parse": "1.0.5",
         "supports-color": "3.2.3"
@@ -4462,13 +4473,13 @@
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
-      "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
+      "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
       "dev": true,
       "requires": {
         "debug": "3.1.0",
-        "istanbul-lib-coverage": "1.1.1",
+        "istanbul-lib-coverage": "1.1.2",
         "mkdirp": "0.5.1",
         "rimraf": "2.6.2",
         "source-map": "0.5.7"
@@ -4486,9 +4497,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
-      "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.4.tgz",
+      "integrity": "sha512-DfSTVOTkuO+kRmbO8Gk650Wqm1WRGr6lrdi2EwDK1vxpS71vdlLd613EpzOKdIFioB5f/scJTjeWBnvd1FWejg==",
       "dev": true,
       "requires": {
         "handlebars": "4.0.11"
@@ -4506,7 +4517,7 @@
       "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.1",
+        "chalk": "2.3.2",
         "jest-get-type": "21.2.0",
         "leven": "2.1.0",
         "pretty-format": "21.2.1"
@@ -4529,7 +4540,7 @@
       "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
+        "argparse": "1.0.10",
         "esprima": "2.7.3"
       }
     },
@@ -4698,8 +4709,8 @@
       "dev": true,
       "requires": {
         "app-root-path": "2.0.1",
-        "chalk": "2.3.1",
-        "commander": "2.14.1",
+        "chalk": "2.3.2",
+        "commander": "2.15.1",
         "cosmiconfig": "3.1.0",
         "debug": "3.1.0",
         "dedent": "0.7.0",
@@ -4720,9 +4731,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
         "debug": {
@@ -4776,7 +4787,7 @@
         "log-update": "1.0.2",
         "ora": "0.2.3",
         "p-map": "1.2.0",
-        "rxjs": "5.5.6",
+        "rxjs": "5.5.7",
         "stream-to-observable": "0.2.0",
         "strip-ansi": "3.0.1"
       },
@@ -4989,7 +5000,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -5136,7 +5147,7 @@
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.1"
+        "chalk": "2.3.2"
       }
     },
     "log-update": {
@@ -5166,7 +5177,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -5213,14 +5224,14 @@
       }
     },
     "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -5233,24 +5244,24 @@
       "dev": true
     },
     "make-dir": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+      "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
       "requires": {
         "pify": "3.0.0"
       }
     },
     "make-error": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.3.tgz",
-      "integrity": "sha512-j3dZCri3cCd23wgPqK/0/KvTN8R+W6fXDqQe8BNLbTpONjbA8SPaRr+q0BQq9bx3Q/+g68/gDIh9FW3by702Tg=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
+      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g=="
     },
     "make-error-cause": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
       "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
       "requires": {
-        "make-error": "1.3.3"
+        "make-error": "1.3.4"
       }
     },
     "map-obj": {
@@ -5260,9 +5271,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
-      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
       "dev": true
     },
     "math-expression-evaluator": {
@@ -5363,16 +5374,16 @@
       "optional": true
     },
     "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
     },
     "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimic-fn": {
@@ -5418,9 +5429,9 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
       "dev": true,
       "optional": true
     },
@@ -5437,9 +5448,9 @@
       "dev": true
     },
     "nise": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.5.tgz",
-      "integrity": "sha512-Es4hGuq3lpip5PckrB+Qpuma282M0UJANJ+jxAgI+0wWTL9X6MtNv+M385JgqsAE8hv6NvD3lv8CQtXgEnvlpQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.2.tgz",
+      "integrity": "sha512-KPKb+wvETBiwb4eTwtR/OsA2+iijXP+VnlSFYJo3EHjm2yjek1NWxHOUQat3i7xNLm1Bm18UA5j5Wor0yO2GtA==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
@@ -5486,10 +5497,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
+        "hosted-git-info": "2.6.0",
         "is-builtin-module": "1.0.0",
         "semver": "5.0.3",
-        "validate-npm-package-license": "3.0.1"
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -5542,15 +5553,15 @@
       "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
       "dev": true,
       "requires": {
-        "commander": "2.14.1",
+        "commander": "2.15.1",
         "npm-path": "2.0.4",
         "which": "1.3.0"
       },
       "dependencies": {
         "commander": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         }
       }
@@ -5707,7 +5718,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -5776,9 +5787,9 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
         "os-homedir": "1.0.2",
@@ -5960,9 +5971,9 @@
       "dev": true
     },
     "pepjs": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/pepjs/-/pepjs-0.4.3.tgz",
-      "integrity": "sha1-FggOlwqud5kTdWwtrviOqnSG30E="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/pepjs/-/pepjs-0.4.2.tgz",
+      "integrity": "sha1-EyZO6olJhP9CPIPkDS+k4d7Byfo="
     },
     "pify": {
       "version": "3.0.0",
@@ -6062,10 +6073,10 @@
       "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-9.2.0.tgz",
       "integrity": "sha512-petRj39w05GvH1WKuGFmzxR9+k+R9E7zX5XWTFee7P/qf88hMuLT7aAO/RsmldpQMtJsWQISkTQlfMRECKlxhw==",
       "requires": {
-        "concat-stream": "1.6.0",
-        "form-data": "2.3.1",
+        "concat-stream": "1.6.2",
+        "form-data": "2.3.2",
         "make-error-cause": "1.2.2",
-        "tough-cookie": "2.3.3"
+        "tough-cookie": "2.3.4"
       }
     },
     "popsicle-proxy-agent": {
@@ -6543,19 +6554,19 @@
       "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.17",
+        "postcss": "6.0.21",
         "postcss-media-query-parser": "0.2.3"
       },
       "dependencies": {
         "postcss": {
-          "version": "6.0.17",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
-          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.1",
+            "chalk": "2.3.2",
             "source-map": "0.6.1",
-            "supports-color": "5.2.0"
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -6707,18 +6718,18 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.17"
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "postcss": {
-          "version": "6.0.17",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
-          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.1",
+            "chalk": "2.3.2",
             "source-map": "0.6.1",
-            "supports-color": "5.2.0"
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -6736,18 +6747,18 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.17"
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "postcss": {
-          "version": "6.0.17",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
-          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.1",
+            "chalk": "2.3.2",
             "source-map": "0.6.1",
-            "supports-color": "5.2.0"
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -6765,18 +6776,18 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.17"
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "postcss": {
-          "version": "6.0.17",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
-          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.1",
+            "chalk": "2.3.2",
             "source-map": "0.6.1",
-            "supports-color": "5.2.0"
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -6794,18 +6805,18 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.17"
+        "postcss": "6.0.21"
       },
       "dependencies": {
         "postcss": {
-          "version": "6.0.17",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
-          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+          "version": "6.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
+          "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.1",
+            "chalk": "2.3.2",
             "source-map": "0.6.1",
-            "supports-color": "5.2.0"
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -7044,7 +7055,7 @@
       "dev": true,
       "requires": {
         "ansi-regex": "3.0.0",
-        "ansi-styles": "3.2.0"
+        "ansi-styles": "3.2.1"
       }
     },
     "process-nextick-args": {
@@ -7195,9 +7206,9 @@
       }
     },
     "rc": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
-      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+      "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
       "requires": {
         "deep-extend": "0.4.2",
         "ini": "1.3.5",
@@ -7272,9 +7283,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
-      "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+      "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -7430,7 +7441,7 @@
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "requires": {
-        "rc": "1.2.5",
+        "rc": "1.2.6",
         "safe-buffer": "5.1.1"
       }
     },
@@ -7439,7 +7450,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "requires": {
-        "rc": "1.2.5"
+        "rc": "1.2.6"
       }
     },
     "regjsgen": {
@@ -7466,9 +7477,9 @@
       }
     },
     "remap-istanbul": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.10.1.tgz",
-      "integrity": "sha512-gsNQXs5kJLhErICSyYhzVZ++C8LBW8dgwr874Y2QvzAUS75zBlD/juZgXs39nbYJ09fZDlX2AVLVJAY2jbFJoQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.11.0.tgz",
+      "integrity": "sha512-gQqJ+mW+jF7Hv8hXYO/pIRMz6WgZyrlp3rSxejGXzwqtK9+sNTB/tUSnLWAFTgQx4x5dx0sPDsLvbpZXuZ0omQ==",
       "dev": true,
       "requires": {
         "amdefine": "1.0.1",
@@ -7533,7 +7544,7 @@
         "oauth-sign": "0.4.0",
         "qs": "1.2.2",
         "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
+        "tough-cookie": "2.3.4",
         "tunnel-agent": "0.4.3"
       },
       "dependencies": {
@@ -7672,9 +7683,9 @@
       }
     },
     "rxjs": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
-      "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.7.tgz",
+      "integrity": "sha512-Hxo2ac8gRQjwjtKgukMIwBRbq5+KAeEV5hXM4obYBOAghev41bDQWgFH4svYiU9UnQ5kNww2LgfyBdevCd2HXA==",
       "dev": true,
       "requires": {
         "symbol-observable": "1.0.1"
@@ -7859,24 +7870,24 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.3.0.tgz",
-      "integrity": "sha512-pmf05hFgEZUS52AGJcsVjOjqAyJW2yo14cOwVYvzCyw7+inv06YXkLyW75WG6X6p951lzkoKh51L2sNbR9CDvw==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.8.tgz",
+      "integrity": "sha512-EWZf/D5BN/BbDFPmwY2abw6wgELVmk361self+lcwEmVw0WWUxURp2S/YoDB2WG/xurFVzKQglMARweYRWM6Hw==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
-        "diff": "3.4.0",
+        "diff": "3.5.0",
         "lodash.get": "4.4.2",
         "lolex": "2.3.2",
-        "nise": "1.2.5",
-        "supports-color": "5.2.0",
+        "nise": "1.3.2",
+        "supports-color": "5.3.0",
         "type-detect": "4.0.8"
       },
       "dependencies": {
         "diff": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
           "dev": true
         }
       }
@@ -7918,24 +7929,35 @@
       "dev": true
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
-    "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
       "dev": true
     },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
       "dev": true
     },
     "split": {
@@ -7948,9 +7970,9 @@
       }
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
       "dev": true
     },
     "staged-git-files": {
@@ -8077,9 +8099,9 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-      "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+      "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
       "requires": {
         "has-flag": "3.0.0"
       }
@@ -8105,7 +8127,7 @@
           "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
+            "argparse": "1.0.10",
             "esprima": "2.7.3"
           }
         }
@@ -8139,19 +8161,20 @@
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "dev": true,
       "requires": {
-        "bl": "1.2.1",
+        "bl": "1.2.2",
         "end-of-stream": "1.4.1",
-        "readable-stream": "2.3.4",
+        "readable-stream": "2.3.5",
         "xtend": "4.0.1"
       },
       "dependencies": {
         "bl": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-          "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+          "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.4"
+            "readable-stream": "2.3.5",
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -8316,9 +8339,9 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
         "punycode": "1.4.1"
       }
@@ -8348,26 +8371,26 @@
       "requires": {
         "babel-code-frame": "6.26.0",
         "colors": "1.1.2",
-        "diff": "3.4.0",
+        "diff": "3.5.0",
         "findup-sync": "0.3.0",
         "glob": "7.1.2",
         "optimist": "0.6.1",
-        "resolve": "1.5.0",
+        "resolve": "1.6.0",
         "semver": "5.5.0",
         "tslib": "1.8.1",
         "tsutils": "1.9.1"
       },
       "dependencies": {
         "diff": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
           "dev": true
         },
         "resolve": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
+          "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
           "dev": true,
           "requires": {
             "path-parse": "1.0.5"
@@ -8409,13 +8432,13 @@
       "dev": true
     },
     "type-is": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
+        "mime-types": "2.1.18"
       }
     },
     "typed-css-modules": {
@@ -8425,7 +8448,7 @@
       "dev": true,
       "requires": {
         "camelcase": "4.1.0",
-        "chalk": "2.3.1",
+        "chalk": "2.3.2",
         "chokidar": "1.7.0",
         "css-modules-loader-core": "1.1.0",
         "glob": "7.1.2",
@@ -8494,21 +8517,19 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "nan": "2.8.0",
+            "nan": "2.10.0",
             "node-pre-gyp": "0.6.39"
           },
           "dependencies": {
             "abbrev": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-              "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "ajv": {
               "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-              "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -8518,21 +8539,18 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "bundled": true,
               "dev": true
             },
             "aproba": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-              "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-              "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -8542,49 +8560,42 @@
             },
             "asn1": {
               "version": "0.2.3",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-              "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "assert-plus": {
               "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-              "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "asynckit": {
               "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "aws-sign2": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "aws4": {
               "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "balanced-match": {
               "version": "0.4.2",
-              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+              "bundled": true,
               "dev": true
             },
             "bcrypt-pbkdf": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-              "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -8593,8 +8604,7 @@
             },
             "block-stream": {
               "version": "0.0.9",
-              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-              "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "inherits": "2.0.3"
@@ -8602,8 +8612,7 @@
             },
             "boom": {
               "version": "2.10.1",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "hoek": "2.16.3"
@@ -8611,8 +8620,7 @@
             },
             "brace-expansion": {
               "version": "1.1.7",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-              "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "balanced-match": "0.4.2",
@@ -8621,34 +8629,29 @@
             },
             "buffer-shims": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-              "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+              "bundled": true,
               "dev": true
             },
             "caseless": {
               "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "co": {
               "version": "4.6.0",
-              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+              "bundled": true,
               "dev": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "delayed-stream": "1.0.0"
@@ -8656,26 +8659,22 @@
             },
             "concat-map": {
               "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+              "bundled": true,
               "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+              "bundled": true,
               "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+              "bundled": true,
               "dev": true
             },
             "cryptiles": {
               "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-              "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "boom": "2.10.1"
@@ -8683,8 +8682,7 @@
             },
             "dashdash": {
               "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-              "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -8693,8 +8691,7 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 }
@@ -8702,8 +8699,7 @@
             },
             "debug": {
               "version": "2.6.8",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-              "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -8712,35 +8708,30 @@
             },
             "deep-extend": {
               "version": "0.4.2",
-              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "delayed-stream": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+              "bundled": true,
               "dev": true
             },
             "delegates": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
-              "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "ecc-jsbn": {
               "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-              "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -8749,28 +8740,24 @@
             },
             "extend": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "extsprintf": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-              "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+              "bundled": true,
               "dev": true
             },
             "forever-agent": {
               "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "form-data": {
               "version": "2.1.4",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-              "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -8781,14 +8768,12 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+              "bundled": true,
               "dev": true
             },
             "fstream": {
               "version": "1.0.11",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "graceful-fs": "4.1.11",
@@ -8799,8 +8784,7 @@
             },
             "fstream-ignore": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-              "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -8811,8 +8795,7 @@
             },
             "gauge": {
               "version": "2.7.4",
-              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -8828,8 +8811,7 @@
             },
             "getpass": {
               "version": "0.1.7",
-              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-              "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -8838,8 +8820,7 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 }
@@ -8847,8 +8828,7 @@
             },
             "glob": {
               "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "fs.realpath": "1.0.0",
@@ -8861,21 +8841,18 @@
             },
             "graceful-fs": {
               "version": "4.1.11",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+              "bundled": true,
               "dev": true
             },
             "har-schema": {
               "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-              "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "har-validator": {
               "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-              "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -8885,15 +8862,13 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "hawk": {
               "version": "3.1.3",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "boom": "2.10.1",
@@ -8904,14 +8879,12 @@
             },
             "hoek": {
               "version": "2.16.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+              "bundled": true,
               "dev": true
             },
             "http-signature": {
               "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -8922,8 +8895,7 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "once": "1.4.0",
@@ -8932,21 +8904,18 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "bundled": true,
               "dev": true
             },
             "ini": {
               "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "number-is-nan": "1.0.1"
@@ -8954,28 +8923,24 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "isarray": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+              "bundled": true,
               "dev": true
             },
             "isstream": {
               "version": "0.1.2",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "jodid25519": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-              "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -8984,22 +8949,19 @@
             },
             "jsbn": {
               "version": "0.1.1",
-              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-              "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "json-schema": {
               "version": "0.2.3",
-              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-              "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "json-stable-stringify": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-              "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -9008,22 +8970,19 @@
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "jsonify": {
               "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "jsprim": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-              "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -9035,8 +8994,7 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 }
@@ -9044,14 +9002,12 @@
             },
             "mime-db": {
               "version": "1.27.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-              "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+              "bundled": true,
               "dev": true
             },
             "mime-types": {
               "version": "2.1.15",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-              "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "mime-db": "1.27.0"
@@ -9059,8 +9015,7 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "brace-expansion": "1.1.7"
@@ -9068,14 +9023,12 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "bundled": true,
               "dev": true
             },
             "mkdirp": {
               "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "minimist": "0.0.8"
@@ -9083,15 +9036,13 @@
             },
             "ms": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "node-pre-gyp": {
               "version": "0.6.39",
-              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
-              "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -9110,8 +9061,7 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -9121,8 +9071,7 @@
             },
             "npmlog": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
-              "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -9134,28 +9083,24 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+              "bundled": true,
               "dev": true
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "wrappy": "1.0.2"
@@ -9163,22 +9108,19 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-              "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -9188,41 +9130,35 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+              "bundled": true,
               "dev": true
             },
             "performance-now": {
               "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-              "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+              "bundled": true,
               "dev": true
             },
             "punycode": {
               "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "qs": {
               "version": "6.4.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-              "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -9234,8 +9170,7 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 }
@@ -9243,8 +9178,7 @@
             },
             "readable-stream": {
               "version": "2.2.9",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-              "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "buffer-shims": "1.0.0",
@@ -9258,8 +9192,7 @@
             },
             "request": {
               "version": "2.81.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -9289,8 +9222,7 @@
             },
             "rimraf": {
               "version": "2.6.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "glob": "7.1.2"
@@ -9298,35 +9230,30 @@
             },
             "safe-buffer": {
               "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+              "bundled": true,
               "dev": true
             },
             "semver": {
               "version": "5.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "sntp": {
               "version": "1.0.9",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "hoek": "2.16.3"
@@ -9334,8 +9261,7 @@
             },
             "sshpk": {
               "version": "1.13.0",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-              "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -9352,8 +9278,7 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                  "bundled": true,
                   "dev": true,
                   "optional": true
                 }
@@ -9361,8 +9286,7 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
@@ -9372,8 +9296,7 @@
             },
             "string_decoder": {
               "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-              "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "safe-buffer": "5.0.1"
@@ -9381,15 +9304,13 @@
             },
             "stringstream": {
               "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "ansi-regex": "2.1.1"
@@ -9397,15 +9318,13 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "tar": {
               "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "block-stream": "0.0.9",
@@ -9415,8 +9334,7 @@
             },
             "tar-pack": {
               "version": "3.4.0",
-              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-              "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -9432,8 +9350,7 @@
             },
             "tough-cookie": {
               "version": "2.3.2",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-              "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -9442,8 +9359,7 @@
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -9452,35 +9368,30 @@
             },
             "tweetnacl": {
               "version": "0.14.5",
-              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "uid-number": {
               "version": "0.0.6",
-              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+              "bundled": true,
               "dev": true
             },
             "uuid": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-              "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+              "bundled": true,
               "dev": true,
               "optional": true
             },
             "verror": {
               "version": "1.3.6",
-              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-              "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -9489,8 +9400,7 @@
             },
             "wide-align": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-              "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -9499,8 +9409,7 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+              "bundled": true,
               "dev": true
             }
           }
@@ -9588,7 +9497,7 @@
           "requires": {
             "graceful-fs": "4.1.11",
             "minimatch": "3.0.4",
-            "readable-stream": "2.3.4",
+            "readable-stream": "2.3.5",
             "set-immediate-shim": "1.0.1"
           }
         },
@@ -9647,7 +9556,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.102",
+        "@types/lodash": "4.14.106",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",
@@ -9655,7 +9564,7 @@
         "handlebars": "4.0.5",
         "highlight.js": "9.12.0",
         "lodash": "4.17.5",
-        "marked": "0.3.12",
+        "marked": "0.3.19",
         "minimatch": "3.0.4",
         "progress": "1.1.8",
         "shelljs": "0.7.8",
@@ -9669,7 +9578,7 @@
           "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
           "dev": true,
           "requires": {
-            "@types/node": "8.9.3"
+            "@types/node": "8.10.0"
           }
         },
         "@types/minimatch": {
@@ -9750,12 +9659,12 @@
       "integrity": "sha1-CexUzVsR3V8e8vwKsx03ACyita0=",
       "requires": {
         "array-uniq": "1.0.3",
-        "configstore": "3.1.1",
+        "configstore": "3.1.2",
         "debug": "2.6.9",
         "detect-indent": "5.0.0",
         "graceful-fs": "4.1.11",
         "has": "1.0.1",
-        "invariant": "2.2.2",
+        "invariant": "2.2.4",
         "is-absolute": "0.2.6",
         "jspm-config": "0.3.4",
         "listify": "1.0.0",
@@ -9770,7 +9679,7 @@
         "popsicle-rewrite": "1.0.0",
         "popsicle-status": "2.0.1",
         "promise-finally": "3.0.0",
-        "rc": "1.2.5",
+        "rc": "1.2.6",
         "rimraf": "2.6.2",
         "sort-keys": "1.1.2",
         "string-template": "1.0.0",
@@ -9778,15 +9687,15 @@
         "thenify": "3.3.0",
         "throat": "3.2.0",
         "touch": "1.0.0",
-        "typescript": "2.7.1",
+        "typescript": "2.7.2",
         "xtend": "4.0.1",
         "zip-object": "0.1.0"
       },
       "dependencies": {
         "typescript": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
-          "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw=="
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+          "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
         }
       }
     },
@@ -9884,10 +9793,14 @@
       "dev": true
     },
     "underscore.string": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
-      "integrity": "sha1-gGmSYzZl1eX8tNsfs6hi62jp5to=",
-      "dev": true
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.1.1",
+        "util-deprecate": "1.0.2"
+      }
     },
     "uniq": {
       "version": "1.0.1",
@@ -9945,14 +9858,15 @@
       "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
     },
     "update-notifier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.4.0.tgz",
+      "integrity": "sha1-+bTHAPv9TsEsgRWHJYd31WPYyGY=",
       "requires": {
         "boxen": "1.3.0",
-        "chalk": "2.3.1",
-        "configstore": "3.1.1",
+        "chalk": "2.3.2",
+        "configstore": "3.1.2",
         "import-lazy": "2.1.0",
+        "is-ci": "1.1.0",
         "is-installed-globally": "0.1.0",
         "is-npm": "1.0.0",
         "latest-version": "3.1.0",
@@ -9995,13 +9909,13 @@
       "dev": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "vary": {
@@ -10022,13 +9936,18 @@
       "integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w=",
       "dev": true
     },
+    "web-animations-js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/web-animations-js/-/web-animations-js-2.3.1.tgz",
+      "integrity": "sha1-Om2bwVGWN3qQ+OKAP6UmIWWwRRA="
+    },
     "websocket-driver": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.10",
+        "http-parser-js": "0.4.11",
         "websocket-extensions": "0.1.3"
       }
     },

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -22,8 +22,16 @@ export interface CommandWrapperConfig {
 	eject?: boolean;
 }
 
-export function getCommandsMap(groupDef: GroupDef) {
+export function getCommandsMap(groupDef: GroupDef, registerMock?: Function) {
 	const commands = new Map();
+	if (registerMock === undefined) {
+		registerMock = (compositeKey: string) => {
+			return (func: Function) => {
+				func('key', {});
+				return compositeKey;
+			};
+		};
+	}
 
 	groupDef.forEach((group) => {
 		group.commands.forEach((command) => {
@@ -35,9 +43,7 @@ export function getCommandsMap(groupDef: GroupDef) {
 				name: command.commandName,
 				group: group.groupName,
 				description: compositeKey,
-				register: stub()
-					.callsArgWith(0, 'key', {})
-					.returns(compositeKey),
+				register: registerMock!(compositeKey),
 				runSpy,
 				run: runSpy
 			};


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Parsed aliases are only available from yargs when running a command with a group and name - Therefore running a default command such as `dojo test` throws an error because there is no aliases object.

This change moves from using an internally yargs generated and maintained aliases map, to explicitly maintaining an equivalent map in dojo/cli. This means that command line options saved in the dojorc config will work for default commands, aliased commands and regular commands.

Resolves #221 
