### PR TITLE
Only ensure the directory, not full path is created

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -1,5 +1,6 @@
 import { renderFile } from 'ejs';
 import { writeFile, ensureDir } from 'fs-extra';
+import * as path from 'path';
 import chalk from 'chalk';
 
 export function ejsRender(source: string, replacements: Object): Promise<string> {
@@ -15,7 +16,8 @@ export function ejsRender(source: string, replacements: Object): Promise<string>
 }
 
 export function writeRenderedFile(str: string, destination: string): Promise<void> {
-	return ensureDir(destination).then(() => {
+	const parsedPath = path.parse(destination);
+	return ensureDir(parsedPath.dir).then(() => {
 		return writeFile(destination, str);
 	});
 }

--- a/tests/unit/template.ts
+++ b/tests/unit/template.ts
@@ -8,7 +8,7 @@ let writeFileStub: SinonStub;
 let consoleStub: SinonStub;
 let ensureDirStub: SinonStub;
 const testEjsSrc = 'tests/support/template.ejs';
-const testDest = '/tmp/test/destination';
+const testDest = '/tmp/test/destination/file.ts';
 const value = 'testValue';
 
 registerSuite('template', {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Parse the file path to only ensure the directory exists when using renderFiles

Resolves #263 
