### PR TITLE
.dojorc extends support with @speedy/json-extends

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -146,6 +146,14 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@speedy/json-extends": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@speedy/json-extends/-/json-extends-1.2.0.tgz",
+      "integrity": "sha512-cM/tuoAoyCYdBkn596H4oWkS1B0Kn/G+wXLtbg5/+vsJsCbh4EfwMYsw5q8lbjy/W5Ko+MagDcD/YcmcquN6yw==",
+      "requires": {
+        "lodash": "^4.17.4"
+      }
+    },
     "@theintern/digdug": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.1.2.tgz",
@@ -2866,7 +2874,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2887,12 +2896,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2907,17 +2918,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3034,7 +3048,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3046,6 +3061,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3060,6 +3076,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3067,12 +3084,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3091,6 +3110,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3171,7 +3191,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3183,6 +3204,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3268,7 +3290,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3304,6 +3327,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3323,6 +3347,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3366,12 +3391,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typings.json"
   ],
   "dependencies": {
-    "@speedy/json-extends": "^1.2.0",
+    "@speedy/json-extends": "1.2.0",
     "ajv": "6.6.2",
     "chalk": "2.4.1",
     "configstore": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "typings.json"
   ],
   "dependencies": {
+    "@speedy/json-extends": "^1.2.0",
     "ajv": "6.6.2",
     "chalk": "2.4.1",
     "configstore": "3.1.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export async function init() {
 
 		registerCommands(yargs, mergedCommands);
 	} catch (err) {
-		console.log(`Commands are not available: ${err}`);
+		console.log(`Commands are not available:\n ${err.message}`);
 	}
 
 	try {

--- a/src/loadCommands.ts
+++ b/src/loadCommands.ts
@@ -2,6 +2,7 @@ import * as globby from 'globby';
 import { resolve as pathResolve, join } from 'path';
 import { CliConfig, CommandWrapper, GroupMap } from './interfaces';
 import configurationHelper from './configurationHelper';
+import chalk from 'chalk';
 
 export function isEjected(groupName: string, command: string): boolean {
 	const config: any = configurationHelper.sandbox(groupName, command).get();
@@ -72,7 +73,7 @@ export async function loadCommands(paths: string[], load: (path: string) => Comm
 					}
 				}
 			} catch (error) {
-				error.message = `Failed to load module ${path}\nNested error: ${error.message}`;
+				error.message = `${chalk.red(`Failed to load module ${path}`)}\n\nNested error:\n ${error.message}`;
 				reject(error);
 			}
 		});

--- a/tests/unit/index.ts
+++ b/tests/unit/index.ts
@@ -104,7 +104,7 @@ describe('cli main module', () => {
 				assert.throw(mockUpdate.default, Error, errMessage);
 				assert.equal(
 					(console.log as sinon.SinonStub).args[0][0],
-					`Commands are not available: Error: ${errMessage}`
+					`Commands are not available:\n ${errMessage}`
 				);
 			});
 		});

--- a/tests/unit/index.ts
+++ b/tests/unit/index.ts
@@ -77,7 +77,7 @@ describe('cli main module', () => {
 
 	it('should catch runtime errors', () => {
 		describe('runtime error inner', () => {
-			const errMessage = 'ugh - oh noes';
+			const errMessage = '\n ugh - oh noes';
 			const expectedError = new Error(errMessage);
 
 			beforeEach(() => {


### PR DESCRIPTION
**Type:**  feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The aim is to add a `extends` property to `.dojorc` which will allow for extension for a `.dojorc` from another previously defined `.dojorc` configuration. 

This PR aims to:

* Allow for multiple nested extension, i.e. a `.dojorc` file can extend another `.dojorc` file which can extend another and so forth indefinitely.
* Provide deep 'merging' of configuration objects (i.e. configuration property values that are also objects will be recursively merged). This will only work for Objects and not Arrays or other types (we have agree this isn't such a great idea as per https://github.com/Microsoft/TypeScript/issues/20110).

Resolves #295 
