### PR TITLE
Perf: Only glob for commands of that type when a command is passed in the cli args

### DIFF
--- a/src/loadCommands.ts
+++ b/src/loadCommands.ts
@@ -2,6 +2,7 @@ import * as globby from 'globby';
 import { resolve as pathResolve, join } from 'path';
 import { CliConfig, CommandWrapper, GroupMap } from './interfaces';
 import configurationHelper from './configurationHelper';
+import { argv } from 'yargs';
 
 export function isEjected(groupName: string, command: string): boolean {
 	const config: any = configurationHelper.sandbox(groupName, command).get();
@@ -16,7 +17,9 @@ export function isEjected(groupName: string, command: string): boolean {
  */
 export async function enumerateInstalledCommands(config: CliConfig): Promise<string[]> {
 	const { searchPrefixes } = config;
+	const [command] = argv._;
 	const globPaths = searchPrefixes.reduce((globPaths: string[], key) => {
+		key = command ? `${key}-${command}` : key;
 		return globPaths.concat(config.searchPaths.map((depPath) => pathResolve(depPath, `${key}-*`)));
 	}, []);
 	return globby(globPaths, { ignore: '**/*.{map,d.ts}' });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)

**Description:**
This is a simple perf fix for when running a single command. At the moment we glob for all commands even when a command is passed in the cli args. This just narrows it to only glob for that command as a prefix, ie running:
```
dojo test
```
previously would result in:
```
/node_modules/@dojo/cli-*
```
and now results in:
```
/node_modules/@dojo/cli-test-*
```