### PR TITLE
When discovering installed commands, do not scope when ran from another command

### DIFF
--- a/src/allCommands.ts
+++ b/src/allCommands.ts
@@ -3,9 +3,10 @@ import { GroupMap, CommandMap } from './interfaces';
 import { initCommandLoader, createBuiltInCommandLoader } from './command';
 import config from './config';
 
-export async function loadExternalCommands(): Promise<GroupMap> {
+export async function loadExternalCommands(group?: string): Promise<GroupMap> {
+	group = group !== undefined ? group : process.argv[2];
 	const installedCommandLoader = initCommandLoader(config.searchPrefixes);
-	const installedCommandsPaths = await enumerateInstalledCommands(config);
+	const installedCommandsPaths = await enumerateInstalledCommands(config, group);
 	return await loadCommands(installedCommandsPaths, installedCommandLoader);
 }
 

--- a/src/allCommands.ts
+++ b/src/allCommands.ts
@@ -3,8 +3,7 @@ import { GroupMap, CommandMap } from './interfaces';
 import { initCommandLoader, createBuiltInCommandLoader } from './command';
 import config from './config';
 
-export async function loadExternalCommands(group?: string): Promise<GroupMap> {
-	group = group !== undefined ? group : process.argv[2];
+export async function loadExternalCommands(group: string = process.argv[2]): Promise<GroupMap> {
 	const installedCommandLoader = initCommandLoader(config.searchPrefixes);
 	const installedCommandsPaths = await enumerateInstalledCommands(config, group);
 	return await loadCommands(installedCommandsPaths, installedCommandLoader);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -22,7 +22,8 @@ async function run(helper: Helper, args: { dojorc?: string } = {}) {
 		rootDir = cwd;
 	}
 
-	const dojoRcPath = join(rootDir, args.dojorc || '.dojorc');
+	const dojoRcName = args.dojorc || '.dojorc';
+	const dojoRcPath = join(rootDir, dojoRcName);
 	const file = existsSync(dojoRcPath) && readFileSync(dojoRcPath, 'utf8');
 	let json: { [name: string]: {} } = {};
 	let indent = '\t';
@@ -32,7 +33,7 @@ async function run(helper: Helper, args: { dojorc?: string } = {}) {
 		json = JSON.parse(file);
 	}
 
-	const groupMap = await loadExternalCommands();
+	const groupMap = await loadExternalCommands('');
 	const values = [];
 
 	for (let [, commandMap] of groupMap.entries()) {
@@ -46,7 +47,7 @@ async function run(helper: Helper, args: { dojorc?: string } = {}) {
 	}
 
 	writeFileSync(dojoRcPath, JSON.stringify(json, null, indent));
-	console.log(chalk.white(`Successfully wrote ${args.dojorc} to ${dojoRcPath}`));
+	console.log(chalk.white(`Successfully wrote ${dojoRcName} to ${dojoRcPath}`));
 }
 
 export default {

--- a/src/loadCommands.ts
+++ b/src/loadCommands.ts
@@ -15,8 +15,7 @@ export function isEjected(groupName: string, command: string): boolean {
  * @param config
  * @returns {Promise<string []>} the paths of all installed commands
  */
-export async function enumerateInstalledCommands(config: CliConfig): Promise<string[]> {
-	const [, , group] = process.argv;
+export async function enumerateInstalledCommands(config: CliConfig, group?: string): Promise<string[]> {
 	const { searchPrefixes } = config;
 	const builtins = ['version', 'init', 'eject', 'validate'];
 

--- a/tests/unit/loadCommands.ts
+++ b/tests/unit/loadCommands.ts
@@ -171,12 +171,10 @@ registerSuite('loadCommands', {
 			},
 			tests: {
 				async 'should not load commands that are not in specified group'() {
-					process.argv = ['node', 'dojo.js', 'bar'];
-					const installedPaths = await enumInstalledCommands(goodConfig);
+					const installedPaths = await enumInstalledCommands(goodConfig, 'bar');
 					assert.isTrue(installedPaths.length === 0);
 				},
 				async 'should load commands that are in specified group'() {
-					process.argv = ['node', 'dojo.js', 'foo'];
 					const installedPaths = await enumInstalledCommands(goodConfig);
 					assert.isTrue(installedPaths.length === 2);
 				}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**
In a number of performance related PR's (like https://github.com/dojo/cli/pull/283), we stopped loading all the installed commands if a group was provided to the cli. For example:
```
dojo create ____
```
The above would only glob for paths with `cli-create` and only load those too.

This is fine for normal interactive use of the cli to run commands, but commands such as cli-create-app can use the command helper to programmatically call another command. In this case that was `dojo init`. Because of the above, the determined group was still `create` (because passed in the terminal by the user), which meant that `dojo init` would only find commands by that name. 

The code in cli is pretty convoluted, so the easiest way for me to fix this was to lift the `argv` bit out of `enumerateInstalledCommands`, and take the group in specifically. Not pretty, but it will do.

Resolves https://github.com/dojo/cli/issues/299 
Resolves https://github.com/dojo/cli/issues/305
