### PR TITLE
Make validate asynchronous

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -42,7 +42,7 @@ export type ValidationWrapper = {
 };
 
 export interface ValidateHelper {
-	validate(validateOpts: ValidationWrapper): Promise<any>;
+	validate(validateOpts: ValidationWrapper): Promise<boolean>;
 }
 export interface CommandHelper {
 	run(group: string, commandName?: string, args?: Argv): Promise<any>;
@@ -103,7 +103,7 @@ export interface Command<T = any> {
 	register(options: OptionsHelper, helper: Helper): void;
 	run(helper: Helper, args?: T): Promise<any>;
 	eject?(helper: Helper): EjectOutput;
-	validate?: (helper: Helper) => boolean;
+	validate?: (helper: Helper) => Promise<boolean>;
 	name?: string;
 	group?: string;
 	alias?: Alias[] | Alias;

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -131,7 +131,7 @@ function registerGroups(yargs: Argv, helper: HelperFactory, groupName: string, c
 				.showHelpOnFail(false, formatHelp({ _: [groupName] }, groupMap))
 				.strict();
 		},
-		(argv: any) => {
+		async (argv: any) => {
 			if (defaultCommand && argv._.length === 1) {
 				if (argv.h || argv.help) {
 					console.log(formatHelp(argv, groupMap));
@@ -141,7 +141,7 @@ function registerGroups(yargs: Argv, helper: HelperFactory, groupName: string, c
 				const args = getOptions(aliases, config, argv);
 
 				if (typeof defaultCommand.validate === 'function') {
-					const valid = defaultCommand.validate(helper.sandbox(groupName, defaultCommand.name));
+					const valid = await defaultCommand.validate(helper.sandbox(groupName, defaultCommand.name));
 					if (!valid) {
 						return;
 					}
@@ -168,7 +168,7 @@ function registerCommands(yargs: Argv, helper: HelperFactory, groupName: string,
 
 				return optionsYargs.showHelpOnFail(false, formatHelp({ _: [groupName, name] }, groupMap)).strict();
 			},
-			(argv: any) => {
+			async (argv: any) => {
 				if (argv.h || argv.help) {
 					console.log(formatHelp(argv, groupMap));
 					return Promise.resolve({});
@@ -178,7 +178,7 @@ function registerCommands(yargs: Argv, helper: HelperFactory, groupName: string,
 				const args = getOptions(aliases, config, argv);
 
 				if (typeof command.validate === 'function') {
-					const valid = command.validate(helper.sandbox(groupName, command.name));
+					const valid = await command.validate(helper.sandbox(groupName, command.name));
 					if (!valid) {
 						return;
 					}

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -19,7 +19,7 @@ export interface CommandWrapperConfig {
 	eject?: boolean;
 	installed?: boolean;
 	global?: boolean;
-	validate?: () => boolean;
+	validate?: () => Promise<any>;
 }
 
 export function getGroupMap(groupDef: GroupDef, registerMock?: Function, validate?: boolean) {

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -19,7 +19,7 @@ export interface CommandWrapperConfig {
 	eject?: boolean;
 	installed?: boolean;
 	global?: boolean;
-	validate?: () => Promise<any>;
+	validate?: () => Promise<boolean>;
 }
 
 export function getGroupMap(groupDef: GroupDef, registerMock?: Function, validate?: boolean) {

--- a/tests/unit/commands/validate.ts
+++ b/tests/unit/commands/validate.ts
@@ -324,7 +324,7 @@ describe('validate', () => {
 					getCommandWrapperWithConfiguration({
 						group: 'command',
 						name: 'test',
-						validate: sinon.stub().returns(true)
+						validate: sinon.stub().resolves(true)
 					})
 				],
 				[
@@ -332,7 +332,7 @@ describe('validate', () => {
 					getCommandWrapperWithConfiguration({
 						group: 'command1',
 						name: 'test1',
-						validate: sinon.stub().returns(true)
+						validate: sinon.stub().resolves(true)
 					})
 				]
 			]);

--- a/tests/unit/commands/validate.ts
+++ b/tests/unit/commands/validate.ts
@@ -314,7 +314,7 @@ describe('validate', () => {
 					);
 				},
 				(error: { message: string }) => {
-					assert.fail(null, null, 'validate should handle error throws gracefully');
+					assert.fail(null, null, 'validate should handle error throws gracefully, got error:' + error);
 				}
 			);
 		});

--- a/tests/unit/registerCommands.ts
+++ b/tests/unit/registerCommands.ts
@@ -263,27 +263,27 @@ registerSuite('registerCommands', {
 					const { register } = groupMap.get('group1').get('command1');
 					assert.isTrue(register.calledTwice);
 				},
-				'Should run default command when yargs called with only group name'() {
+				async 'Should run default command when yargs called with only group name'() {
 					const { run } = groupMap.get('group1').get('command1');
-					yargsStub.command.firstCall.args[3]({ _: ['group'] });
+					await yargsStub.command.firstCall.args[3]({ _: ['group'] });
 					assert.isTrue(run.calledOnce);
 				},
-				'Should not run default command when yargs called with group name and command'() {
+				async 'Should not run default command when yargs called with group name and command'() {
 					const { run } = groupMap.get('group1').get('command1');
-					yargsStub.command.firstCall.args[3]({ _: ['group', 'command'] });
+					await yargsStub.command.firstCall.args[3]({ _: ['group', 'command'] });
 					assert.isFalse(run.calledOnce);
 				},
-				'Should run validateable command when yargs called'() {
+				async 'Should run validateable command when yargs called'() {
 					const command = groupMap.get('group1').get('command1');
-					command.validate = sinon.stub().returns(true);
-					yargsStub.command.firstCall.args[3]({ _: ['group'] });
+					command.validate = sinon.stub().resolves(true);
+					await yargsStub.command.firstCall.args[3]({ _: ['group'] });
 					assert.isTrue(command.validate.calledOnce);
 					assert.isTrue(command.run.calledOnce);
 				},
-				'Should not run validateable command when yargs called with failing command'() {
+				async 'Should not run validateable command when yargs called with failing command'() {
 					const command = groupMap.get('group1').get('command1');
-					command.validate = sinon.stub().returns(false);
-					yargsStub.command.firstCall.args[3]({ _: ['group'] });
+					command.validate = sinon.stub().resolves(false);
+					await yargsStub.command.firstCall.args[3]({ _: ['group'] });
 					assert.isTrue(command.validate.calledOnce);
 					assert.isFalse(command.run.called);
 				}
@@ -300,27 +300,25 @@ registerSuite('registerCommands', {
 			},
 
 			tests: {
-				'Should run validateCommand and continue if valid'() {
+				async 'Should run validateCommand and continue if valid'() {
 					groupMap = getGroupMap(groupDef, () => () => {}, true);
 					const command = groupMap.get('group1').get('command1');
-					command.validate = sinon.stub().returns(true);
+					command.validate = sinon.stub().resolves(true);
 					const registerCommands = mockModule.getModuleUnderTest().default;
 					registerCommands(yargsStub, groupMap);
-					yargsStub.command.secondCall.args[3]({});
-					assert.isTrue(command.validate.called);
-					assert.isTrue(command.validate.returned(true));
-					assert.isTrue(command.run.calledOnce);
+					await yargsStub.command.secondCall.args[3]({});
+					assert.isTrue(command.validate.called, 'validate was not called');
+					assert.isTrue(command.run.calledOnce, 'run wasnt called');
 				},
-				'Should run validateCommand stop if invalid'() {
+				async 'Should run validateCommand stop if invalid'() {
 					groupMap = getGroupMap(groupDef, () => () => {}, true);
 					const command = groupMap.get('group1').get('command1');
-					command.validate = sinon.stub().returns(false);
+					command.validate = sinon.stub().resolves(false);
 					const registerCommands = mockModule.getModuleUnderTest().default;
 					registerCommands(yargsStub, groupMap);
-					yargsStub.command.secondCall.args[3]({});
-					assert.isTrue(command.validate.called);
-					assert.isTrue(command.validate.returned(false));
-					assert.isFalse(command.run.calledOnce);
+					await yargsStub.command.secondCall.args[3]({});
+					assert.isTrue(command.validate.called, 'validate was not called');
+					assert.isFalse(command.run.calledOnce, 'run was called when it shouldnt have been');
 				}
 			}
 		},


### PR DESCRIPTION
**Type:**  feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [X] Unit or Functional tests are included in the PR

**Description:**

At the moment validate expects a boolean return type but the ValidateHelper returns a Promise, meaning you can't use the helper in a command.

Resolves #272 