### PR TITLE
Add support for creating directories that don't exist on renderFiles

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -1,6 +1,5 @@
 import { renderFile } from 'ejs';
-import { dirname } from 'path';
-import { writeFile, existsSync, mkdirSync } from 'fs-extra';
+import { writeFile, ensureDir } from 'fs-extra';
 import chalk from 'chalk';
 
 export function ejsRender(source: string, replacements: Object): Promise<string> {
@@ -16,8 +15,7 @@ export function ejsRender(source: string, replacements: Object): Promise<string>
 
 export function writeRenderedFile(str: string, destination: string): Promise<void> {
 	return new Promise<void>((resolve, reject) => {
-		console.log('?????? \n');
-		ensureDirectoryExistence(destination);
+		ensureDir(destination);
 		writeFile(destination, str, (err?: Error) => {
 			if (err) {
 				reject(err);
@@ -25,15 +23,6 @@ export function writeRenderedFile(str: string, destination: string): Promise<voi
 			resolve();
 		});
 	});
-}
-
-export function ensureDirectoryExistence(filePath: string) {
-	const directoryName = dirname(filePath);
-	if (existsSync(directoryName)) {
-		return true;
-	}
-	ensureDirectoryExistence(directoryName);
-	mkdirSync(directoryName);
 }
 
 export default async function(source: string, destination: string, replacements: Object): Promise<void> {

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,5 +1,6 @@
 import { renderFile } from 'ejs';
-import { writeFile } from 'fs-extra';
+import { dirname } from 'path';
+import { writeFile, existsSync, mkdirSync } from 'fs-extra';
 import chalk from 'chalk';
 
 export function ejsRender(source: string, replacements: Object): Promise<string> {
@@ -15,6 +16,8 @@ export function ejsRender(source: string, replacements: Object): Promise<string>
 
 export function writeRenderedFile(str: string, destination: string): Promise<void> {
 	return new Promise<void>((resolve, reject) => {
+		console.log('?????? \n');
+		ensureDirectoryExistence(destination);
 		writeFile(destination, str, (err?: Error) => {
 			if (err) {
 				reject(err);
@@ -22,6 +25,15 @@ export function writeRenderedFile(str: string, destination: string): Promise<voi
 			resolve();
 		});
 	});
+}
+
+export function ensureDirectoryExistence(filePath: string) {
+	const directoryName = dirname(filePath);
+	if (existsSync(directoryName)) {
+		return true;
+	}
+	ensureDirectoryExistence(directoryName);
+	mkdirSync(directoryName);
 }
 
 export default async function(source: string, destination: string, replacements: Object): Promise<void> {

--- a/src/template.ts
+++ b/src/template.ts
@@ -7,6 +7,7 @@ export function ejsRender(source: string, replacements: Object): Promise<string>
 		renderFile(source, replacements, (err: Error, str?: string) => {
 			if (err) {
 				reject(err);
+				return;
 			}
 			resolve(str);
 		});
@@ -14,14 +15,8 @@ export function ejsRender(source: string, replacements: Object): Promise<string>
 }
 
 export function writeRenderedFile(str: string, destination: string): Promise<void> {
-	return new Promise<void>((resolve, reject) => {
-		ensureDir(destination);
-		writeFile(destination, str, (err?: Error) => {
-			if (err) {
-				reject(err);
-			}
-			resolve();
-		});
+	return ensureDir(destination).then(() => {
+		return writeFile(destination, str);
 	});
 }
 

--- a/tests/unit/template.ts
+++ b/tests/unit/template.ts
@@ -5,10 +5,8 @@ import * as fs from 'fs-extra';
 import { stub, SinonStub } from 'sinon';
 
 let writeFileStub: SinonStub;
-let mkdirsStub: SinonStub;
 let consoleStub: SinonStub;
-let existsSyncStub: SinonStub;
-let mkdirSyncStub: SinonStub;
+let ensureDirStub: SinonStub;
 const testEjsSrc = 'tests/support/template.ejs';
 const testDest = '/tmp/test/destination';
 const value = 'testValue';
@@ -22,33 +20,18 @@ registerSuite('template', {
 	},
 	beforeEach() {
 		writeFileStub = stub(fs, 'writeFile').callsArg(2);
-		mkdirsStub = stub(fs, 'mkdirsSync');
-		mkdirSyncStub = stub(fs, 'mkdirSync');
-		existsSyncStub = stub(fs, 'existsSync').returns(true);
+		ensureDirStub = stub(fs, 'ensureDir').returns(true);
 	},
 	afterEach() {
-		mkdirSyncStub.restore();
-		existsSyncStub.restore();
+		ensureDirStub.restore();
 		writeFileStub.restore();
-		mkdirsStub.restore();
 	},
 
 	tests: {
 		async 'directories are checked to exist'() {
 			await template(testEjsSrc, testDest, { value });
-			assert.isTrue(existsSyncStub.called);
-			assert.strictEqual(existsSyncStub.firstCall.args[0], '/tmp/test');
-		},
-		async 'creates directories if they do not exist'() {
-			existsSyncStub.onCall(0).returns(false);
-			existsSyncStub.onCall(1).returns(false);
-			existsSyncStub.onCall(2).returns(true);
-			await template(testEjsSrc, testDest, { value });
-			assert.isTrue(existsSyncStub.called);
-			assert.strictEqual(existsSyncStub.firstCall.args[0], '/tmp/test');
-			assert.strictEqual(existsSyncStub.secondCall.args[0], '/tmp');
-			assert.strictEqual(existsSyncStub.thirdCall.args[0], '/');
-			assert.strictEqual(mkdirSyncStub.callCount, 2);
+			assert.isTrue(ensureDirStub.called);
+			assert.strictEqual(ensureDirStub.firstCall.args[0], '/tmp/test/destination');
 		},
 		async 'can render ejs file'() {
 			await template(testEjsSrc, testDest, { value });

--- a/tests/unit/template.ts
+++ b/tests/unit/template.ts
@@ -7,6 +7,8 @@ import { stub, SinonStub } from 'sinon';
 let writeFileStub: SinonStub;
 let mkdirsStub: SinonStub;
 let consoleStub: SinonStub;
+let existsSyncStub: SinonStub;
+let mkdirSyncStub: SinonStub;
 const testEjsSrc = 'tests/support/template.ejs';
 const testDest = '/tmp/test/destination';
 const value = 'testValue';
@@ -21,13 +23,33 @@ registerSuite('template', {
 	beforeEach() {
 		writeFileStub = stub(fs, 'writeFile').callsArg(2);
 		mkdirsStub = stub(fs, 'mkdirsSync');
+		mkdirSyncStub = stub(fs, 'mkdirSync');
+		existsSyncStub = stub(fs, 'existsSync').returns(true);
 	},
 	afterEach() {
+		mkdirSyncStub.restore();
+		existsSyncStub.restore();
 		writeFileStub.restore();
 		mkdirsStub.restore();
 	},
 
 	tests: {
+		async 'directories are checked to exist'() {
+			await template(testEjsSrc, testDest, { value });
+			assert.isTrue(existsSyncStub.called);
+			assert.strictEqual(existsSyncStub.firstCall.args[0], '/tmp/test');
+		},
+		async 'creates directories if they do not exist'() {
+			existsSyncStub.onCall(0).returns(false);
+			existsSyncStub.onCall(1).returns(false);
+			existsSyncStub.onCall(2).returns(true);
+			await template(testEjsSrc, testDest, { value });
+			assert.isTrue(existsSyncStub.called);
+			assert.strictEqual(existsSyncStub.firstCall.args[0], '/tmp/test');
+			assert.strictEqual(existsSyncStub.secondCall.args[0], '/tmp');
+			assert.strictEqual(existsSyncStub.thirdCall.args[0], '/');
+			assert.strictEqual(mkdirSyncStub.callCount, 2);
+		},
 		async 'can render ejs file'() {
 			await template(testEjsSrc, testDest, { value });
 			assert.strictEqual(writeFileStub.firstCall.args[1].trim(), value);

--- a/tests/unit/template.ts
+++ b/tests/unit/template.ts
@@ -19,8 +19,8 @@ registerSuite('template', {
 		consoleStub.restore();
 	},
 	beforeEach() {
-		writeFileStub = stub(fs, 'writeFile').callsArg(2);
-		ensureDirStub = stub(fs, 'ensureDir').returns(true);
+		writeFileStub = stub(fs, 'writeFile').resolves();
+		ensureDirStub = stub(fs, 'ensureDir').resolves();
 	},
 	afterEach() {
 		ensureDirStub.restore();


### PR DESCRIPTION
**Type:** Feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Resolves #247 
