### PR TITLE
Unify execution

### DIFF
--- a/docs/dojo-cli-lifecycle.svg
+++ b/docs/dojo-cli-lifecycle.svg
@@ -31,10 +31,6 @@
             <text x="15px" y="251.326px" style="font-family:'ArialMT', 'Arial', sans-serif;font-size:20px;">This phase calls register() on the</text>
             <text x="15px" y="271.326px" style="font-family:'ArialMT', 'Arial', sans-serif;font-size:20px;">command as part of the yargs</text>
             <text x="15px" y="291.326px" style="font-family:'ArialMT', 'Arial', sans-serif;font-size:20px;">builder step.</text>
-            <text x="15px" y="355.326px" style="font-family:'ArialMT', 'Arial', sans-serif;font-size:20px;">Note: the default command is</text>
-            <text x="15px" y="375.326px" style="font-family:'ArialMT', 'Arial', sans-serif;font-size:20px;">registered separately<tspan x="200.283px 205.84px 210.293px 223.633px " y="375.326px 375.326px 375.326px 375.326px ">. An</tspan>y</text>
-            <text x="15px" y="395.326px" style="font-family:'ArialMT', 'Arial', sans-serif;font-size:20px;">change to command registration</text>
-            <text x="15px" y="415.326px" style="font-family:'ArialMT', 'Arial', sans-serif;font-size:20px;">needs to happen in two places.</text>
         </g>
     </g>
     <g id="validate">

--- a/src/registerCommands.ts
+++ b/src/registerCommands.ts
@@ -113,7 +113,13 @@ function parseAliases(aliases: Aliases, key: string, optionAlias: string | strin
 /**
  * Runs through a command's validation and run phases.
  */
-async function executeCommand(command: CommandWrapper, argv: any, groupName: string, aliases: Aliases, helper: HelperFactory) {
+async function executeCommand(
+	command: CommandWrapper,
+	argv: any,
+	groupName: string,
+	aliases: Aliases,
+	helper: HelperFactory
+) {
 	const config = helper.sandbox(groupName, command.name).configuration.get();
 	const args = getOptions(aliases, config, argv);
 


### PR DESCRIPTION
**Type:** cleanup

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

The code to execute a command's validation and run phases exists in two places: once for the default command and once for other commands. It's too easy to make a change to how a command is executed in one spot and not the other.

This PR unifies command validation and execution for both default and other commands.
