### PR TITLE
Show a warning when there is no package.json when running dojo init

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -7,7 +7,7 @@ import chalk from 'chalk';
 
 const pkgDir = require('pkg-dir');
 const noPackageWarning =
-	chalk.yellow(`A root `) +
+	chalk.yellow(`Warning: A root `) +
 	chalk.whiteBright.bold('package.json ') +
 	chalk.yellow(
 		`was not found; this directory will be used for the root for your Dojo project. It is strongly recommended you create one by running `

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,9 +6,22 @@ import { loadExternalCommands } from '../allCommands';
 import chalk from 'chalk';
 
 const pkgDir = require('pkg-dir');
+const noPackageWarning =
+	chalk.yellow(`A root `) +
+	chalk.whiteBright.bold('package.json ') +
+	chalk.yellow(
+		`was not found; this directory will be used for the root for your Dojo project. It is strongly recommended you create one by running `
+	) +
+	chalk.whiteBright.bold('npm init');
 
 async function run(helper: Helper, args: {}) {
-	const rootDir = pkgDir.sync(process.cwd());
+	const cwd = process.cwd();
+	let rootDir = pkgDir.sync(cwd);
+	if (!rootDir) {
+		console.warn(noPackageWarning);
+		rootDir = cwd;
+	}
+
 	const dojoRcPath = join(rootDir, '.dojorc');
 	const file = existsSync(dojoRcPath) && readFileSync(dojoRcPath, 'utf8');
 	let json: { [name: string]: {} } = {};

--- a/tests/unit/commands/init.ts
+++ b/tests/unit/commands/init.ts
@@ -3,11 +3,14 @@ const { assert } = intern.getPlugin('chai');
 
 import MockModule from '../../support/MockModule';
 import * as sinon from 'sinon';
+import chalk from 'chalk';
 
 describe('init command', () => {
 	let mockModule: MockModule;
 	let sandbox: sinon.SinonSandbox;
 	let fs: any;
+	let pkgDir: any;
+	let warnStub: any;
 
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
@@ -15,8 +18,9 @@ describe('init command', () => {
 		mockModule.dependencies(['fs', 'pkg-dir', '../allCommands']);
 
 		sandbox.stub(console, 'log');
+		warnStub = sandbox.stub(console, 'warn');
 
-		const pkgDir = mockModule.getMock('pkg-dir');
+		pkgDir = mockModule.getMock('pkg-dir');
 		pkgDir.ctor.sync = sandbox.stub().returns('./');
 
 		fs = mockModule.getMock('fs');
@@ -45,6 +49,25 @@ describe('init command', () => {
 	afterEach(() => {
 		sandbox.restore();
 		mockModule.destroy();
+	});
+
+	it('shows a warning if no package.json file is found', async () => {
+		pkgDir.ctor.sync = sandbox.stub().returns(undefined);
+		fs.readFileSync = sandbox.stub().returns(undefined);
+		const moduleUnderTest = mockModule.getModuleUnderTest().default;
+		await moduleUnderTest.run();
+		assert.isTrue(pkgDir.ctor.sync.calledOnce);
+		assert.isTrue(warnStub.calledOnce);
+		assert.isTrue(
+			warnStub.calledWith(
+				chalk.yellow(`A root `) +
+					chalk.whiteBright.bold('package.json ') +
+					chalk.yellow(
+						`was not found; this directory will be used for the root for your Dojo project. It is strongly recommended you create one by running `
+					) +
+					chalk.whiteBright.bold('npm init')
+			)
+		);
 	});
 
 	it('creates a .dojorc with the available commands', async () => {

--- a/tests/unit/commands/init.ts
+++ b/tests/unit/commands/init.ts
@@ -60,7 +60,7 @@ describe('init command', () => {
 		assert.isTrue(warnStub.calledOnce);
 		assert.isTrue(
 			warnStub.calledWith(
-				chalk.yellow(`A root `) +
+				chalk.yellow(`Warning: A root `) +
 					chalk.whiteBright.bold('package.json ') +
 					chalk.yellow(
 						`was not found; this directory will be used for the root for your Dojo project. It is strongly recommended you create one by running `


### PR DESCRIPTION
**Type:** Feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Resolves #252

** Screenshot **

![screenshot_20180816_121821](https://user-images.githubusercontent.com/8822075/44205491-7955fe80-a14e-11e8-89be-3aaa991f29d2.png)

