### PR TITLE
Better handle calling help on non existent commands

### DIFF
--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -217,7 +217,7 @@ export default function(yargs: Argv, groupMap: GroupMap): void {
 				return dojoYargs;
 			},
 			(argv: any) => {
-				const isGroupCommand = argv._.length && argv._.length > 0;
+				const isGroupCommand = Boolean(argv._.length);
 				if (isGroupCommand) {
 					const groupCommand = groupMap.get(argv._[0]);
 					if (!groupCommand || !groupCommand.get(argv._[1])) {

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -217,6 +217,13 @@ export default function(yargs: Argv, groupMap: GroupMap): void {
 				return dojoYargs;
 			},
 			(argv: any) => {
+				const isGroupCommand = argv._.length && argv._.length > 0;
+				if (isGroupCommand) {
+					const groupCommand = groupMap.get(argv._[0]);
+					if (!groupCommand || !groupCommand.get(argv._[1])) {
+						throw `Unable to find given command`;
+					}
+				}
 				console.log(formatHelp(argv, groupMap));
 			}
 		)

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -109,7 +109,7 @@ registerSuite('registerCommands', {
 					assert.isTrue(help.calledOnce);
 					assert.isTrue(consoleLogStub.calledOnce);
 				},
-				'error if group help called on non existant group'() {
+				'error if help called on non existant group'() {
 					const help = mockModule.getMock('./help').formatHelp;
 					help.reset();
 					try {
@@ -120,7 +120,7 @@ registerSuite('registerCommands', {
 						assert.isTrue(consoleLogStub.notCalled);
 					}
 				},
-				'error if group help called on non existant command'() {
+				'error if help called on non existant command'() {
 					const help = mockModule.getMock('./help').formatHelp;
 					help.reset();
 					try {

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -93,18 +93,43 @@ registerSuite('registerCommands', {
 					help.reset();
 					yargsStub.command.lastCall.args[3]({ _: [], h: true });
 					assert.isTrue(help.calledOnce);
+					assert.isTrue(consoleLogStub.calledOnce);
 				},
 				'group help called'() {
 					const help = mockModule.getMock('./help').formatHelp;
 					help.reset();
 					yargsStub.command.firstCall.args[3]({ _: ['group'], h: true });
 					assert.isTrue(help.calledOnce);
+					assert.isTrue(consoleLogStub.calledOnce);
 				},
 				'command help called'() {
 					const help = mockModule.getMock('./help').formatHelp;
 					help.reset();
 					yargsStub.command.secondCall.args[3]({ _: ['group', 'command'], h: true });
 					assert.isTrue(help.calledOnce);
+					assert.isTrue(consoleLogStub.calledOnce);
+				},
+				'error if group help called on non existant group'() {
+					const help = mockModule.getMock('./help').formatHelp;
+					help.reset();
+					try {
+						yargsStub.command.lastCall.args[3]({ _: ['nonexistant'], h: true });
+						assert.fail(null, null, 'getting unknown group should throw an error');
+					} catch {
+						assert.isTrue(help.notCalled);
+						assert.isTrue(consoleLogStub.notCalled);
+					}
+				},
+				'error if group help called on non existant command'() {
+					const help = mockModule.getMock('./help').formatHelp;
+					help.reset();
+					try {
+						yargsStub.command.lastCall.args[3]({ _: ['group', 'nonexistant'], h: true });
+						assert.fail(null, null, 'getting unknown command should throw an error');
+					} catch {
+						assert.isTrue(help.notCalled);
+						assert.isTrue(consoleLogStub.notCalled);
+					}
 				}
 			}
 		},


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

At the moment the CLI returns the help template on non existent commands. This PR fixes that.

Resolves #266 

![screenshot_20181015_115521](https://user-images.githubusercontent.com/8822075/46946962-48704800-d071-11e8-8770-99f46b4b2cb8.png)

