### PR TITLE
Fix dojo version from not listing installed commands

### DIFF
--- a/src/loadCommands.ts
+++ b/src/loadCommands.ts
@@ -18,7 +18,7 @@ export async function enumerateInstalledCommands(config: CliConfig): Promise<str
 	const [, , group] = process.argv;
 	const { searchPrefixes } = config;
 	const globPaths = searchPrefixes.reduce((globPaths: string[], key) => {
-		key = group ? `${key}-${group}` : key;
+		key = group && group !== 'version' ? `${key}-${group}` : key;
 		return globPaths.concat(config.searchPaths.map((depPath) => pathResolve(depPath, `${key}-*`)));
 	}, []);
 	return globby(globPaths, { ignore: '**/*.{map,d.ts}' });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

Fixes the bug where calling `dojo version` does not provide any versions for installed commands.

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Resolves #289 
