### PR TITLE
Reformat the version command to be clearer for users

### DIFF
--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -45,7 +45,7 @@ async function getLatestCommandVersions(): Promise<NpmPackageDetails[]> {
 	const packageJsonFilePath = join(packagePath, 'package.json');
 	const packageJson: PackageDetails = require(packageJsonFilePath);
 
-	console.log('Fetching latest version information...');
+	console.log(chalk.yellow('Fetching latest version information...'));
 
 	return await getLatestCommands(packageJson.name);
 }

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -99,15 +99,16 @@ function isBuiltInCommand(commandPath: string): boolean {
  * @returns {string}
  */
 function createOutput(myPackageDetails: PackageDetails, commandVersions: ModuleVersion[]) {
-	let output = '';
+	let output = versionCurrentVersion.replace('{version}', chalk.blue(myPackageDetails.version));
 	if (commandVersions.length) {
 		output += versionRegisteredCommands;
-		output += '\n' + commandVersions.map((command) => `${command.name}@${command.version}`).join('\n') + '\n';
+		output +=
+			'\n' +
+			commandVersions.map((command) => `  ▹  ${command.name}@${chalk.blue(command.version)}`).join('\n') +
+			'\n';
 	} else {
 		output += versionNoRegisteredCommands;
 	}
-
-	output += versionCurrentVersion.replace('{version}', chalk.blue(myPackageDetails.version));
 	return output;
 }
 

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -24,6 +24,7 @@ const INBUILT_COMMAND_VERSION = '__IN_BUILT_COMMAND__';
 interface ModuleVersion {
 	name: string;
 	version: string;
+	latest?: string;
 	group: string;
 }
 
@@ -66,16 +67,8 @@ async function areCommandsOutdated(moduleVersions: ModuleVersion[]): Promise<any
 	}, {});
 
 	return moduleVersions.map(({ name, version, group }) => {
-		const latestVersion = latestVersions[name];
-		const canBeUpdated = version !== latestVersion;
-		const versionStr = canBeUpdated
-			? `${chalk.blue(version)} ${chalk.green(`(latest is ${latestVersion})`)}`
-			: chalk.blue(version);
-		return {
-			name: name,
-			version: versionStr,
-			group: group
-		};
+		const latest = latestVersions[name];
+		return { name, version, latest, group };
 	});
 }
 
