### PR TITLE
Read/save package.json dojo config and preserve indent for all configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -468,6 +468,12 @@
       "integrity": "sha1-+o4a0dR0aIp1cUDJHebazm9KvI0=",
       "dev": true
     },
+    "@types/readline-sync": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/readline-sync/-/readline-sync-1.4.3.tgz",
+      "integrity": "sha512-YP9NVli96E+qQLAF2db+VjnAUEeZcFVg4YnMgr8kpDUFwQBnj31rPLOVHmazbKQhaIkJ9cMHsZhpKdzUeL0KTg==",
+      "dev": true
+    },
     "@types/resolve": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.7.tgz",
@@ -5146,6 +5152,11 @@
         "readable-stream": "^2.0.2",
         "set-immediate-shim": "^1.0.1"
       }
+    },
+    "readline-sync": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.9.tgz",
+      "integrity": "sha1-PtqOZfI80qF+YTAbHwADOWr17No="
     },
     "regenerator-runtime": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "tslib": "1.8.1",
     "update-notifier": "2.5.0",
     "yargs": "10.1.2",
-    "readline-sync": "^1.4.9"
+    "readline-sync": "1.4.9"
   },
   "devDependencies": {
     "@dojo/scripts": "~3.0.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "string-width": "2.1.1",
     "tslib": "1.8.1",
     "update-notifier": "2.5.0",
-    "yargs": "10.1.2"
+    "yargs": "10.1.2",
+    "readline-sync": "^1.4.9"
   },
   "devDependencies": {
     "@dojo/scripts": "~3.0.1",
@@ -79,6 +80,7 @@
     "@types/node": "~9.6.5",
     "@types/sinon": "~4.3.3",
     "@types/update-notifier": "^1.0.1",
+    "@types/readline-sync": "^1.4.3",
     "@types/yargs": "^10.0.0",
     "codecov": "~3.0.4",
     "cpx": "~1.5.0",

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -2,7 +2,7 @@ import { Argv } from 'yargs';
 import chalk from 'chalk';
 import { CommandWrapper, Helper, OptionsHelper, ValidationWrapper } from '../interfaces';
 import { loadExternalCommands } from '../allCommands';
-import configurationHelperFactory, { getConfigFile } from '../configurationHelper';
+import configurationHelperFactory, { getConfig } from '../configurationHelper';
 import { Validator } from 'jsonschema';
 import CommandHelper from '../CommandHelper';
 import HelperFactory from '../Helper';
@@ -95,7 +95,7 @@ export function builtInCommandValidation(validation: ValidationWrapper): Promise
 }
 
 function validateCommands(commands: Map<string, Map<string, CommandWrapper>>, helper: HelperFactory) {
-	const config = getConfigFile();
+	const config = getConfig();
 
 	const noConfig = config === undefined;
 	const emptyConfig = typeof config === 'object' && Object.keys(config).length === 0;

--- a/src/configurationHelper.ts
+++ b/src/configurationHelper.ts
@@ -8,16 +8,10 @@ const pkgDir = require('pkg-dir');
 
 const appPath = pkgDir.sync(process.cwd());
 let dojoRcPath: string;
+let packageJsonPath: string;
 if (appPath) {
 	dojoRcPath = join(appPath, '.dojorc');
-}
-
-const packageJsonPath = join(appPath, 'package.json');
-let hasPackageConfig = false;
-if (existsSync(packageJsonPath)) {
-	const { dojo } = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
-
-	hasPackageConfig = typeof dojo === 'object';
+	packageJsonPath = join(appPath, 'package.json');
 }
 
 function readPackageConfig() {
@@ -67,15 +61,17 @@ export function getConfigFile(): Config | undefined {
 }
 
 function getConfig(): Config | undefined {
-	if (!dojoRcExists() && hasPackageConfig) {
-		return readPackageConfig();
+	const packageConfig = readPackageConfig();
+	if (!dojoRcExists() && typeof packageConfig === 'object') {
+		return packageConfig;
 	} else {
 		return getConfigFile();
 	}
 }
 
 function writeConfig(config: Config) {
-	if (!dojoRcExists() && hasPackageConfig) {
+	const packageConfig = readPackageConfig();
+	if (!dojoRcExists() && typeof packageConfig === 'object') {
 		writePackageConfig(config);
 	} else {
 		writeConfigFile(config);
@@ -108,7 +104,7 @@ class SingleCommandConfigurationHelper implements ConfigurationHelper {
 	 */
 	get(commandName: string = this._configurationKey): Config {
 		const config = getConfig() || {};
-		return config[this._configurationKey];
+		return config[commandName];
 	}
 
 	/**

--- a/src/configurationHelper.ts
+++ b/src/configurationHelper.ts
@@ -21,12 +21,8 @@ if (existsSync(packageJsonPath)) {
 }
 
 function readPackageConfig() {
-	if (existsSync(packageJsonPath)) {
-		const { dojo } = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
-		return dojo;
-	}
-
-	return {};
+	const { dojo } = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+	return dojo;
 }
 
 let canWriteToPackageJson: boolean | undefined;

--- a/src/configurationHelper.ts
+++ b/src/configurationHelper.ts
@@ -49,7 +49,7 @@ function writePackageConfig(config: Config, indent: string | number) {
 	if (canWriteToPackageJson === undefined) {
 		canWriteToPackageJson = Boolean(
 			readlineSync.keyInYN(
-				'You are using a "dojo" configuration in your package.json. Saving the current settings will update your package.json. Continue? [ (N)o / (Y)OLO ]: ',
+				'You are using a "dojo" configuration in your package.json. Saving the current settings will update your package.json. Continue? [ (N)o / (Y)es ]: ',
 				{ guide: false }
 			)
 		);

--- a/src/configurationHelper.ts
+++ b/src/configurationHelper.ts
@@ -41,7 +41,6 @@ function parseConfigs(): ConfigWrapper {
 			throw Error(chalk.red(`Could not parse the package.json file to get config: ${error}`));
 		}
 	}
-
 	return configWrapper;
 }
 
@@ -71,7 +70,9 @@ function writeDojoRcConfig(config: Config, indent: string | number) {
 
 export function getConfig(): Config | undefined {
 	const { packageJsonConfig, dojoRcConfig } = parseConfigs();
-	const { hasDojoRcConfig, hasPackageConfig } = checkForMultiConfig(dojoRcConfig, packageJsonConfig);
+	const hasPackageConfig = typeof packageJsonConfig === 'object';
+	const hasDojoRcConfig = typeof dojoRcConfig === 'object';
+
 	if (!hasDojoRcConfig && hasPackageConfig) {
 		return packageJsonConfig;
 	} else {
@@ -79,22 +80,18 @@ export function getConfig(): Config | undefined {
 	}
 }
 
-function checkForMultiConfig(dojoRcConfig: Config | undefined, packageJsonConfig: Config | undefined) {
+function warnAboutMultiConfig() {
+	const warning = `Warning: Both a .dojorc configuration and a dojo configuration in your package.json were found. The .dojorc file will take precedent. It is recommended you stick to one configuration option.`;
+	console.warn(chalk.yellow(warning));
+}
+
+export function checkForMultiConfig() {
+	const { dojoRcConfig, packageJsonConfig } = parseConfigs();
 	const hasPackageConfig = typeof packageJsonConfig === 'object';
 	const hasDojoRcConfig = typeof dojoRcConfig === 'object';
-
 	if (hasPackageConfig && hasDojoRcConfig) {
-		console.warn(
-			chalk.yellow(
-				`Warning: Both a .dojorc configuration and a dojo configuration in your package.json were found. The .dojorc file will take precedent. It is recommended you stick to one configuration option.`
-			)
-		);
+		warnAboutMultiConfig();
 	}
-
-	return {
-		hasPackageConfig,
-		hasDojoRcConfig
-	};
 }
 
 class SingleCommandConfigurationHelper implements ConfigurationHelper {
@@ -148,7 +145,8 @@ class SingleCommandConfigurationHelper implements ConfigurationHelper {
 		}
 
 		const { packageJsonConfig, packageJsonIndent, dojoRcConfig, dojoRcIndent } = parseConfigs();
-		const { hasDojoRcConfig, hasPackageConfig } = checkForMultiConfig(dojoRcConfig, packageJsonConfig);
+		const hasPackageConfig = typeof packageJsonConfig === 'object';
+		const hasDojoRcConfig = typeof dojoRcConfig === 'object';
 
 		const updateConfig = dojoRcConfig || packageJsonConfig || {};
 

--- a/src/configurationHelper.ts
+++ b/src/configurationHelper.ts
@@ -1,7 +1,9 @@
 import chalk from 'chalk';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { ConfigurationHelper, Config } from './interfaces';
+import { Config, ConfigurationHelper } from './interfaces';
+import * as readlineSync from 'readline-sync';
+
 const pkgDir = require('pkg-dir');
 
 const appPath = pkgDir.sync(process.cwd());
@@ -10,8 +12,50 @@ if (appPath) {
 	dojoRcPath = join(appPath, '.dojorc');
 }
 
+const packageJsonPath = join(appPath, 'package.json');
+let hasPackageConfig = false;
+if (existsSync(packageJsonPath)) {
+	const { dojo } = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+
+	hasPackageConfig = typeof dojo === 'object';
+}
+
+function readPackageConfig() {
+	if (existsSync(packageJsonPath)) {
+		const { dojo } = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+		return dojo;
+	}
+
+	return {};
+}
+
+let canWriteToPackageJson: boolean | undefined;
+
+function writePackageConfig(config: Config) {
+	if (canWriteToPackageJson === undefined) {
+		canWriteToPackageJson = Boolean(
+			readlineSync.keyInYN(
+				'You are using a "dojo" configuration in your package.json. Saving the current settings will update your package.json. Continue? [ (N)o / (Y)OLO ]: ',
+				{ guide: false }
+			)
+		);
+	}
+
+	if (canWriteToPackageJson) {
+		const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+
+		packageJson.dojo = config;
+
+		writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+	}
+}
+
 function writeConfigFile(config: Config) {
 	writeFileSync(dojoRcPath, JSON.stringify(config, null, 2));
+}
+
+function dojoRcExists() {
+	return !!dojoRcPath && existsSync(dojoRcPath);
 }
 
 export function getConfigFile(): Config | undefined {
@@ -24,6 +68,22 @@ export function getConfigFile(): Config | undefined {
 		}
 	}
 	return undefined;
+}
+
+function getConfig(): Config | undefined {
+	if (!dojoRcExists() && hasPackageConfig) {
+		return readPackageConfig();
+	} else {
+		return getConfigFile();
+	}
+}
+
+function writeConfig(config: Config) {
+	if (!dojoRcExists() && hasPackageConfig) {
+		writePackageConfig(config);
+	} else {
+		writeConfigFile(config);
+	}
 }
 
 class SingleCommandConfigurationHelper implements ConfigurationHelper {
@@ -43,15 +103,15 @@ class SingleCommandConfigurationHelper implements ConfigurationHelper {
 	 * @returns an object representation of .dojorc
 	 */
 	get(): Config;
+
 	/**
 	 * Retrieves the configurationFactory object from the file system
 	 *
 	 * @param commandName - the command name that's accessing config
 	 * @returns an object representation of .dojorc
 	 */
-	get(commandName: string): Config;
-	get(commandName?: string): Config {
-		const config = getConfigFile() || {};
+	get(commandName: string = this._configurationKey): Config {
+		const config = getConfig() || {};
 		return config[this._configurationKey];
 	}
 
@@ -82,7 +142,7 @@ class SingleCommandConfigurationHelper implements ConfigurationHelper {
 		Object.assign(commmandConfig, config);
 		Object.assign(dojoRc, { [this._configurationKey]: commmandConfig });
 
-		writeConfigFile(dojoRc);
+		writeConfig(dojoRc);
 	}
 }
 

--- a/src/configurationHelper.ts
+++ b/src/configurationHelper.ts
@@ -59,7 +59,7 @@ function dojoRcExists() {
 }
 
 export function getConfigFile(): Config | undefined {
-	const configExists = !!dojoRcPath && existsSync(dojoRcPath);
+	const configExists = dojoRcExists();
 	if (configExists) {
 		try {
 			return JSON.parse(readFileSync(dojoRcPath, 'utf8'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import registerCommands from './registerCommands';
 import { join } from 'path';
 import commandLoader from './allCommands';
 import installableCommands, { mergeInstalledCommandsWithAvailableCommands } from './installableCommands';
+import { checkForMultiConfig } from './configurationHelper';
 const pkgDir = require('pkg-dir');
 
 export async function init() {
@@ -22,4 +23,8 @@ export async function init() {
 	} catch (err) {
 		console.log(`Commands are not available: ${err}`);
 	}
+
+	try {
+		checkForMultiConfig();
+	} catch {}
 }

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -18,7 +18,7 @@ export interface Config {
 
 export interface ConfigurationHelper {
 	set(config: Config): void;
-	get(): {};
+	get(command?: string): {};
 }
 
 export type RenderFilesConfig = {

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -16,6 +16,13 @@ export interface Config {
 	[key: string]: any;
 }
 
+export interface ConfigWrapper {
+	packageJsonConfig?: Config;
+	packageJsonIndent?: number | string;
+	dojoRcConfig?: Config;
+	dojoRcIndent?: number | string;
+}
+
 export interface ConfigurationHelper {
 	set(config: Config): void;
 	get(command?: string): {};

--- a/tests/unit/commands/validate.ts
+++ b/tests/unit/commands/validate.ts
@@ -206,7 +206,7 @@ describe('validate', () => {
 			const groupMap = new Map([['test', commandMap]]);
 
 			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves(groupMap);
-			mockConfigurationHelper.getConfigFile = sandbox.stub().returns(undefined);
+			mockConfigurationHelper.getConfig = sandbox.stub().returns(undefined);
 
 			const helper = getHelper();
 			return moduleUnderTest.run(helper, {}).then(
@@ -225,7 +225,7 @@ describe('validate', () => {
 			const groupMap = new Map([['test', commandMap]]);
 
 			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves(groupMap);
-			mockConfigurationHelper.getConfigFile = sandbox.stub().returns({});
+			mockConfigurationHelper.getConfig = sandbox.stub().returns({});
 
 			const helper = getHelper();
 			return moduleUnderTest.run(helper, {}).then(
@@ -247,12 +247,12 @@ describe('validate', () => {
 			const groupMap = new Map([['test', commandMap]]);
 
 			mockAllExternalCommands.loadExternalCommands = sandbox.stub().resolves(groupMap);
-			mockConfigurationHelper.getConfigFile = sandbox.stub().returns({ ...matchedConfig });
+			mockConfigurationHelper.getConfig = sandbox.stub().returns({ ...matchedConfig });
 
 			const helper = getHelper();
 			return moduleUnderTest.run(helper, {}).then(
 				() => {
-					assert.isTrue(mockConfigurationHelper.getConfigFile.called);
+					assert.isTrue(mockConfigurationHelper.getConfig.called);
 					assert.isTrue(consoleLogStub.called);
 					assert.equal(
 						consoleLogStub.getCall(0).args[0],
@@ -266,7 +266,7 @@ describe('validate', () => {
 		});
 
 		it(`should return no validatable commands with no validatable commands`, () => {
-			mockConfigurationHelper.getConfigFile = sandbox.stub().returns({ foo: 'bar' });
+			mockConfigurationHelper.getConfig = sandbox.stub().returns({ foo: 'bar' });
 			const installedCommandWrapper = getCommandWrapperWithConfiguration({
 				group: 'command',
 				name: 'test'
@@ -294,7 +294,7 @@ describe('validate', () => {
 				name: 'test',
 				validate: sinon.stub().throws('A test error')
 			});
-			mockConfigurationHelper.getConfigFile = sandbox.stub().returns({
+			mockConfigurationHelper.getConfig = sandbox.stub().returns({
 				foo: 'bar'
 			});
 			const commandMap: CommandMap = new Map<string, CommandWrapper>([['command', installedCommandWrapper]]);
@@ -317,7 +317,7 @@ describe('validate', () => {
 		});
 
 		it(`should log out that there were no issues if all commands are valid`, () => {
-			mockConfigurationHelper.getConfigFile = sandbox.stub().returns({ foo: 'bar' });
+			mockConfigurationHelper.getConfig = sandbox.stub().returns({ foo: 'bar' });
 			const commandMap: CommandMap = new Map<string, CommandWrapper>([
 				[
 					'command',

--- a/tests/unit/configurationHelper.ts
+++ b/tests/unit/configurationHelper.ts
@@ -118,7 +118,7 @@ registerSuite('Configuration Helper', {
 			'Should return undefined command config when no dojorc config for command exists'() {
 				mockFs.existsSync.returns(false);
 				const config = configurationHelper.sandbox('testGroupName', 'testCommandName').get();
-				assert.isTrue(mockFs.readFileSync.notCalled);
+				assert.isTrue(mockFs.readFileSync.calledOnce);
 				assert.equal(config, undefined);
 			},
 			'Should return existing config when a dojorc entry exists'() {
@@ -141,7 +141,9 @@ registerSuite('Configuration Helper', {
 				);
 			},
 			'Should throw an error when the config is not valid JSON'() {
-				mockFs.readFileSync.returns('{]');
+				mockFs.readFileSync = sinon.stub();
+				mockFs.readFileSync.onCall(0).returns('{}');
+				mockFs.readFileSync.onCall(1).returns('{]');
 				const test = () => configurationHelper.sandbox('testGroupName', 'testCommandName').get();
 				assert.throws(test, Error, /^Invalid \.dojorc: /);
 			}
@@ -170,8 +172,9 @@ registerSuite('Configuration Helper', {
 
 		tests: {
 			'Should return undefined config when pkgdir returns null'() {
+				mockFs.readFileSync = sinon.stub();
+				mockFs.readFileSync.onCall(0).returns('{}');
 				const config = configurationHelper.sandbox('testGroupName', 'testCommandName').get();
-				assert.isFalse(mockFs.readFileSync.called);
 				assert.isFalse(mockPath.join.called);
 				assert.equal(config, undefined);
 			},

--- a/tests/unit/configurationHelper.ts
+++ b/tests/unit/configurationHelper.ts
@@ -4,6 +4,7 @@ const { assert } = intern.getPlugin('chai');
 import { resolve as pathResolve } from 'path';
 import * as sinon from 'sinon';
 import MockModule from '../support/MockModule';
+import chalk from 'chalk';
 
 let sandbox: any;
 let mockModule: MockModule;
@@ -13,7 +14,9 @@ let mockPath: any;
 let mockReadlineSync: any;
 let moduleUnderTest: any;
 let configurationHelper: any;
+let consoleErrorStub: sinon.SinonStub;
 let consoleWarnStub: sinon.SinonStub;
+let configToIndent: any;
 
 const packagePath = pathResolve(__dirname, '../support');
 const dojoRcPath = `${packagePath}/.dojorc`;
@@ -37,6 +40,8 @@ registerSuite('Configuration Helper', {
 			mockReadlineSync.isInKeyYN = sinon.stub().returns(true);
 			moduleUnderTest = mockModule.getModuleUnderTest().default;
 			configurationHelper = moduleUnderTest;
+			consoleWarnStub = sandbox.stub(console, 'warn');
+			consoleErrorStub = sandbox.stub(console, 'error');
 		},
 		afterEach() {
 			sandbox.restore();
@@ -48,7 +53,7 @@ registerSuite('Configuration Helper', {
 				const newConfig = { foo: 'bar' };
 				mockFs.readFileSync = sinon.stub().returns(JSON.stringify({ 'testGroupName-testCommandName': {} }));
 				configurationHelper.sandbox('testGroupName', 'testCommandName').set(newConfig);
-
+				assert.isTrue(consoleWarnStub.notCalled);
 				assert.isTrue(mockFs.writeFileSync.calledOnce);
 				assert.equal(mockFs.writeFileSync.firstCall.args[0], dojoRcPath);
 				assert.equal(
@@ -60,7 +65,7 @@ registerSuite('Configuration Helper', {
 				const newConfig = { foo: 'bar' };
 				mockFs.readFileSync = sinon.stub().returns(JSON.stringify({ testGroupName: {} }));
 				configurationHelper.sandbox('testGroupName').set(newConfig);
-
+				assert.isTrue(consoleWarnStub.notCalled);
 				assert.isTrue(mockFs.writeFileSync.calledOnce);
 				assert.equal(mockFs.writeFileSync.firstCall.args[0], dojoRcPath);
 				assert.equal(
@@ -71,25 +76,26 @@ registerSuite('Configuration Helper', {
 			'Should merge new config with old when save called'() {
 				const newConfig = { foo: 'bar' };
 				const existingConfig = { existing: 'config' };
+				const mergedConfigs = Object.assign(existingConfig, newConfig);
+
 				mockFs.readFileSync.returns(JSON.stringify({ 'testGroupName-testCommandName': existingConfig }));
 				configurationHelper.sandbox('testGroupName', 'testCommandName').set(newConfig);
+				assert.isTrue(consoleErrorStub.notCalled);
+				assert.isTrue(consoleWarnStub.notCalled);
 				assert.isTrue(mockFs.writeFileSync.calledOnce);
 				assert.equal(
 					mockFs.writeFileSync.firstCall.args[1],
-					JSON.stringify(
-						{ 'testGroupName-testCommandName': Object.assign(existingConfig, newConfig) },
-						null,
-						2
-					)
+					JSON.stringify({ 'testGroupName-testCommandName': mergedConfigs }, null, 2)
 				);
 			},
-			'Should write new config when one does not exist'() {
+			'Should write new config to .dojorc path when one does not exist'() {
 				mockFs.existsSync.returns(false);
 				assert.isTrue(mockFs.readFileSync.notCalled);
 
 				const newConfig = { foo: 'bar' };
 				configurationHelper.sandbox('testGroupName', 'testCommandName').set(newConfig);
-
+				assert.isTrue(consoleErrorStub.notCalled);
+				assert.isTrue(consoleWarnStub.notCalled);
 				assert.isTrue(mockFs.writeFileSync.calledOnce);
 				assert.equal(mockFs.writeFileSync.firstCall.args[0], dojoRcPath);
 				assert.equal(
@@ -97,12 +103,15 @@ registerSuite('Configuration Helper', {
 					JSON.stringify({ 'testGroupName-testCommandName': newConfig }, null, 2)
 				);
 			},
-			'Should merge new commandNames with existing command config when save called'() {
+			'Should merge new commandNames with existing command config to .dojorc when set called'() {
 				const newConfig = { foo: 'bar' };
 				const existingConfig = { existing: 'config' };
 				mockFs.readFileSync.returns(JSON.stringify({ existingCommandName: existingConfig }));
 				configurationHelper.sandbox('testGroupName', 'testCommandName').set(newConfig);
+				assert.isTrue(consoleErrorStub.notCalled);
+				assert.isTrue(consoleWarnStub.notCalled);
 				assert.isTrue(mockFs.writeFileSync.calledOnce);
+				assert.equal(mockFs.writeFileSync.firstCall.args[0], dojoRcPath);
 				assert.deepEqual(
 					mockFs.writeFileSync.firstCall.args[1],
 					JSON.stringify(
@@ -111,21 +120,68 @@ registerSuite('Configuration Helper', {
 							'testGroupName-testCommandName': newConfig
 						},
 						null,
-						2
+						'  '
+					)
+				);
+			},
+			'Should write .dojorc with current .dojorc identation of 4 spaces'() {
+				const newConfig = { foo: 'bar' };
+				const existingConfig = { existing: 'config' };
+				mockFs.readFileSync
+					.onCall(0)
+					.returns(JSON.stringify({ existingCommandName: existingConfig }, null, '    '));
+				mockFs.readFileSync.onCall(1).returns('{}');
+				configurationHelper.sandbox('testGroupName', 'testCommandName').set(newConfig);
+				assert.isTrue(consoleWarnStub.notCalled);
+				assert.isTrue(consoleErrorStub.notCalled);
+				assert.equal(
+					mockFs.writeFileSync.firstCall.args[1],
+					JSON.stringify(
+						{
+							existingCommandName: existingConfig,
+							'testGroupName-testCommandName': newConfig
+						},
+						null,
+						'    '
+					)
+				);
+			},
+			'Should write .dojorc with current .dojorc identation of 2 spaces'() {
+				const newConfig = { foo: 'bar' };
+				const existingConfig = { existing: 'config' };
+				mockFs.readFileSync
+					.onCall(0)
+					.returns(JSON.stringify({ existingCommandName: existingConfig }, null, '  '));
+				mockFs.readFileSync.onCall(1).returns('{}');
+				configurationHelper.sandbox('testGroupName', 'testCommandName').set(newConfig);
+				assert.isTrue(consoleWarnStub.notCalled);
+				assert.isTrue(consoleErrorStub.notCalled);
+				assert.equal(
+					mockFs.writeFileSync.firstCall.args[1],
+					JSON.stringify(
+						{
+							existingCommandName: existingConfig,
+							'testGroupName-testCommandName': newConfig
+						},
+						null,
+						'  '
 					)
 				);
 			},
 			'Should return undefined command config when no dojorc config for command exists'() {
 				mockFs.existsSync.returns(false);
 				const config = configurationHelper.sandbox('testGroupName', 'testCommandName').get();
-				assert.isTrue(mockFs.readFileSync.calledOnce);
+				assert.isTrue(mockFs.readFileSync.notCalled);
 				assert.equal(config, undefined);
 			},
 			'Should return existing config when a dojorc entry exists'() {
 				const existingConfig = { existing: 'config' };
+				mockFs.existsSync.onCall(0).returns(true);
+				mockFs.existsSync.onCall(1).returns(false);
 				mockFs.readFileSync.returns(JSON.stringify({ 'testGroupName-testCommandName': existingConfig }));
 				const config = configurationHelper.sandbox('testGroupName', 'testCommandName').get();
-				assert.isTrue(mockFs.readFileSync.calledTwice);
+				assert.isTrue(mockFs.readFileSync.calledOnce);
+				assert.equal(mockFs.readFileSync.firstCall.args[0], dojoRcPath);
 				assert.deepEqual(config, existingConfig);
 			},
 			'Should accept and ignore commandName parameter'() {
@@ -141,11 +197,20 @@ registerSuite('Configuration Helper', {
 				);
 			},
 			'Should throw an error when the config is not valid JSON'() {
+				mockFs.existsSync.returns(true);
 				mockFs.readFileSync = sinon.stub();
 				mockFs.readFileSync.onCall(0).returns('{}');
 				mockFs.readFileSync.onCall(1).returns('{]');
 				const test = () => configurationHelper.sandbox('testGroupName', 'testCommandName').get();
-				assert.throws(test, Error, /^Invalid \.dojorc: /);
+
+				assert.throws(
+					test,
+					Error,
+					chalk.red(
+						`Could not parse the package.json file to get config: SyntaxError: Unexpected token ] in JSON at position 1`
+					)
+				);
+				assert.equal(mockFs.readFileSync.callCount, 2, 'both package.json and .dojorc should be read');
 			}
 		}
 	},
@@ -161,7 +226,7 @@ registerSuite('Configuration Helper', {
 			mockFs.writeFileSync = sandbox.stub();
 			mockPath = mockModule.getMock('path');
 			mockPath.join = sandbox.stub();
-			consoleWarnStub = sandbox.stub(console, 'warn');
+			consoleErrorStub = sandbox.stub(console, 'error');
 			moduleUnderTest = mockModule.getModuleUnderTest().default;
 			configurationHelper = moduleUnderTest;
 		},
@@ -181,13 +246,24 @@ registerSuite('Configuration Helper', {
 			'Should warn user when config save called outside of a pkgdir'() {
 				configurationHelper.sandbox('testGroupName', 'testCommandName').set({});
 				assert.isFalse(mockFs.writeFileSync.called);
-				assert.isTrue(consoleWarnStub.calledOnce);
+				assert.isTrue(consoleErrorStub.calledOnce);
 			}
 		}
 	},
 
 	'package json': {
 		beforeEach() {
+			configToIndent = {
+				dojo: {
+					test: {
+						hello: 'world'
+					},
+					'testGroupName-testCommandName': {
+						one: 'two',
+						hello: 'world'
+					}
+				}
+			};
 			sandbox = sinon.sandbox.create();
 			mockModule = new MockModule('../../src/configurationHelper', require);
 			mockModule.dependencies(['pkg-dir', 'fs', 'path', 'readline-sync', dojoRcPath]);
@@ -196,16 +272,20 @@ registerSuite('Configuration Helper', {
 			mockFs = mockModule.getMock('fs');
 			mockFs.existsSync = sinon.stub().callsFake((filename) => filename === packageJsonPath);
 			mockFs.readFileSync = sinon.stub().returns(
-				JSON.stringify({
-					dojo: {
-						test: {
-							hello: 'world'
-						},
-						'testGroupName-testCommandName': {
-							one: 'two'
+				JSON.stringify(
+					{
+						dojo: {
+							test: {
+								hello: 'world'
+							},
+							'testGroupName-testCommandName': {
+								one: 'two'
+							}
 						}
-					}
-				})
+					},
+					null,
+					'    '
+				)
 			);
 			mockFs.writeFileSync = sinon.stub();
 			mockPath = mockModule.getMock('path');
@@ -237,15 +317,37 @@ registerSuite('Configuration Helper', {
 					hello: 'world'
 				});
 
-				assert.isTrue(mockReadlineSync.keyInYN.called);
+				assert.isTrue(mockReadlineSync.keyInYN.called, 'yes/no is called');
 
 				configurationHelper.sandbox('testGroupName', 'testCommandName').set({
 					hello: 'world'
 				});
 
-				assert.isTrue(mockReadlineSync.keyInYN.calledOnce);
+				assert.isTrue(mockReadlineSync.keyInYN.calledOnce, 'yes/no is only called once');
 
-				assert.isTrue(mockFs.writeFileSync.calledTwice);
+				assert.isTrue(mockFs.writeFileSync.calledTwice, 'the file is written twice');
+			},
+
+			'writes package.json with current package.json identation of 4 spaces'() {
+				configurationHelper.sandbox('testGroupName', 'testCommandName').set({
+					hello: 'world'
+				});
+				const indentFour = '    ';
+				const indentedConfig = JSON.stringify(configToIndent, null, indentFour);
+
+				assert.equal(mockFs.writeFileSync.firstCall.args[1], indentedConfig);
+			},
+
+			'writes package.json with current package.json identation of 2 spaces'() {
+				const indentTwo = '  ';
+				const indentedConfig = JSON.stringify(configToIndent, null, indentTwo);
+				mockFs.readFileSync = sinon.stub().returns(indentedConfig);
+
+				configurationHelper.sandbox('testGroupName', 'testCommandName').set({
+					hello: 'world'
+				});
+
+				assert.equal(mockFs.writeFileSync.firstCall.args[1], indentedConfig);
 			},
 
 			'does not write to package.json if no answered'() {

--- a/tests/unit/index.ts
+++ b/tests/unit/index.ts
@@ -4,6 +4,7 @@ const { assert } = intern.getPlugin('chai');
 import MockModule from '../support/MockModule';
 import * as sinon from 'sinon';
 import { join } from 'path';
+// import { resolve as pathResolve } from 'path';
 
 describe('cli main module', () => {
 	let mockModule: MockModule;
@@ -73,6 +74,7 @@ describe('cli main module', () => {
 			});
 		});
 	});
+
 	it('should catch runtime errors', () => {
 		describe('runtime error inner', () => {
 			const errMessage = 'ugh - oh noes';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Description:

Adding the ability to read from .dojorc configuration from package.json. If the dojo key exists in your package.json...

```json
{ 
  "dojo" : {
    "build-app": {
    }
  }
}
```

And .dojorc does not exist, the config will be read from package.json. When you try to write config, and it's stored in package.json, you get a confirmation.

You are using a "dojo" configuration in your package.json. Saving the current settings will update your package.json. Continue? [ (N)o / (Y)es ]:

Additionally, you can now pass a command name into the get() method in order to read configuration that belongs to another command. Note that this applies to read only. You still cannot write to another command's config.

All of this is to support future work on @dojo/cli-create-theme to read a list of themeable elements that will be stored in package.json.
