### PR TITLE
Show an error when no package.json is found for builtin commands requiring it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,14 +4,16 @@ import registerCommands from './registerCommands';
 import { join } from 'path';
 import commandLoader from './allCommands';
 import installableCommands, { mergeInstalledCommandsWithAvailableCommands } from './installableCommands';
+import { existsSync } from 'fs';
+import chalk from 'chalk';
 const pkgDir = require('pkg-dir');
 
 export async function init() {
-	try {
-		const packagePath = pkgDir.sync(__dirname);
-		const packageJsonFilePath = join(packagePath, 'package.json');
-		const packageJson = <any>require(packageJsonFilePath);
+	const packagePath = pkgDir.sync(__dirname);
+	const packageJsonFilePath = join(packagePath, 'package.json');
+	const packageJson = <any>require(packageJsonFilePath);
 
+	try {
 		updateNotifier(packageJson);
 
 		const availableCommands = await installableCommands(packageJson.name);
@@ -20,6 +22,18 @@ export async function init() {
 
 		registerCommands(yargs, mergedCommands);
 	} catch (err) {
-		console.log(`Commands are not available: ${err}`);
+		console.error(chalk.red(`Commands are not available: ${err}`));
+		return;
+	}
+
+	const pwdPackageJsonexists = existsSync(join(process.cwd(), 'package.json'));
+	if (!pwdPackageJsonexists) {
+		console.warn(
+			chalk.yellow(
+				'Warning: a package.json file was not found and is expected for many Dojo CLI commands. You can initialise one by running'
+			),
+			chalk.yellow.bold('npm init'),
+			`\n`
+		);
 	}
 }


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Resolves #252

** Screenshot **

![screenshot_20180815_175643](https://user-images.githubusercontent.com/8822075/44161244-a5bd3c80-a0b4-11e8-8ba3-a157e3c5eaaa.png)