@@ -104,7 +97,15 @@ function createOutput(myPackageDetails: PackageDetails, commandVersions: ModuleV
 		output += versionRegisteredCommands;
 		output +=
 			'\n' +
-			commandVersions.map((command) => `  ▹  ${command.name}@${chalk.blue(command.version)}`).join('\n') +
+			commandVersions
+				.map((command) => {
+					return command.version === command.latest || command.latest === undefined
+						? `  ▹  ${command.name}@${chalk.blue(command.version)}`
+						: `  ▹  ${command.name}@${chalk.blue(command.version)} ${chalk.green(
+								`(latest is ${command.latest})`
+						  )}`;
+				})
+				.join('\n') +
 			'\n';
 	} else {
 		output += versionNoRegisteredCommands;

--- a/tests/unit/commands/version.ts
+++ b/tests/unit/commands/version.ts
@@ -12,9 +12,9 @@ import { getCommandWrapperWithConfiguration } from '../../support/testHelper';
 const validPackageInfo: any = require('../../support/valid-package/package.json');
 const anotherValidPackageInfo: any = require('../../support/another-valid-package/package.json');
 
-const outputPrefix = 'The currently installed commands are:\n';
-const noCommandsPrefix = 'There are no registered commands available.';
-const outputSuffix = '\nYou are currently running @dojo/cli@' + chalk.blue('1.0.0');
+const outputPrefix = 'You are currently running @dojo/cli@' + chalk.blue('1.0.0') + '\n\n';
+const outputSuffix = 'The currently installed commands are:\n';
+const outputSuffixNoCommands = 'There are no registered commands available.';
 
 describe('version command', () => {
 	let moduleUnderTest: any;
@@ -59,7 +59,7 @@ describe('version command', () => {
 	});
 
 	it(`should run and return 'no registered commands' when there are no installed commands`, () => {
-		const noCommandOutput = `${noCommandsPrefix}${outputSuffix}`;
+		const noCommandOutput = `${outputPrefix}${outputSuffixNoCommands}`;
 		const groupMap = new Map();
 
 		const helper = { command: 'version' };
@@ -75,7 +75,7 @@ describe('version command', () => {
 	});
 
 	it(`should run and return 'no registered commands' when passed an invalid path to an installed command`, () => {
-		const noCommandOutput = `${noCommandsPrefix}${outputSuffix}`;
+		const noCommandOutput = `${outputPrefix}${outputSuffixNoCommands}`;
 
 		const badCommandWrapper = getCommandWrapperWithConfiguration({
 			group: 'apple',
@@ -110,12 +110,6 @@ describe('version command', () => {
 			name: 'anotherTest',
 			path: join(__dirname, '../../support/another-valid-package')
 		});
-
-		const expectedOutput = `${outputPrefix}
-${validPackageInfo.name}@${validPackageInfo.version}
-${anotherValidPackageInfo.name}@${anotherValidPackageInfo.version}
-${outputSuffix}`;
-
 		const commandMap: CommandMap = new Map<string, CommandWrapper>([
 			['installedCommand1', installedCommandWrapper1],
 			['installedCommand2', installedCommandWrapper2]
@@ -123,6 +117,11 @@ ${outputSuffix}`;
 		const groupMap = new Map([['test', commandMap]]);
 		mockAllCommands.default = sandbox.stub().resolves(groupMap);
 		const helper = { command: 'version' };
+
+		const expectedOutput = `${outputPrefix}${outputSuffix}
+  ▹  ${validPackageInfo.name}@${chalk.blue(validPackageInfo.version)}
+  ▹  ${anotherValidPackageInfo.name}@${chalk.blue(anotherValidPackageInfo.version)}`;
+
 		return moduleUnderTest.run(helper, { outdated: false }).then(
 			() => {
 				assert.equal(logStub.firstCall.args[0].trim(), expectedOutput);
@@ -146,18 +145,17 @@ ${outputSuffix}`;
 			path: join(__dirname, '../../../src/commands/builtInCommand.js')
 		});
 
-		const expectedOutput = `${outputPrefix}
-${validPackageInfo.name}@${validPackageInfo.version}
-${outputSuffix}`;
-
 		const commandMap: CommandMap = new Map<string, CommandWrapper>([
 			['installedCommand1', installedCommandWrapper],
 			['builtInCommand1', builtInCommandWrapper]
 		]);
 		const groupMap = new Map([['test', commandMap]]);
 
-		const helper = { command: 'version' };
 		mockAllCommands.default = sandbox.stub().resolves(groupMap);
+		const helper = { command: 'version' };
+		const expectedOutput = `${outputPrefix}${outputSuffix}
+  ▹  ${validPackageInfo.name}@${chalk.blue(validPackageInfo.version)}`;
+
 		return moduleUnderTest.run(helper, { outdated: false }).then(
 			() => {
 				assert.equal(logStub.firstCall.args[0].trim(), expectedOutput);
@@ -182,9 +180,8 @@ ${outputSuffix}`;
 			path: join(__dirname, '../../support/valid-package')
 		});
 
-		const expectedOutput = `${outputPrefix}
-${validPackageInfo.name}@${chalk.blue(validPackageInfo.version)}
-${outputSuffix}`;
+		const expectedOutput = `${outputPrefix}${outputSuffix}
+  ▹  ${validPackageInfo.name}@${chalk.blue(validPackageInfo.version)}`;
 
 		const commandMap: CommandMap = new Map<string, CommandWrapper>([
 			['installedCommand1', installedCommandWrapper]
@@ -217,9 +214,8 @@ ${outputSuffix}`;
 			path: join(__dirname, '../../support/valid-package')
 		});
 
-		const expectedOutput = `${outputPrefix}
-${validPackageInfo.name}@${chalk.blue(validPackageInfo.version)} ${chalk.green('(latest is 1.2.3)')}
-${outputSuffix}`;
+		const expectedOutput = `${outputPrefix}${outputSuffix}
+  ▹  ${validPackageInfo.name}@${chalk.blue(validPackageInfo.version)} ${chalk.green('(latest is 1.2.3)')}`;
 
 		const commandMap: CommandMap = new Map<string, CommandWrapper>([
 			['installedCommand1', installedCommandWrapper]

--- a/tests/unit/commands/version.ts
+++ b/tests/unit/commands/version.ts
@@ -192,7 +192,7 @@ describe('version command', () => {
 		mockAllCommands.default = sandbox.stub().resolves(groupMap);
 		return moduleUnderTest.run(helper, { outdated: true }).then(
 			() => {
-				assert.isTrue(logStub.firstCall.calledWith('Fetching latest version information...'));
+				assert.isTrue(logStub.firstCall.calledWith(chalk.yellow('Fetching latest version information...')));
 				assert.equal(logStub.secondCall.args[0].trim(), expectedOutput);
 			},
 			() => {
@@ -226,7 +226,7 @@ describe('version command', () => {
 		mockAllCommands.default = sandbox.stub().resolves(groupMap);
 		return moduleUnderTest.run(helper, { outdated: true }).then(
 			() => {
-				assert.isTrue(logStub.firstCall.calledWith('Fetching latest version information...'));
+				assert.isTrue(logStub.firstCall.calledWith(chalk.yellow('Fetching latest version information...')));
 				assert.equal(logStub.secondCall.args[0].trim(), expectedOutput);
 			},
 			() => {
@@ -255,7 +255,7 @@ describe('version command', () => {
 		mockAllCommands.default = sandbox.stub().resolves(groupMap);
 		return moduleUnderTest.run(helper, { outdated: true }).then(
 			() => {
-				assert.isTrue(logStub.firstCall.calledWith('Fetching latest version information...'));
+				assert.isTrue(logStub.firstCall.calledWith(chalk.yellow('Fetching latest version information...')));
 				assert.isTrue(logStub.secondCall.calledWith(expectedOutput));
 			},
 			() => {


### PR DESCRIPTION
**Type:**  Feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [X] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [X] Unit or Functional tests are included in the PR

**Description:**
Makes the output slightly nicer for end users:

- Put CLI version first before listing commands
- Change the fetch to a different colour to differentiate it
- Make the version for installed commands blue to match the CLI version 
- Indent commands slightly to give it a list feel
- Move all colour formatting logic `areCommandsOutdated`

![screenshot_20180907_171722](https://user-images.githubusercontent.com/8822075/45230786-ea0db800-b2c1-11e8-9e29-dbdc7ad24c2b.png)


